### PR TITLE
Ignore clippy issue with GraphQL capitialization in types

### DIFF
--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -53,9 +53,11 @@ pub enum Resource {
     Template,
 }
 
+#[allow(clippy::upper_case_acronyms)]
 pub type GraphQLResult<T> = std::result::Result<T, GraphQLError>;
 
 #[derive(Clone, Debug)]
+#[allow(clippy::upper_case_acronyms)]
 pub enum GraphQLError {
     EnvironmentNotFoundError(String),
     MissingDataError,


### PR DESCRIPTION
A recent change to the Rust toolchain causes clippy to complain about the capitalization. The change just tells clippy to ignore these changes.