### PR TITLE
Change CT_ to CLOUDTRUTH_ for app environment variables

### DIFF
--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,5 +1,5 @@
 use crate::config::profiles::Profile;
-use crate::config::{CT_API_KEY, CT_SERVER_URL, ENV_VAR_PREFIX};
+use crate::config::{CT_API_KEY, CT_OLD_API_KEY, CT_SERVER_URL};
 use std::env;
 
 pub(crate) struct ConfigEnv {}
@@ -7,14 +7,14 @@ pub(crate) struct ConfigEnv {}
 impl ConfigEnv {
     pub(crate) fn load_profile() -> Profile {
         Profile {
-            api_key: ConfigEnv::get_override(CT_API_KEY),
+            api_key: ConfigEnv::get_override(CT_API_KEY)
+                .or_else(|| ConfigEnv::get_override(CT_OLD_API_KEY)),
             server_url: ConfigEnv::get_override(CT_SERVER_URL),
             source_profile: None,
         }
     }
 
-    fn get_override(config_name: &str) -> Option<String> {
-        assert!(config_name.starts_with(ENV_VAR_PREFIX));
+    pub fn get_override(config_name: &str) -> Option<String> {
         let value = env::var(config_name);
 
         if let Ok(value) = value {
@@ -28,7 +28,7 @@ impl ConfigEnv {
 #[cfg(test)]
 mod tests {
     use crate::config::profiles::Profile;
-    use crate::config::{ConfigEnv, CT_API_KEY, CT_SERVER_URL};
+    use crate::config::{ConfigEnv, CT_API_KEY, CT_OLD_API_KEY, CT_SERVER_URL};
     use serial_test::serial;
     use std::env;
 
@@ -36,6 +36,7 @@ mod tests {
     #[serial]
     fn create_profile_from_empty_env() {
         env::remove_var(CT_API_KEY);
+        env::remove_var(CT_OLD_API_KEY);
         env::remove_var(CT_SERVER_URL);
 
         assert_eq!(
@@ -57,6 +58,46 @@ mod tests {
         assert_eq!(
             Profile {
                 api_key: Some("new_key".to_string()),
+                server_url: Some("http://localhost:7001/graphql".to_string()),
+                source_profile: None
+            },
+            ConfigEnv::load_profile()
+        );
+
+        env::remove_var(CT_API_KEY);
+        env::remove_var(CT_SERVER_URL);
+    }
+
+    #[test]
+    #[serial]
+    fn create_profile_new_env_takes_precedence() {
+        env::set_var(CT_API_KEY, "new_key");
+        env::set_var(CT_OLD_API_KEY, "old_key");
+        env::set_var(CT_SERVER_URL, "http://localhost:7001/graphql");
+
+        assert_eq!(
+            Profile {
+                api_key: Some("new_key".to_string()),
+                server_url: Some("http://localhost:7001/graphql".to_string()),
+                source_profile: None
+            },
+            ConfigEnv::load_profile()
+        );
+
+        env::remove_var(CT_API_KEY);
+        env::remove_var(CT_SERVER_URL);
+    }
+
+    #[test]
+    #[serial]
+    fn create_profile_from_old_env() {
+        env::remove_var(CT_API_KEY);
+        env::set_var(CT_OLD_API_KEY, "old_key");
+        env::set_var(CT_SERVER_URL, "http://localhost:7001/graphql");
+
+        assert_eq!(
+            Profile {
+                api_key: Some("old_key".to_string()),
                 server_url: Some("http://localhost:7001/graphql".to_string()),
                 source_profile: None
             },

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -188,7 +188,7 @@ impl Config {
             && ConfigEnv::get_override(CT_API_KEY).is_none()
         {
             warnings.push(format!(
-                "Pleaes use {} to set the API key instead of {}",
+                "Please use {} instead of {} to set the API key.",
                 CT_API_KEY, CT_OLD_API_KEY
             ));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod main_test {
     use crate::cli;
-    use crate::config::{CT_API_KEY, CT_SERVER_URL};
+    use crate::config::{CT_API_KEY, CT_OLD_API_KEY, CT_SERVER_URL};
     use assert_cmd::prelude::*;
     use predicates::prelude::predicate::str::*;
     use std::process::Command;
@@ -319,10 +319,33 @@ mod main_test {
             println!("need_api_key test: {}", cmd_args.join(" "));
             let mut cmd = cmd();
             cmd.env(CT_API_KEY, "")
+                .env(CT_OLD_API_KEY, "")
                 .args(cmd_args)
                 .assert()
                 .failure()
                 .stderr(starts_with("The API key is missing."));
+        }
+    }
+
+    #[test]
+    fn old_api_key() {
+        let commands = &[
+            vec!["parameters", "list"],
+            vec!["environments", "list"],
+            vec!["templates", "list"],
+            vec!["--env", "non-default", "templates", "list"],
+            vec!["run", "--command", "printenv"],
+            vec!["run", "-c", "printenv"],
+            vec!["run", "-s", "FOO=BAR", "--", "ls", "-lh", "/tmp"],
+        ];
+        for cmd_args in commands {
+            println!("need_api_key test: {}", cmd_args.join(" "));
+            let mut cmd = cmd();
+            cmd.env(CT_OLD_API_KEY, "new_key")
+                .args(cmd_args)
+                .assert()
+                .failure()
+                .stderr(starts_with("The API key is using the old variable."));
         }
     }
 


### PR DESCRIPTION
When the "old" environment variable is in use, a different error message is displayed to the user telling them to update to the new environment variable.

```
# with both set
(new-host-4):~/cloudtruth-cli $ cargo run -q -- env ls
default
my_new_environment
(new-host-4):~/cloudtruth-cli $ unset CLOUDTRUTH_API_KEY
(new-host-4):~/cloudtruth-cli $ cargo run -q -- env ls
Pleaes use CLOUDTRUTH_API_KEY to set the API key instead of CT_API_KEY
default
my_new_environment
(new-host-4):~/cloudtruth-cli $ 
```