### PR TITLE
Introduce CLI run inherit option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,10 +91,18 @@ pub fn build_cli() -> App<'static, 'static> {
                 .visible_aliases(&["run", "r"])
                 .about("Run a shell with the parameters in place")
                 .args(&[
-                    Arg::with_name("preserve")
-                        .long("preserve")
-                        .short("p")
-                        .help("Preserve existing environment"),
+                    Arg::with_name("inheritance")
+                        .long("inherit")
+                        .short("i")
+                        .takes_value(true)
+                        .case_insensitive(true)
+                        // TODO: Rick Porter 3/21 - pull subprocess::Inheritance enum value strings?
+                        .possible_value("none")
+                        .possible_value("underlay")
+                        .possible_value( "overlay")
+                        .possible_value("exclusive")
+                        .default_value("overlay")
+                        .help("Handle the relationship between local and CloudTruth environments."),
                     Arg::with_name("set")
                         .long("set")
                         .short("s")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -102,7 +102,7 @@ pub fn build_cli() -> App<'static, 'static> {
                         .possible_value( "overlay")
                         .possible_value("exclusive")
                         .default_value("overlay")
-                        .help("Handle the relationship between local and CloudTruth environments."),
+                        .help("Handle the relationship between local and CloudTruth environments"),
                     Arg::with_name("set")
                         .long("set")
                         .short("s")

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,12 +15,13 @@ use crate::config::DEFAULT_ENV_NAME;
 use crate::environments::Environments;
 use crate::graphql::GraphQLError;
 use crate::parameters::Parameters;
-use crate::subprocess::{SubProcess, SubProcessIntf};
+use crate::subprocess::{Inheritance, SubProcess, SubProcessIntf};
 use crate::templates::Templates;
 use clap::ArgMatches;
 use color_eyre::eyre::Result;
 use std::io::{self, Write};
 use std::process;
+use std::str::FromStr;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 fn check_config() -> Result<()> {
@@ -98,10 +99,10 @@ fn process_run_command(
     }
 
     // Setup the environment for the sub-process.
-    let preserve = subcmd_args.is_present("preserve");
+    let inherit = Inheritance::from_str(subcmd_args.value_of("inheritance").unwrap()).unwrap();
     let overrides = subcmd_args.values_of_lossy("set").unwrap_or_default();
     let removals = subcmd_args.values_of_lossy("remove").unwrap_or_default();
-    sub_proc.set_environment(org_id, env, environments, preserve, &overrides, &removals)?;
+    sub_proc.set_environment(org_id, env, environments, inherit, &overrides, &removals)?;
     sub_proc.run_command(command.as_str(), &arguments)?;
 
     Ok(())


### PR DESCRIPTION
Replace CLI run "--preserve" flag with "--inherit <none|underlay|overlay|exclusive>" for more environment control.

Example output:
```
new-host-4):~/cloudtruth-cli $ cargo run -q -- run -h
cloudtruth-run 
Run a shell with the parameters in place

USAGE:
    cloudtruth run [OPTIONS] [-- <arguments>...]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -c, --command <command>        Run this command
    -i, --inherit <inheritance>    Handle the relationship between local and CloudTruth environments. [default: overlay]
                                   [possible values: none, underlay, overlay, exclusive]
    -r, --remove <remove>...       Remove the variables from the CloudTruth environment for this run
    -s, --set <set>...             Set the variables in this run, even possibly overriding the CloudTruth environment

ARGS:
    <arguments>...    Treat the rest of the arguments as the command
(new-host-4):~/cloudtruth-cli $ cargo run -q -- run -c "printenv | grep ANOTHER"
ANOTHER=VALUE
(new-host-4):~/cloudtruth-cli $ cargo run -q -- run -i none -c "printenv | grep ANOTHER"
ANOTHER=VALUE
(new-host-4):~/cloudtruth-cli $ cargo run -q -- run -i underlay -c "printenv | grep ANOTHER"
ANOTHER=SNA
(new-host-4):~/cloudtruth-cli $ cargo run -q -- run -i overlay -c "printenv | grep ANOTHER"
ANOTHER=VALUE
(new-host-4):~/cloudtruth-cli $ cargo run -q -- run -i exclusive -c "printenv | grep ANOTHER"
Error: 
   0: Conflicting definitions in run environment for: ANOTHER

Location:
   src/main.rs:105

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
(new-host-4):~/cloudtruth-cli $ 

##############
# when the value is the same, no error thrown
(new-host-4):~/cloudtruth-cli $ export ANOTHER=VALUE
(new-host-4):~/cloudtruth-cli $ cargo run -q -- run -i exclusive -c "printenv | grep ANOTHER"
ANOTHER=VALUE
(new-host-4):~/cloudtruth-cli $ 

##############
# explicit sets (to a different value) also cause error to be thrown
(new-host-4):~/cloudtruth-cli $ cargo run -q -- run -i exclusive -s Some_key_name=Bogus -c "printenv"
Error: 
   0: Conflicting definitions in run environment for: ANOTHER, Some_key_name

Location:
   src/main.rs:105

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
(new-host-4):~/cloudtruth-cli $```