### PR TITLE
Get all environment parameter values in one query

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod main_test {
     use crate::cli;
-    use crate::config::CT_API_KEY;
+    use crate::config::{CT_API_KEY, CT_SERVER_URL};
     use assert_cmd::prelude::*;
     use predicates::prelude::predicate::str::*;
     use std::process::Command;
@@ -262,6 +262,9 @@ mod main_test {
 
         // Explicitly clear the API key so an individual dev's personal config isn't used for tests.
         cmd.env(CT_API_KEY, "");
+
+        // Explicitly set the server to a bogus value that a server cannot to
+        cmd.env(CT_SERVER_URL, "http://0.0.0.0:0");
 
         cmd
     }

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -50,16 +50,9 @@ impl SubProcess {
         environments: &Environments,
     ) -> Result<EnvSettings> {
         // Create EnvSettings with all the CloudTruth environment values for this environment.
-        let mut ct_vars = EnvSettings::new();
         let parameters = Parameters::new();
         let env_id = environments.get_id(org_id, env)?;
-        let list = parameters.get_parameter_names(org_id, env_id)?;
-        for key in list.iter() {
-            let parameter = parameters.get_body(org_id, env, key)?;
-            // Put the key/value pair into the environment
-            let value = parameter.unwrap_or_else(|| "".to_string());
-            ct_vars.insert(key.to_string(), value);
-        }
+        let ct_vars = parameters.get_parameter_values(org_id, env_id)?;
         Ok(ct_vars)
     }
 


### PR DESCRIPTION
The 'run' command displayed startup delay when we had many parameters present. It looks like the initial query had all the data, but we previously queried the parameters individually.