### PR TITLE
Consider project in most 'template' queries

### DIFF
--- a/graphql/template_queries.graphql
+++ b/graphql/template_queries.graphql
@@ -1,8 +1,10 @@
-query GetTemplateByNameQuery($organizationId: ID, $environmentName: String, $templateName: String!) {
+query GetTemplateByNameQuery($organizationId: ID, $projectName: String, $environmentName: String, $templateName: String!) {
   viewer {
     organization(id: $organizationId) {
-      template(name: $templateName) {
-        evaluated(environmentName: $environmentName)
+      project(name: $projectName) {
+        template(name: $templateName) {
+          evaluated(environmentName: $environmentName)
+        }
       }
     }
   }
@@ -19,15 +21,17 @@ query GetImplicitTemplateQuery($organizationId: ID, $environmentName: String, $t
 }
 
 
-query TemplatesQuery($organizationId: ID) {
+query TemplatesQuery($organizationId: ID, $projectName: String) {
   viewer {
     id
     organization(id: $organizationId) {
-      templates {
-        nodes {
-          id
-          name
-          description
+      project(name: $projectName)  {
+        templates {
+          nodes {
+            id
+            name
+            description
+          }
         }
       }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -463,9 +463,13 @@ fn process_templates_command(
     subcmd_args: &ArgMatches,
 ) -> Result<()> {
     if let Some(subcmd_args) = subcmd_args.subcommand_matches("list") {
-        let details = templates.get_template_details(org_id)?;
+        let proj_name = resolved.proj_name.clone();
+        let details = templates.get_template_details(org_id, proj_name.clone())?;
         if details.is_empty() {
-            println!("There are no templates in your account.")
+            println!(
+                "There are no templates in project `{}`.",
+                proj_name.unwrap_or_else(|| DEFAULT_PROJ_NAME.to_string())
+            );
         } else if !subcmd_args.is_present("values") {
             let list = details
                 .iter()
@@ -491,9 +495,10 @@ fn process_templates_command(
             }
         }
     } else if let Some(subcmd_args) = subcmd_args.subcommand_matches("get") {
+        let proj_name = resolved.proj_name.clone();
         let template_name = subcmd_args.value_of("KEY").unwrap();
         let env_name = resolved.env_name.as_deref();
-        let body = templates.get_body_by_name(org_id, env_name, template_name)?;
+        let body = templates.get_body_by_name(org_id, proj_name, env_name, template_name)?;
 
         if let Some(body) = body {
             println!("{}", body)


### PR DESCRIPTION
Sample output:
```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- templates ls -v
+---------------+------------------+
| Name          | Description      |
+---------------+------------------+
| some template | some description |
+---------------+------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- --project Project1 templates ls 
There are no templates in project `Project1`.
(new-host-4):~/cloudtruth-cli $
```