### PR TITLE
Move 'warn_user()' message to stderr and add color

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,14 @@ fn check_config() -> Result<()> {
 }
 
 fn warn_user(message: String) {
-    println!("WARN: {}", message);
+    let mut stderr = StandardStream::stderr(ColorChoice::Auto);
+    let mut warning_color_spec = ColorSpec::new();
+    warning_color_spec.set_fg(Some(Color::Yellow));
+
+    // All commands below may fail, but just keep going with best effort.
+    let _ = stderr.set_color(&warning_color_spec);
+    let _ = writeln!(&mut stderr, "WARN: {}", message);
+    let _ = stderr.reset();
 }
 
 fn warn_missing_subcommand(command: &str) {
@@ -440,7 +447,7 @@ mod main_test {
             cmd.args(cmd_args)
                 .assert()
                 .success()
-                .stdout(starts_with(warn_msg));
+                .stderr(starts_with(warn_msg));
         }
     }
 }


### PR DESCRIPTION
Example outputs (color not shown below, but lines starting with "WARN" are in yellow):

```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- env
WARN: No 'environments' sub-command executed.
(new-host-4):~/cloudtruth-cli $ cargo run -q -- run -i none -- "command contains spaces"
WARN: command contains spaces, and will likely fail.
Try using 'cloudtruth run command "command contains spaces"'
sh: contains: command not found
(new-host-4):~/cloudtruth-cli $ 
```