### PR TITLE
Avoid environment/project validation errors for those sub-commands

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -414,11 +414,13 @@ fn main() -> Result<()> {
     if let Some(matches) = matches.subcommand_matches("environments") {
         let environments = Environments::new();
         process_environment_command(org_id, &environments, matches)?;
+        process::exit(0)
     }
 
     if let Some(matches) = matches.subcommand_matches("projects") {
         let projects = Projects::new();
         process_project_command(org_id, &projects, matches)?;
+        process::exit(0)
     }
 
     // Everything below here requires resolved environment/project values


### PR DESCRIPTION
Without this, we could get validation errors even though we should not need to validate the project/environment.

```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- -e foo --project bar env ls 
Environment1
default
The 'foo' environment could not be found in your account.
The 'bar' project could not be found in your account.
(new-host-4):~/cloudtruth-cli $
```