### PR TITLE
Change how project/environment are validated/resolved

### DIFF
--- a/src/environments.rs
+++ b/src/environments.rs
@@ -52,20 +52,6 @@ impl Environments {
         }
     }
 
-    pub fn is_valid_environment_name(
-        &self,
-        org_id: Option<&str>,
-        name: Option<&str>,
-    ) -> GraphQLResult<bool> {
-        let env = self.get_id(org_id, name)?;
-
-        if env.is_some() {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
     fn get_environments_full(
         &self,
         org_id: Option<&str>,

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -28,13 +28,6 @@ pub trait ProjectsIntf {
         proj_name: Option<&str>,
     ) -> GraphQLResult<Option<String>>;
 
-    /// Make sure the provided `proj_name` is valid.
-    fn is_valid_project_name(
-        &self,
-        org_id: Option<&str>,
-        proj_name: Option<&str>,
-    ) -> GraphQLResult<bool>;
-
     /// Get a complete list of projects for this organization.
     fn get_project_names(&self, org_id: Option<&str>) -> GraphQLResult<Vec<String>>;
 }
@@ -91,20 +84,6 @@ impl ProjectsIntf for Projects {
                 .map(|proj| proj.id))
         } else {
             Err(GraphQLError::MissingDataError)
-        }
-    }
-
-    fn is_valid_project_name(
-        &self,
-        org_id: Option<&str>,
-        proj_name: Option<&str>,
-    ) -> GraphQLResult<bool> {
-        let proj = self.get_id(org_id, proj_name)?;
-
-        if proj.is_some() {
-            Ok(true)
-        } else {
-            Ok(false)
         }
     }
 


### PR DESCRIPTION
Instead of checking that environment/project are valid (and then tossing those ID's), we remember the IDs for later use. This simplifies some of the other places where we previously needed to resolve the environment ID. This should avoid at least one query (and probably two) to the CloudTruth servers.

With the new validation, I shuffled some things around to avoid validating environment/project before necessary. For example, there is no need to make sure a valid project is specified when getting a list of projects.