### PR TITLE
Fix an issue where a parameter without a set value was being reported as not existing.

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -31,31 +31,33 @@ pub type GraphQLResult<T> = std::result::Result<T, GraphQLError>;
 
 #[derive(Debug, Clone)]
 pub enum GraphQLError {
-    #[allow(dead_code)]
-    ItemNotFoundError,
+    EnvironmentNotFoundError(String),
     MissingDataError,
     NetworkError(Arc<reqwest::Error>),
+    ParameterNotFoundError(String),
     ResponseError(Vec<graphql_client::Error>),
     ServerError,
-    #[allow(dead_code)]
-    WrongDataTypeError,
 }
 
 impl fmt::Display for GraphQLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
-            GraphQLError::ItemNotFoundError => write!(f, "Unable to find item"),
+            GraphQLError::EnvironmentNotFoundError(name) => {
+                write!(f, "Unable to find environment '{}'", name)
+            }
             GraphQLError::MissingDataError => write!(
                 f,
                 "GraphQL response did not error, but does not have required data"
             ),
             GraphQLError::NetworkError(_) => write!(f, "Network error performing GraphQL query"),
+            GraphQLError::ParameterNotFoundError(key) => {
+                write!(f, "Unable to find parameter '{}'", key)
+            }
             GraphQLError::ResponseError(_) => write!(
                 f,
                 "GraphQL call successfully executed, but the response has errors"
             ),
             GraphQLError::ServerError => write!(f, "General server error"),
-            GraphQLError::WrongDataTypeError => write!(f, "Wrong GraphQL type returned"),
         }
     }
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,12 @@
+// Intended to be used in partial handling of errors. Assuming an enum is used as the error object,
+// a local handler can match against the enum and handle the variants that require special error-
+// handling. This macro can be used in the catch-all branch to propagate the error out of the caller
+// for the global error handler to deal with. We use a macro for this operation in order to avoid
+// problems where wrapping the error object can result in the location information adding extra
+// stack traces and so we don't need to litter the code with calls into the exception handling
+// library.
+macro_rules! propagate_error {
+    ($err:ident) => {{
+        return Err(From::from($err));
+    }};
+}


### PR DESCRIPTION
A parameter can exist in CloudTruth without an explicitly configured value. I.e., there is a difference between a parameter without a value set and a parameter with an empty value. The CLI client had been incorrectly treating the former case as a missing parameter. Now the states are properly accounted for.