### PR TITLE
Add 'config list' option

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,7 +44,10 @@ pub fn build_cli() -> App<'static, 'static> {
             .about("Configuration options for this application")
             .subcommands(vec![
                 SubCommand::with_name("edit")
-                    .about("Edit your configuration data for this application")
+                    .about("Edit your configuration data for this application"),
+                SubCommand::with_name("list")
+                    .visible_alias("ls")
+                    .about("List CloudTruth profiles in the local config file"),
                 ])
         )
         .subcommand(

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -159,6 +159,16 @@ impl Config {
         Ok(profile.into())
     }
 
+    pub fn get_profile_names() -> Result<Vec<String>> {
+        let mut profiles: Vec<String> = Vec::new();
+        if let Some(config_file) = Self::config_file() {
+            if config_file.exists() {
+                let config = Self::read_config(config_file.as_path())?;
+                profiles = ConfigFile::get_profile_names(&config)?;
+            }
+        }
+        Ok(profiles)
+    }
     pub fn edit() -> Result<()> {
         if let Some(config_file) = Self::config_file() {
             if !config_file.exists() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,6 +166,13 @@ fn main() -> Result<()> {
     if let Some(matches) = matches.subcommand_matches("config") {
         if matches.subcommand_matches("edit").is_some() {
             Config::edit()?;
+        } else if matches.subcommand_matches("list").is_some() {
+            let profile_names = Config::get_profile_names()?;
+            if profile_names.is_empty() {
+                println!("No profiles exist in config.");
+            } else {
+                println!("{}", profile_names.join("\n"));
+            }
         } else {
             warn_missing_subcommand("config");
         }


### PR DESCRIPTION
Without this change, we need to look at the config file (usually getting into the editor via `config edit`) to see what profiles we have configured. 