### PR TITLE
a clean docker environment for building the CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+target/
+Dockerfile

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,29 @@
+#
+# Copyright (C) 2021 CloudTruth, Inc.
+# All Rights Reserved
+#
+# This is a clean rust development container for building the CLI.
+# Map the project directory to /home/dev/cli when running the container.
+# Use "make image" then "make shell" to get a clean shell for building.
+#
+
+FROM rust:alpine
+
+ENV APP_USER="dev"
+ENV APP_DIR="/home/$APP_USER/cli"
+ENV CROSS_DOCKER_IN_DOCKER=true
+ENV OS_DEPS="bash docker-cli make musl-dev openssl-dev"
+
+RUN apk add --no-cache $OS_DEPS
+
+ARG user_uid=61000
+ARG user_gid=61000
+RUN addgroup -S $APP_USER -g $user_gid
+RUN adduser -S $APP_USER -G $APP_USER -s /bin/false -u $user_uid
+
+WORKDIR $APP_DIR
+USER $APP_USER
+CMD bash
+
+# install the things we need to build
+RUN cargo install cargo-deb cargo-generate-rpm cross

--- a/Makefile
+++ b/Makefile
@@ -4,9 +4,37 @@
 
 os_name := $(shell uname -s)
 
-.PHONY: prerequisites cargo test lint targets precommit
+.PHONY: image shell all cargo clean lint precommit prerequisites test lint targets
+
+### Commands for outside the container
+
+image:
+	docker build --build-arg user_uid=$(shell id -u) --build-arg user_gid=$(shell id -g) -t cloudtruth/cli . -f Dockerfile.dev
+
+shell:
+	docker run --rm --privileged=true \
+		--group-add $(shell stat -c '%g' /var/run/docker.sock) \
+		-v $(PWD):/home/dev/cli \
+		-v $(HOME)/.cargo:/home/dev/.cargo \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-it cloudtruth/cli
+
+### Commands for either outside or inside the container
 
 all: precommit
+
+cargo:
+	cargo build
+
+clean:
+	rm -rf target/
+
+lint:
+	cargo fmt --all -- --check
+	cargo clippy --all-features -- -D warnings
+	shellcheck install.sh
+
+precommit: cargo test lint
 
 prerequisites:
 ifeq ($(os_name),Darwin)
@@ -15,25 +43,18 @@ else
 	sudo apt-get install shellcheck;
 endif
 
-lint:
-	cargo fmt --all -- --check
-	cargo clippy --all-features -- -D warnings
-	shellcheck install.sh
-
-cargo:
-	cargo build
-
 test:
 	cargo test
 	make -C tests
 
-precommit: cargo test lint
-
 targets:
 	@echo ""
-	@echo "precommit     - build rust targets, tests, and lints the files"
 	@echo "cargo         - builds rust target"
+	@echo "clean         - clean out build targets"
+	@echo "image         - make the cloudtruth/cli docker container for development"
 	@echo "lint          - checks for formatting issues"
-	@echo "test          - runs tests (no linting)"
+	@echo "precommit     - build rust targets, tests, and lints the files"
 	@echo "prerequisites - install prerequisites"
+	@echo "shell         - drop into the cloudtruth/cli docker container for development"
+	@echo "test          - runs tests (no linting)"
 	@echo ""


### PR DESCRIPTION
I found this useful so I did not have to figure out what my linux host needed to be installed to build the cli.
It does not provide a CLI runtime environment image, it is purely for development.

$ make image
$ make shell

(inside container)

cargo build