### PR TITLE
Add --secrets to 'param list' to show the secret values

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,10 @@ fn values_flag() -> Arg<'static, 'static> {
     Arg::with_name("values").short("v").long("values")
 }
 
+fn secrets_display_flag() -> Arg<'static, 'static> {
+    Arg::with_name("secret").short("s").long("secrets")
+}
+
 pub fn build_cli() -> App<'static, 'static> {
     app_from_crate!()
         .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -95,12 +99,9 @@ pub fn build_cli() -> App<'static, 'static> {
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth parameters")
-                        .arg(values_flag()
-                            .help("Display parameter information/values")
-                        )
-                        .arg(table_format_options()
-                            .help("Format for parameter values data")
-                        ),
+                        .arg(values_flag().help("Display parameter information/values"))
+                        .arg(table_format_options().help("Format for parameter values data"))
+                        .arg(secrets_display_flag().help("Display the secret parameter values")),
                     SubCommand::with_name("set")
                         .about(concat!("Set a static value in the selected project/environment for ",
                             "an existing parameter or creates a new one if needed"))
@@ -136,9 +137,7 @@ pub fn build_cli() -> App<'static, 'static> {
                         .possible_value("dotenv")
                         .possible_value("shell")
                         .index(1))
-                    .arg(Arg::with_name("secrets")
-                        .long("secrets")
-                        .help("Display the values of secret parameters"))
+                    .arg(secrets_display_flag().help("Display the secret parameter values"))
                     .arg(Arg::with_name("starts_with")
                         .long("starts-with")
                         .help("Return parameters starting with search")

--- a/src/main.rs
+++ b/src/main.rs
@@ -308,6 +308,7 @@ fn process_parameters_command(
             if ct_vars.is_empty() {
                 println!("No CloudTruth variables found!");
             } else {
+                let show_secrets = subcmd_args.is_present("secret");
                 let mut table = Table::new();
                 table.set_titles(Row::new(vec![
                     Cell::new("Name").with_style(Attr::Bold),
@@ -316,7 +317,7 @@ fn process_parameters_command(
                     Cell::new("Description").with_style(Attr::Bold),
                 ]));
                 for entry in ct_vars {
-                    let out_val = if entry.secret {
+                    let out_val = if entry.secret && !show_secrets {
                         REDACTED.to_string()
                     } else {
                         entry.value


### PR DESCRIPTION
Example output:

```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- param ls -v
+-----------------+---------------+---------+---------------------------------+
| Name            | Value         | Source  | Description                     |
+-----------------+---------------+---------+---------------------------------+
| ANOTHER_VALUE   | uninteresting | default | set just description            |
| MY_KEY_NAME     | my_value      | default | dummy key name/value            |
| MY_SECRET       | *****         | default | something to test secret hiding |
| new_param_value | third value   | default | fresh description               |
+-----------------+---------------+---------+---------------------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- param ls -v -s
+-----------------+-----------------------+---------+---------------------------------+
| Name            | Value                 | Source  | Description                     |
+-----------------+-----------------------+---------+---------------------------------+
| ANOTHER_VALUE   | uninteresting         | default | set just description            |
| MY_KEY_NAME     | my_value              | default | dummy key name/value            |
| MY_SECRET       | super-sensitive-value | default | something to test secret hiding |
| new_param_value | third value           | default | fresh description               |
+-----------------+-----------------------+---------+---------------------------------+
(new-host-4):~/cloudtruth-cli $
```