### PR TITLE
Add parameters 'list --values' option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a40b47ad93e1a5404e6c18dec46b628214fee441c70f4ab5d6942142cc268a3d"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +211,7 @@ dependencies = [
  "indoc",
  "once_cell",
  "predicates",
+ "prettytable-rs",
  "reqwest",
  "rusty-hook",
  "serde",
@@ -293,6 +306,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "csv"
+version = "1.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "difference"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +340,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fed639d60b58d0f53498ab13d26f621fd77569cc6edb031f4cc36a2ad9da0f"
 dependencies = [
  "dirs-sys",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -345,6 +391,12 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -1112,6 +1164,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettytable-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fd04b170004fa2daccf418a7f8253aaf033c27760b5f225889024cf66d7ac2e"
+dependencies = [
+ "atty",
+ "csv",
+ "encode_unicode",
+ "lazy_static",
+ "term",
+ "unicode-width",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,6 +1271,15 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -1492,6 +1567,17 @@ dependencies = [
  "rand",
  "redox_syscall 0.2.4",
  "remove_dir_all",
+ "winapi",
+]
+
+[[package]]
+name = "term"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+dependencies = [
+ "byteorder",
+ "dirs",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ env_logger = "0.8"
 graphql_client = "0.9.0"
 indoc = "1.0"
 once_cell = "1.5"
+prettytable-rs = "0.8.0"
 reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"

--- a/graphql/parameter_queries.graphql
+++ b/graphql/parameter_queries.graphql
@@ -38,8 +38,15 @@ query ParametersDetailQuery($organizationId: ID, $environmentId: ID) {
           id
           isSecret
           keyName
+          description
           environmentValue(environmentId: $environmentId) {
             parameterValue
+            inheritedFrom {
+              name
+            }
+            environment {
+              name
+            }
           }
         }
       }

--- a/graphql/parameter_queries.graphql
+++ b/graphql/parameter_queries.graphql
@@ -29,6 +29,24 @@ query ParametersQuery($organizationId: ID, $environmentId: ID) {
   }
 }
 
+query ParametersDetailQuery($organizationId: ID, $environmentId: ID) {
+  viewer {
+    id
+    organization(id: $organizationId) {
+      parameters(orderBy: { keyName: ASC }) {
+        nodes {
+          id
+          isSecret
+          keyName
+          environmentValue(environmentId: $environmentId) {
+            parameterValue
+          }
+        }
+      }
+    }
+  }
+}
+
 mutation UpsertParameterMutation($orgId: ID, $environmentName: String, $keyName: String!, $value: String) {
   upsertParameter(input: { keyName: $keyName, value: $value, environmentName: $environmentName, organizationId: $orgId }) {
     clientMutationId

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -73,7 +73,15 @@ pub fn build_cli() -> App<'static, 'static> {
                         .arg(Arg::with_name("KEY").required(true).index(1))
                         .arg(Arg::with_name("VALUE").required(true).index(2)),
                     SubCommand::with_name("show")
-                        .about("Display parameters and values in a table"),
+                        .about("Display parameters and values in a table")
+                        .arg(Arg::with_name("format")
+                            .short("f")
+                            .long("format")
+                            .takes_value(true)
+                            .default_value("table")
+                            .possible_values(&["table", "csv"])
+                            .help("Parameter output data format")
+                        ),
                 ]),
         )
         .subcommand(SubCommand::with_name("templates")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -71,7 +71,9 @@ pub fn build_cli() -> App<'static, 'static> {
                     SubCommand::with_name("set")
                         .about("Set a static value in the selected environment for an existing parameter or creates a new one if needed")
                         .arg(Arg::with_name("KEY").required(true).index(1))
-                        .arg(Arg::with_name("VALUE").required(true).index(2))
+                        .arg(Arg::with_name("VALUE").required(true).index(2)),
+                    SubCommand::with_name("show")
+                        .about("Display parameters and values in a table"),
                 ]),
         )
         .subcommand(SubCommand::with_name("templates")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -67,21 +67,24 @@ pub fn build_cli() -> App<'static, 'static> {
                         .arg(Arg::with_name("KEY").required(true).index(1)),
                     SubCommand::with_name("list")
                         .visible_alias("ls")
-                        .about("List CloudTruth parameters"),
-                    SubCommand::with_name("set")
-                        .about("Set a static value in the selected environment for an existing parameter or creates a new one if needed")
-                        .arg(Arg::with_name("KEY").required(true).index(1))
-                        .arg(Arg::with_name("VALUE").required(true).index(2)),
-                    SubCommand::with_name("show")
-                        .about("Display parameters and values in a table")
+                        .about("List CloudTruth parameters")
+                        .arg(Arg::with_name("values")
+                            .short("v")
+                            .long("values")
+                            .help("Display parameters and values")
+                        )
                         .arg(Arg::with_name("format")
                             .short("f")
                             .long("format")
                             .takes_value(true)
                             .default_value("table")
                             .possible_values(&["table", "csv"])
-                            .help("Parameter output data format")
+                            .help("Parameter 'values' output data format")
                         ),
+                    SubCommand::with_name("set")
+                        .about("Set a static value in the selected environment for an existing parameter or creates a new one if needed")
+                        .arg(Arg::with_name("KEY").required(true).index(1))
+                        .arg(Arg::with_name("VALUE").required(true).index(2)),
                 ]),
         )
         .subcommand(SubCommand::with_name("templates")

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use std::process;
 use std::str::FromStr;
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
-const REDACTED: &str = "REDACTED";
+const REDACTED: &str = "*****";
 
 fn check_config() -> Result<()> {
     if let Some(issues) = Config::global().validate() {

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -204,24 +204,27 @@ impl Parameters {
                 .parameters
                 .nodes;
             for p in params {
+                let mut param_value: String = "".to_string();
+                let mut source: String = "".to_string();
+
                 if let Some(env_value) = p.environment_value {
-                    let source: String;
                     if let Some(inherit) = env_value.inherited_from {
                         source = inherit.name;
                     } else {
                         source = env_value.environment.name;
                     }
-                    if let Some(param_value) = env_value.parameter_value {
-                        env_vars.push(ParameterDetails {
-                            id: p.id,
-                            key: p.key_name,
-                            value: param_value,
-                            secret: p.is_secret,
-                            description: p.description.unwrap_or_default(),
-                            source,
-                        });
-                    }
+                    param_value = env_value.parameter_value.unwrap_or_default();
                 }
+
+                // Add an entry for every parameter, even if it has no value or source
+                env_vars.push(ParameterDetails {
+                    id: p.id,
+                    key: p.key_name,
+                    value: param_value,
+                    secret: p.is_secret,
+                    description: p.description.unwrap_or_default(),
+                    source,
+                });
             }
 
             Ok(env_vars)

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -42,6 +42,8 @@ pub struct ParameterDetails {
     pub key: String,
     pub value: String,
     pub secret: bool,
+    pub description: String,
+    pub source: String,
 }
 
 impl Parameters {
@@ -203,12 +205,20 @@ impl Parameters {
                 .nodes;
             for p in params {
                 if let Some(env_value) = p.environment_value {
+                    let source: String;
+                    if let Some(inherit) = env_value.inherited_from {
+                        source = inherit.name;
+                    } else {
+                        source = env_value.environment.name;
+                    }
                     if let Some(param_value) = env_value.parameter_value {
                         env_vars.push(ParameterDetails {
                             id: p.id,
                             key: p.key_name,
                             value: param_value,
                             secret: p.is_secret,
+                            description: p.description.unwrap_or_default(),
+                            source,
                         });
                     }
                 }


### PR DESCRIPTION
I specifically did not add a `--secrets` option to display the secrets, but that would be quite simple.

Here's a sample output (with no secrets):
```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- param -h
cloudtruth-parameters 
Work with CloudTruth parameters

USAGE:
    cloudtruth parameters [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    get     Gets value for parameter in the selected environment
    help    Prints this message or the help of the given subcommand(s)
    list    List CloudTruth parameters [aliases: ls]
    set     Set a static value in the selected environment for an existing parameter or creates a new one if needed
(new-host-4):~/cloudtruth-cli $ cargo run -q -- param list -h
cloudtruth-parameters-list 
List CloudTruth parameters

USAGE:
    cloudtruth parameters list [FLAGS] [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -v, --values     Display parameters and values
    -V, --version    Prints version information

OPTIONS:
    -f, --format <format>    Parameter 'values' output data format [default: table]  [possible values: table, csv]
(new-host-4):~/cloudtruth-cli $ cargo run -q -- -e my_new_environment param list -v
+---------------+---------------------------------------+---------+-----------------------------------+
| Name          | Value                                 | Source  | Description                       |
+---------------+---------------------------------------+---------+-----------------------------------+
| ANOTHER       | VALUE                                 | default |                                   |
| ANOTHER_TEST  | ANOTHER_VALUE                         | default |                                   |
| EMPTY         |                                       | default |                                   |
| FOO           | BAR                                   | default |                                   |
| MY_KEY        | another value with spaces             | default |                                   |
| Some_key_name | Some crazy default static environment | default | This is just a blah key for work. |
| TEST_VARiABLe | test-value                            | default |                                   |
+---------------+---------------------------------------+---------+-----------------------------------+
(new-host-4):~/cloudtruth-cli $
```

In a terminal window, the header row is bolded. We could do other things, but I did not want to get too fancy without adding value.