### PR TITLE
Initial Projects additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Breaking change: use `--config/-c` instead of `--profile/-p` to specify a configuration profile.
+
 # 0.2.0 - 2021-04-06
 
 * Use `CLOUDTRUTH_API_KEY` instead of `CT_API_KEY` to set API key in the environment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-* Breaking change: use `--config/-c` instead of `--profile/-p` to specify a configuration profile.
+* Breaking change: the `--profile` option no longer supports the short (`-p`) version.
+* Projects: list
 
 # 0.2.0 - 2021-04-06
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ profiles:
 Note that you can have multiple named profiles in your configuration, allowing you to maintain multiple sets of configuration fields in the configuration file.
 Values can be inherited from one profile to another by way of the `source_profile` configuration field.
 Profiles without an explicit `source_profile` configuration implicitly inherit from the _default_ profile.
-You may choose which profile to use by passing the `--config` to the CloudTruth CLI binary:
+You may choose which profile to use by passing the `--profile` to the CloudTruth CLI binary:
 
-`cloudtruth --config another-profile <subcommand>`
+`cloudtruth --profile another-profile <subcommand>`
 
-If the `--config` argument is not supplied, the profile named _default_ will be used.
+If the `--profile` argument is not supplied, the profile named _default_ will be used.
 
 ### Environment-based Configuration
 
@@ -101,9 +101,9 @@ All subcommands support a `--help` option to show you how the command should be 
 CloudTruth CLI profiles are a way of organizing the application's configuration data into multiple named groups.
 Profiles, in this sense, are unrelated to configuration values in your CloudTruth account.
 They simply allow you to configure the CloudTruth CLI for multiple organizations or multiple API keys with different access restrictions.
-By default, the profile named _default_ will be used, but you can select the active profile with the `--config` flag:
+By default, the profile named _default_ will be used, but you can select the active profile with the `--profile` flag:
 
-`cloudtruth --config my-profile parameters get my_param`
+`cloudtruth --profile my-profile parameters get my_param`
 
 ### Switching Active CloudTruth Environment
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,11 @@ profiles:
 Note that you can have multiple named profiles in your configuration, allowing you to maintain multiple sets of configuration fields in the configuration file.
 Values can be inherited from one profile to another by way of the `source_profile` configuration field.
 Profiles without an explicit `source_profile` configuration implicitly inherit from the _default_ profile.
-You may choose which profile to use by passing the `--profile` to the CloudTruth CLI binary:
+You may choose which profile to use by passing the `--config` to the CloudTruth CLI binary:
 
-`cloudtruth --profile another-profile <subcommand>`
+`cloudtruth --config another-profile <subcommand>`
 
-If the `--profile` argument is not supplied, the profile named _default_ will be used.
+If the `--config` argument is not supplied, the profile named _default_ will be used.
 
 ### Environment-based Configuration
 
@@ -101,9 +101,9 @@ All subcommands support a `--help` option to show you how the command should be 
 CloudTruth CLI profiles are a way of organizing the application's configuration data into multiple named groups.
 Profiles, in this sense, are unrelated to configuration values in your CloudTruth account.
 They simply allow you to configure the CloudTruth CLI for multiple organizations or multiple API keys with different access restrictions.
-By default, the profile named _default_ will be used, but you can select the active profile with the `--profile` flag:
+By default, the profile named _default_ will be used, but you can select the active profile with the `--config` flag:
 
-`cloudtruth --profile my-profile parameters get my_param`
+`cloudtruth --config my-profile parameters get my_param`
 
 ### Switching Active CloudTruth Environment
 

--- a/graphql/project_queries.graphql
+++ b/graphql/project_queries.graphql
@@ -1,0 +1,23 @@
+query ProjectsQuery($organizationId: ID) {
+  viewer {
+    id
+    organization(id: $organizationId) {
+      projects {
+        nodes {
+          id
+          name
+        }
+      }
+    }
+  }
+}
+
+query GetProjectByNameQuery($organizationId: ID, $projectName: String) {
+  viewer {
+    organization(id: $organizationId) {
+      project(name: $projectName) {
+        id
+      }
+    }
+  }
+}

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -369,8 +369,8 @@ type CreateProjectPayload {
   """
   clientMutationId: String
   errors: [UserError!]!
+  organization: Organization!
   project: Project
-  viewer: Viewer!
 }
 
 """
@@ -610,8 +610,8 @@ type DeleteProjectPayload {
   """
   clientMutationId: String
   errors: [UserError!]!
+  organization: Organization!
   project: Project
-  viewer: Viewer!
 }
 
 """
@@ -1541,6 +1541,7 @@ type Organization implements HasPolicy & Node {
     where: ParameterBoolExp
   ): ParameterConnection!
   policy: OrganizationPolicy!
+  project(name: String): Project
   projects(
     """
     Returns the elements in the list that come after the specified cursor.
@@ -2314,8 +2315,8 @@ type UpdateProjectPayload {
   """
   clientMutationId: String
   errors: [UserError!]!
+  organization: Organization!
   project: Project
-  viewer: Viewer!
 }
 
 """

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,11 +28,17 @@ pub fn build_cli() -> App<'static, 'static> {
         )
         .arg(
             Arg::with_name("profile")
-                .short("p")
+                .short("p")// TODO: remove this to avoid confusion with setting project?
                 .long("profile")
                 .help("The profile from the application configuration file to use")
                 .takes_value(true)
                 .default_value("default")
+        )
+        .arg(
+            Arg::with_name("project")
+                .long("project")
+                .help("The CloudTruth project to work with")
+                .takes_value(true)
         )
         .subcommand(
             SubCommand::with_name("completions")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,15 +27,16 @@ pub fn build_cli() -> App<'static, 'static> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("profile")
-                .short("p")// TODO: remove this to avoid confusion with setting project?
-                .long("profile")
-                .help("The profile from the application configuration file to use")
+            Arg::with_name("config")
+                .short("c")
+                .long("config")
+                .help("The configuration profile from the application configuration file to use")
                 .takes_value(true)
                 .default_value("default")
         )
         .arg(
             Arg::with_name("project")
+                .short("p")
                 .long("project")
                 .help("The CloudTruth project to work with")
                 .takes_value(true)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,16 +27,14 @@ pub fn build_cli() -> App<'static, 'static> {
                 .takes_value(true),
         )
         .arg(
-            Arg::with_name("config")
-                .short("c")
-                .long("config")
+            Arg::with_name("profile")
+                .long("profile")
                 .help("The configuration profile from the application configuration file to use")
                 .takes_value(true)
                 .default_value("default")
         )
         .arg(
             Arg::with_name("project")
-                .short("p")
                 .long("project")
                 .help("The CloudTruth project to work with")
                 .takes_value(true)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -173,4 +173,14 @@ pub fn build_cli() -> App<'static, 'static> {
                         .help("Allow CloudTruth application variables through")
                 ])
         )
+        .subcommand(
+            SubCommand::with_name("projects")
+                .visible_aliases(&["projects", "proj"])
+                .about("Work with CloudTruth projects")
+                .subcommands(vec![
+                    SubCommand::with_name("list")
+                        .visible_alias("ls")
+                        .about("List CloudTruth projects")
+                ])
+        )
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -23,6 +23,9 @@ pub const DEFAULT_ENV_NAME: &str = "default";
 // Default profile name.
 pub const DEFAULT_PROF_NAME: &str = "default";
 
+// Default project name.
+pub const DEFAULT_PROJ_NAME: &str = "default";
+
 /*************************************************************************
  Environment variables.
  All should start with ENV_VAR_PREFIX (CT_xxx).

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,7 +186,7 @@ fn main() -> Result<()> {
     let matches = cli::build_cli().get_matches();
 
     let api_key = matches.value_of("api_key");
-    let profile_name = matches.value_of("config");
+    let profile_name = matches.value_of("profile");
 
     Config::init_global(Config::load_config(api_key, profile_name)?);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,7 +185,7 @@ fn main() -> Result<()> {
     let matches = cli::build_cli().get_matches();
 
     let api_key = matches.value_of("api_key");
-    let profile_name = matches.value_of("profile");
+    let profile_name = matches.value_of("config");
 
     Config::init_global(Config::load_config(api_key, profile_name)?);
 

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -1,0 +1,121 @@
+use crate::graphql::prelude::graphql_request;
+use crate::graphql::{GraphQLError, GraphQLResult};
+use graphql_client::*;
+
+pub struct Projects {}
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/project_queries.graphql",
+    response_derives = "Debug"
+)]
+pub struct GetProjectByNameQuery;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/project_queries.graphql",
+    response_derives = "Debug"
+)]
+pub struct ProjectsQuery;
+
+pub trait ProjectsIntf {
+    /// Resolve the `proj_name` to a String
+    fn get_id(
+        &self,
+        org_id: Option<&str>,
+        proj_name: Option<&str>,
+    ) -> GraphQLResult<Option<String>>;
+
+    /// Make sure the provided `proj_name` is valid.
+    fn is_valid_project_name(
+        &self,
+        org_id: Option<&str>,
+        proj_name: Option<&str>,
+    ) -> GraphQLResult<bool>;
+
+    /// Get a complete list of projects for this organization.
+    fn get_project_names(&self, org_id: Option<&str>) -> GraphQLResult<Vec<String>>;
+}
+
+impl Projects {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    fn get_projects_full(
+        &self,
+        org_id: Option<&str>,
+    ) -> GraphQLResult<Vec<projects_query::ProjectsQueryViewerOrganizationProjectsNodes>> {
+        let query = ProjectsQuery::build_query(projects_query::Variables {
+            organization_id: org_id.map(|id| id.to_string()),
+        });
+        let response_body = graphql_request::<_, projects_query::ResponseData>(&query)?;
+
+        if let Some(errors) = response_body.errors {
+            Err(GraphQLError::ResponseError(errors))
+        } else if let Some(data) = response_body.data {
+            Ok(data
+                .viewer
+                .organization
+                .expect("Primary organization not found")
+                .projects
+                .nodes)
+        } else {
+            Err(GraphQLError::MissingDataError)
+        }
+    }
+}
+
+impl ProjectsIntf for Projects {
+    fn get_id(
+        &self,
+        org_id: Option<&str>,
+        proj_name: Option<&str>,
+    ) -> GraphQLResult<Option<String>> {
+        let query = GetProjectByNameQuery::build_query(get_project_by_name_query::Variables {
+            organization_id: org_id.map(|id| id.to_string()),
+            project_name: proj_name.map(|name| name.to_string()),
+        });
+        let response_body = graphql_request::<_, get_project_by_name_query::ResponseData>(&query)?;
+
+        if let Some(errors) = response_body.errors {
+            Err(GraphQLError::ResponseError(errors))
+        } else if let Some(data) = response_body.data {
+            Ok(data
+                .viewer
+                .organization
+                .expect("Primary organization not found")
+                .project
+                .map(|proj| proj.id))
+        } else {
+            Err(GraphQLError::MissingDataError)
+        }
+    }
+
+    fn is_valid_project_name(
+        &self,
+        org_id: Option<&str>,
+        proj_name: Option<&str>,
+    ) -> GraphQLResult<bool> {
+        let proj = self.get_id(org_id, proj_name)?;
+
+        if proj.is_some() {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn get_project_names(&self, org_id: Option<&str>) -> GraphQLResult<Vec<String>> {
+        let projects = self.get_projects_full(org_id)?;
+        let mut list = projects
+            .into_iter()
+            .map(|n| n.name)
+            .collect::<Vec<String>>();
+        list.sort();
+
+        Ok(list)
+    }
+}


### PR DESCRIPTION
1. Updated to latest GraphQL schema (mainly to query project by name)
2. Add basic project queries, and CLI command to view list of projects
3. Refactor stderr output for reuse
4. Add --project argument to CLI, and validate it

Here's some sample output:
```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- -e foo param ls
The 'foo' environment could not be found in your account.
(new-host-4):~/cloudtruth-cli $ cargo run -q -- -e foo --project prj param ls
The 'foo' environment could not be found in your account.
The 'prj' project could not be found in your account.
(new-host-4):~/cloudtruth-cli $ echo $?
2
(new-host-4):~/cloudtruth-cli $ cargo run -q -- proj ls
Proj2
Project1
default
(new-host-4):~/cloudtruth-cli $ 
```

The above "could not be found in your account" messages are in red on the terminal.