### PR TITLE
Add 'projects' management functions -- 'set' and 'delete'

### DIFF
--- a/graphql/project_queries.graphql
+++ b/graphql/project_queries.graphql
@@ -19,7 +19,52 @@ query GetProjectByNameQuery($organizationId: ID, $projectName: String) {
     organization(id: $organizationId) {
       project(name: $projectName) {
         id
+        name
+        description
+        defaultForOrganization,
       }
+    }
+  }
+}
+
+mutation CreateProjectMutation($organizationId: ID, $projectName: String!, $description: String) {
+  createProject(input: { organizationId: $organizationId, name: $projectName, description: $description }) {
+    clientMutationId
+    project {
+      id
+    }
+
+    errors {
+      path
+      message
+    }
+  }
+}
+
+mutation DeleteProjectMutation($projectId: ID!) {
+  deleteProject(input: { id: $projectId }) {
+    clientMutationId
+    project {
+      id
+    }
+
+    errors {
+      path
+      message
+    }
+  }
+}
+
+mutation UpdateProjectMutation($projectName: String!, $projectId: ID!, $description: String) {
+  updateProject(input: { name: $projectName, id: $projectId, description: $description }) {
+    clientMutationId
+    project {
+      id
+    }
+
+    errors {
+      path
+      message
     }
   }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -249,11 +249,32 @@ pub fn build_cli() -> App<'static, 'static> {
                 .visible_aliases(&["projects", "proj"])
                 .about("Work with CloudTruth projects")
                 .subcommands(vec![
+                    SubCommand::with_name("delete")
+                        .visible_alias("del")
+                        .about("Delete specified CloudTruth project")
+                        .arg(Arg::with_name("NAME")
+                            .index(1)
+                            .required(true)
+                            .help("Project name"))
+                        .arg(Arg::with_name("confirm")
+                            .long("confirm")
+                            .help("Avoid confirmation prompt")),
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth projects")
                         .arg(values_flag().help("Display project information/values"))
-                        .arg(table_format_options().help("Format for project values data"))
+                        .arg(table_format_options().help("Format for project values data")),
+                    SubCommand::with_name("set")
+                        .about("Create/update a CloudTruth project")
+                        .arg(Arg::with_name("NAME")
+                            .index(1)
+                            .required(true)
+                            .help("Project name"))
+                        .arg(Arg::with_name("description")
+                            .short("d")
+                            .long("desc")
+                            .takes_value(true)
+                            .help("Project's description")),
                 ])
         )
 }

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -50,6 +50,7 @@ pub enum Operation {
 pub enum Resource {
     Environment,
     Parameter,
+    Project,
     Template,
 }
 


### PR DESCRIPTION
Example output:
```
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj ls -v 
+----------+-------------------------------------+
| Name     | Description                         |
+----------+-------------------------------------+
| Proj2    | Just another project                |
| Project1 | My very first project!              |
| default  | The auto-generated default project. |
+----------+-------------------------------------+
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj set -h
cloudtruth-projects-set 
Create/update a CloudTruth project

USAGE:
    cloudtruth projects set [OPTIONS] <NAME>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -d, --desc <description>    Project's description

ARGS:
    <NAME>    Project name
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj set new_proj -d "description set at create"
Created project 'new_proj'
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj ls -v 
+----------+-------------------------------------+
| Name     | Description                         |
+----------+-------------------------------------+
| Proj2    | Just another project                |
| Project1 | My very first project!              |
| default  | The auto-generated default project. |
| new_proj | description set at create           |
+----------+-------------------------------------+
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj set new_proj -d "later description"
Updated project 'new_proj'
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj ls -v 
+----------+-------------------------------------+
| Name     | Description                         |
+----------+-------------------------------------+
| Proj2    | Just another project                |
| Project1 | My very first project!              |
| default  | The auto-generated default project. |
| new_proj | later description                   |
+----------+-------------------------------------+
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj del -h
cloudtruth-projects-delete 
Delete specified CloudTruth project

USAGE:
    cloudtruth projects delete [FLAGS] <NAME>

FLAGS:
        --confirm    Avoid confirmation prompt
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <NAME>    Project name
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj del new_proj 
Delete project 'new_proj'? (y/n) n
Project 'new_proj' not deleted!
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj set new_proj -d "later description"
Project 'new_proj' not updated: same description
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj del new_proj --confirm
Deleted project 'new_proj'
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ cargo run -q -- proj ls -v 
+----------+-------------------------------------+
| Name     | Description                         |
+----------+-------------------------------------+
| Proj2    | Just another project                |
| Project1 | My very first project!              |
| default  | The auto-generated default project. |
+----------+-------------------------------------+
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ 
```