### PR TITLE
Config/profile enhancements

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -69,6 +69,9 @@ pub fn build_cli() -> App<'static, 'static> {
                     .about("Edit your configuration data for this application"),
                 SubCommand::with_name("list")
                     .visible_alias("ls")
+                    .arg(values_flag().help("Display profile information/values"))
+                    .arg(table_format_options().help("Display profile value info format"))
+                    .arg(secrets_display_flag().help("Display API key values"))
                     .about("List CloudTruth profiles in the local config file"),
                 ])
         )

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,5 +1,5 @@
 use crate::config::profiles::Profile;
-use crate::config::{CT_API_KEY, CT_OLD_API_KEY, CT_SERVER_URL};
+use crate::config::{CT_API_KEY, CT_ENVIRONMENT, CT_OLD_API_KEY, CT_PROJECT, CT_SERVER_URL};
 use std::env;
 
 pub(crate) struct ConfigEnv {}
@@ -9,6 +9,9 @@ impl ConfigEnv {
         Profile {
             api_key: ConfigEnv::get_override(CT_API_KEY)
                 .or_else(|| ConfigEnv::get_override(CT_OLD_API_KEY)),
+            description: None,
+            environment: ConfigEnv::get_override(CT_ENVIRONMENT),
+            project: ConfigEnv::get_override(CT_PROJECT),
             server_url: ConfigEnv::get_override(CT_SERVER_URL),
             source_profile: None,
         }
@@ -28,20 +31,30 @@ impl ConfigEnv {
 #[cfg(test)]
 mod tests {
     use crate::config::profiles::Profile;
-    use crate::config::{ConfigEnv, CT_API_KEY, CT_OLD_API_KEY, CT_SERVER_URL};
+    use crate::config::{
+        ConfigEnv, CT_API_KEY, CT_ENVIRONMENT, CT_OLD_API_KEY, CT_PROJECT, CT_SERVER_URL,
+    };
     use serial_test::serial;
     use std::env;
+
+    fn remove_env_vars() {
+        env::remove_var(CT_API_KEY);
+        env::remove_var(CT_ENVIRONMENT);
+        env::remove_var(CT_OLD_API_KEY);
+        env::remove_var(CT_PROJECT);
+        env::remove_var(CT_SERVER_URL);
+    }
 
     #[test]
     #[serial]
     fn create_profile_from_empty_env() {
-        env::remove_var(CT_API_KEY);
-        env::remove_var(CT_OLD_API_KEY);
-        env::remove_var(CT_SERVER_URL);
-
+        remove_env_vars();
         assert_eq!(
             Profile {
                 api_key: None,
+                description: None,
+                environment: None,
+                project: None,
                 server_url: None,
                 source_profile: None
             },
@@ -52,59 +65,67 @@ mod tests {
     #[test]
     #[serial]
     fn create_profile_from_env() {
+        remove_env_vars();
         env::set_var(CT_API_KEY, "new_key");
+        env::set_var(CT_ENVIRONMENT, "my_environment");
+        env::set_var(CT_PROJECT, "skunkworks");
         env::set_var(CT_SERVER_URL, "http://localhost:7001/graphql");
 
         assert_eq!(
             Profile {
                 api_key: Some("new_key".to_string()),
+                description: None,
+                environment: Some("my_environment".to_string()),
+                project: Some("skunkworks".to_string()),
                 server_url: Some("http://localhost:7001/graphql".to_string()),
                 source_profile: None
             },
             ConfigEnv::load_profile()
         );
-
-        env::remove_var(CT_API_KEY);
-        env::remove_var(CT_SERVER_URL);
     }
 
     #[test]
     #[serial]
     fn create_profile_new_env_takes_precedence() {
+        remove_env_vars();
         env::set_var(CT_API_KEY, "new_key");
+        env::set_var(CT_ENVIRONMENT, "my_env");
         env::set_var(CT_OLD_API_KEY, "old_key");
+        env::set_var(CT_PROJECT, "skunkworks");
         env::set_var(CT_SERVER_URL, "http://localhost:7001/graphql");
 
         assert_eq!(
             Profile {
                 api_key: Some("new_key".to_string()),
+                description: None,
+                environment: Some("my_env".to_string()),
+                project: Some("skunkworks".to_string()),
                 server_url: Some("http://localhost:7001/graphql".to_string()),
                 source_profile: None
             },
             ConfigEnv::load_profile()
         );
-
-        env::remove_var(CT_API_KEY);
-        env::remove_var(CT_SERVER_URL);
     }
 
     #[test]
     #[serial]
     fn create_profile_from_old_env() {
-        env::remove_var(CT_API_KEY);
+        remove_env_vars();
+        env::set_var(CT_ENVIRONMENT, "my_environ");
+        env::set_var(CT_PROJECT, "skunkworks");
         env::set_var(CT_OLD_API_KEY, "old_key");
         env::set_var(CT_SERVER_URL, "http://localhost:7001/graphql");
 
         assert_eq!(
             Profile {
                 api_key: Some("old_key".to_string()),
+                description: None,
+                environment: Some("my_environ".to_string()),
+                project: Some("skunkworks".to_string()),
                 server_url: Some("http://localhost:7001/graphql".to_string()),
                 source_profile: None
             },
             ConfigEnv::load_profile()
         );
-
-        env::remove_var(CT_API_KEY);
-        env::remove_var(CT_SERVER_URL);
     }
 }

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -64,8 +64,8 @@ impl ConfigFile {
     pub(crate) fn config_file_template() -> &'static str {
         indoc!(
             r#"
-            # You can have multiple profiles to group your configuration. E.g., if you belong to
-            # multiple organizations, you can create two separate profiles each with its own API
+            # You can have multiple profiles to group your configuration. E.g., if you use multiple
+            # projects, you can create two separate profiles each with its own role appropriate API
             # key. When you invoke the CloudTruth CLI tool, you can pass an argument to choose
             # which profile to load. Profiles can inherit values from other profiles by using the
             # `source_profile` setting, providing it with the name of another profile. Profile
@@ -74,10 +74,14 @@ impl ConfigFile {
             profiles:
               default:
                 api_key: ""
+                description: Default environment/project
 
               # another-profile:
               #   source_profile: default
               #   api_key: "my-read-only-api-key"
+              #   description: Read-only user on a different project
+              #   project: other-project-name
+              #   environment: pre-production
         "#
         )
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -75,8 +75,8 @@ const ORGANIZATION_NAME: &str = "CloudTruth";
 #[derive(Debug)]
 pub struct Config {
     pub api_key: String,
-    pub environment: String,
-    pub project: String,
+    pub environment: Option<String>,
+    pub project: Option<String>,
     pub server_url: String,
 }
 
@@ -96,8 +96,8 @@ impl From<Profile> for Config {
     fn from(profile: Profile) -> Self {
         Config {
             api_key: profile.api_key.unwrap_or_else(|| "".to_string()),
-            environment: profile.environment.unwrap_or_else(|| "".to_string()),
-            project: profile.project.unwrap_or_else(|| "".to_string()),
+            environment: profile.environment,
+            project: profile.project,
             server_url: profile
                 .server_url
                 .unwrap_or_else(|| DEFAULT_SERVER_URL.to_string()),

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -4,14 +4,29 @@ use serde::Deserialize;
 #[serde(default)]
 pub struct Profile {
     pub api_key: Option<String>,
+    pub description: Option<String>,
+    pub environment: Option<String>,
+    pub project: Option<String>,
     pub server_url: Option<String>,
     pub(crate) source_profile: Option<String>,
+}
+
+// TODO: Rick Porter 4/21, fix this so don't have to udpate when Profile is updated
+pub struct ProfileDetails {
+    pub api_key: Option<String>,
+    pub description: Option<String>,
+    pub environment: Option<String>,
+    pub name: String,
+    pub project: Option<String>,
 }
 
 impl Default for Profile {
     fn default() -> Self {
         Self {
             api_key: None,
+            description: None,
+            environment: None,
+            project: None,
             server_url: None,
             source_profile: None,
         }
@@ -23,6 +38,15 @@ impl Profile {
     pub(crate) fn merge(&self, other: &Self) -> Profile {
         Profile {
             api_key: other.api_key.clone().or_else(|| self.api_key.clone()),
+            description: other
+                .description
+                .clone()
+                .or_else(|| self.description.clone()),
+            environment: other
+                .environment
+                .clone()
+                .or_else(|| self.environment.clone()),
+            project: other.project.clone().or_else(|| self.project.clone()),
             server_url: other.server_url.clone().or_else(|| self.server_url.clone()),
             source_profile: self.source_profile.clone(),
         }
@@ -37,12 +61,18 @@ mod tests {
     fn merged_values_take_priority() {
         let first = Profile {
             api_key: None,
+            description: None,
+            environment: None,
+            project: None,
             server_url: None,
             ..Profile::default()
         };
 
         let second = Profile {
             api_key: Some("new_key".to_string()),
+            description: Some("describe your param in 25 words or less".to_string()),
+            environment: Some("my_environment".to_string()),
+            project: Some("skunkworks".to_string()),
             server_url: Some("http://localhost:7001/graphql".to_string()),
             ..Profile::default()
         };
@@ -54,12 +84,18 @@ mod tests {
     fn merged_empty_values_are_ignored() {
         let first = Profile {
             api_key: Some("new_key".to_string()),
+            description: Some("describe your param in 25 words or less".to_string()),
+            environment: Some("my_environment".to_string()),
+            project: Some("skunkworks".to_string()),
             server_url: Some("http://localhost:7001/graphql".to_string()),
             ..Profile::default()
         };
 
         let second = Profile {
             api_key: None,
+            description: None,
+            environment: None,
+            project: None,
             server_url: None,
             ..Profile::default()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,16 +133,8 @@ fn user_confirm(message: String) -> bool {
 fn resolve_ids(org_id: Option<&str>, config: &Config) -> Result<ResolvedIds> {
     // The `err` value is used to allow accumulation of multiple errors to the user.
     let mut err = false;
-    let env = if !config.environment.is_empty() {
-        Some(config.environment.as_str())
-    } else {
-        None
-    };
-    let proj = if !config.project.is_empty() {
-        Some(config.project.as_str())
-    } else {
-        None
-    };
+    let env = config.environment.as_deref();
+    let proj = config.project.as_deref();
     let environments = Environments::new();
     let env_id = environments.get_id(org_id, env)?;
     if env_id.is_none() {


### PR DESCRIPTION
Several improvements to profiles and related:
1. Added `environment`, `project`, and `description` to profile config
2. CLI will take environment and/or project in normal precedence: cli argument, environment variable, or lastly config profile
3. Enhanced `config list` with "standard" table options:  `-v/--values`, `-f/--format`, `-s/--secrets`

```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- config ls -h
cloudtruth-config-list 
List CloudTruth profiles in the local config file

USAGE:
    cloudtruth config list [FLAGS] [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -s, --secrets    Display API key values
    -v, --values     Display profile information/values
    -V, --version    Prints version information

OPTIONS:
    -f, --format <format>    Display profile value info format [default: table]  [possible values: table, csv]
(new-host-4):~/cloudtruth-cli $ cargo run -q -- config ls -v
+---------+-------+-------------+----------+----------------------------------------+
| Name    | API   | Environment | Project  | Description                            |
+---------+-------+-------------+----------+----------------------------------------+
| default |       |             |          |                                        |
| ci-rw   | ***** |             |          | CI account to read/write to production |
| ci      | ***** |             |          | CI account on production server        |
| stage   | ***** |             | Project1 | contact staging server                 |
+---------+-------+-------------+----------+----------------------------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- run -c "printenv | grep CLOUDTRUTH"
CLOUDTRUTH_PROJECT=default
CLOUDTRUTH_ENVIRONMENT=default
(new-host-4):~/cloudtruth-cli $ cargo run -q -- --profile stage run -c "printenv | grep CLOUDTRUTH"
CLOUDTRUTH_PROJECT=Project1
CLOUDTRUTH_ENVIRONMENT=default
(new-host-4):~/cloudtruth-cli $ cargo run -q -- --profile stage --project Proj2 run -c "printenv | grep CLOUDTRUTH"
CLOUDTRUTH_PROJECT=Proj2
CLOUDTRUTH_ENVIRONMENT=default
(new-host-4):~/cloudtruth-cli $ 
```