### PR TITLE
Add --values/--format options to projects/environments list sub-command

### DIFF
--- a/graphql/environment_queries.graphql
+++ b/graphql/environment_queries.graphql
@@ -6,6 +6,13 @@ query EnvironmentsQuery($organizationId: ID) {
         nodes {
           id
           name
+          description
+          ancestors {
+            name
+          }
+          parent {
+            name
+          }
         }
       }
     }

--- a/graphql/project_queries.graphql
+++ b/graphql/project_queries.graphql
@@ -6,6 +6,8 @@ query ProjectsQuery($organizationId: ID) {
         nodes {
           id
           name
+          description
+          defaultForOrganization,
         }
       }
     }

--- a/graphql/template_queries.graphql
+++ b/graphql/template_queries.graphql
@@ -27,6 +27,7 @@ query TemplatesQuery($organizationId: ID) {
         nodes {
           id
           name
+          description
         }
       }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,8 +76,8 @@ pub fn build_cli() -> App<'static, 'static> {
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth environments")
-                        .arg(values_flag().help("Display addition environment values"))
-                        .arg(table_format_options().help(""))
+                        .arg(values_flag().help("Display environment information/values"))
+                        .arg(table_format_options().help("Format for environment values data"))
                 ])
         )
         .subcommand(
@@ -92,10 +92,10 @@ pub fn build_cli() -> App<'static, 'static> {
                         .visible_alias("ls")
                         .about("List CloudTruth parameters")
                         .arg(values_flag()
-                            .help("Display parameters and values")
+                            .help("Display parameter information/values")
                         )
                         .arg(table_format_options()
-                            .help("Parameter 'values' output data format")
+                            .help("Format for parameter values data")
                         ),
                     SubCommand::with_name("set")
                         .about("Set a static value in the selected environment for an existing parameter or creates a new one if needed")
@@ -141,6 +141,8 @@ pub fn build_cli() -> App<'static, 'static> {
                 SubCommand::with_name("list")
                     .visible_alias("ls")
                     .about("List CloudTruth templates")
+                    .arg(values_flag().help("Display template information/values"))
+                    .arg(table_format_options().help("Format for template values data"))
             ])
         )
         .subcommand(
@@ -197,8 +199,8 @@ pub fn build_cli() -> App<'static, 'static> {
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth projects")
-                        .arg(values_flag().help("Display additional project values"))
-                        .arg(table_format_options().help("Project 'values' output format"))
+                        .arg(values_flag().help("Display project information/values"))
+                        .arg(table_format_options().help("Format for project values data"))
                 ])
         )
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -76,6 +76,8 @@ pub fn build_cli() -> App<'static, 'static> {
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth environments")
+                        .arg(values_flag().help("Display addition environment values"))
+                        .arg(table_format_options().help(""))
                 ])
         )
         .subcommand(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,6 +9,19 @@ pub fn binary_name() -> String {
         .to_string()
 }
 
+fn table_format_options() -> Arg<'static, 'static> {
+    Arg::with_name("format")
+        .short("f")
+        .long("format")
+        .takes_value(true)
+        .default_value("table")
+        .possible_values(&["table", "csv"])
+}
+
+fn values_flag() -> Arg<'static, 'static> {
+    Arg::with_name("values").short("v").long("values")
+}
+
 pub fn build_cli() -> App<'static, 'static> {
     app_from_crate!()
         .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -76,17 +89,10 @@ pub fn build_cli() -> App<'static, 'static> {
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth parameters")
-                        .arg(Arg::with_name("values")
-                            .short("v")
-                            .long("values")
+                        .arg(values_flag()
                             .help("Display parameters and values")
                         )
-                        .arg(Arg::with_name("format")
-                            .short("f")
-                            .long("format")
-                            .takes_value(true)
-                            .default_value("table")
-                            .possible_values(&["table", "csv"])
+                        .arg(table_format_options()
                             .help("Parameter 'values' output data format")
                         ),
                     SubCommand::with_name("set")
@@ -189,6 +195,8 @@ pub fn build_cli() -> App<'static, 'static> {
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth projects")
+                        .arg(values_flag().help("Display additional project values"))
+                        .arg(table_format_options().help("Project 'values' output format"))
                 ])
         )
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,9 +180,33 @@ fn process_project_command(
     projects: &impl ProjectsIntf,
     subcmd_args: &ArgMatches,
 ) -> Result<()> {
-    if subcmd_args.subcommand_matches("list").is_some() {
-        let list = projects.get_project_names(org_id)?;
-        println!("{}", list.join("\n"))
+    if let Some(subcmd_args) = subcmd_args.subcommand_matches("list") {
+        let details = projects.get_project_details(org_id)?;
+        // NOTE: should always have at least the default project
+        if !subcmd_args.is_present("values") {
+            let list = details
+                .iter()
+                .map(|v| v.name.clone())
+                .collect::<Vec<String>>();
+            println!("{}", list.join("\n"));
+        } else {
+            let fmt = subcmd_args.value_of("format").unwrap();
+            let mut table = Table::new();
+            table.set_titles(Row::new(vec![
+                Cell::new("Name").with_style(Attr::Bold),
+                Cell::new("Description").with_style(Attr::Bold),
+            ]));
+            for entry in details {
+                table.add_row(row![entry.name, entry.description]);
+            }
+            table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
+            if fmt == "csv" {
+                table.to_csv(stdout())?;
+            } else {
+                assert_eq!(fmt, "table");
+                table.printstd();
+            }
+        }
     } else {
         warn_missing_subcommand("projects")?;
     }


### PR DESCRIPTION
Example output:

```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- proj ls 
Proj2
Project1
default
(new-host-4):~/cloudtruth-cli $ cargo run -q -- proj ls -v
+----------+-------------------------------------+
| Name     | Description                         |
+----------+-------------------------------------+
| Proj2    | Just another project                |
| Project1 | My very first project!              |
| default  | The auto-generated default project. |
+----------+-------------------------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- proj ls -v -f csv
Name,Description
Proj2,Just another project
Project1,My very first project!
default,The auto-generated default project.
(new-host-4):~/cloudtruth-cli $ 
(new-host-4):~/cloudtruth-cli $ cargo run -q -- env ls
Environment1
default
(new-host-4):~/cloudtruth-cli $ cargo run -q -- env ls -v
+--------------+---------+-----------------------------------------+
| Name         | Parent  | Description                             |
+--------------+---------+-----------------------------------------+
| Environment1 | default | My first environment on staging!        |
| default      |         | The auto-generated default environment. |
+--------------+---------+-----------------------------------------+
(new-host-4):~/cloudtruth-cli $
```