### PR TITLE
Run integration test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,19 @@ jobs:
 
       - run: cargo build
       - run: cargo test
-      - name: Integration Test
+
+      - name: Integration Test - non-Windows
         env:
           OS: ${{ runner.os }}
         if: runner.os != 'Windows'
         run: |
           cd tests/pytest
           python3 live_test.py --log-commands --job-id "${OS}-${GITHUB_RUN_NUMBER}"
+
+      - name: Integration Test - Windows
+        env:
+          OS: ${{ runner.os }}
+        if: runner.os == 'Windows'
+        run: |
+          cd tests\pytest
+          py live_test.py --log-commands --job-id "$ENV:OS-$ENV:GITHUB_RUN_NUMBER"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
 
     env:
       CLOUDTRUTH_API_KEY: ${{ secrets.CI_ACCT_READWRITE_CT_API_KEY }}
-      JOB_ID: ${{ job.id }}
+      # JOB_ID: ${{ job.id }}
+      JOB_ID: "fake-jobid"
+      JOB_CONTEXT: ${{ toJson(job) }}
 
     strategy:
       fail-fast: false
@@ -86,6 +88,7 @@ jobs:
       - run: cargo test
       - name: Integration Test
         run: |
+          echo "JOB_CONTEXT: $JOB_CONTEXT"
           echo "JOB_ID: $JOB_ID"
           cd tests/pytest
           python3 live_test.py --log-commands --job-id "$JOB_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,9 @@ jobs:
     env:
       CLOUDTRUTH_API_KEY: ${{ secrets.CI_ACCT_READWRITE_CT_API_KEY }}
       # JOB_ID: ${{ job.id }}
-      JOB_ID: "fake-jobid"
+      # JOB_ID: "fake-jobid"
       GH_CONTEXT: ${{ toJson(github) }}
+      JOBS_CONTEXT: ${{ toJson(jobs) }}
 
     strategy:
       fail-fast: false
@@ -92,6 +93,7 @@ jobs:
           STEP_CONTEXT: ${{ toJson(steps) }}
         run: |
           echo "JOB_CONTEXT: $JOB_CONTEXT"
+          echo "JOBS_CONTEXT: $JOBS_CONTEXT"
           #echo "GH_CONTEXT: $GH_CONTEXT"
           echo "STEP_CONTEXT: $STEP_CONTEXT"
           echo "JOB_ID: $JOB_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,4 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           cd tests\pytest
-          py live_test.py --log-commands --log-output --job-id "$ENV:OS-$ENV:GITHUB_RUN_NUMBER"
+          py live_test.py --job-id "$ENV:OS-$ENV:GITHUB_RUN_NUMBER"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd tests/pytest
-          python3 live_test.py --log-commands --job-id "${OS}-${GITHUB_RUN_NUMBER}"
+          python3 live_test.py --job-id "${OS}-${GITHUB_RUN_NUMBER}"
 
       - name: Integration Test - Windows
         env:
@@ -98,4 +98,4 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           cd tests\pytest
-          py live_test.py --log-commands --job-id "$ENV:OS-$ENV:GITHUB_RUN_NUMBER"
+          py live_test.py --log-commands --log-output --job-id "$ENV:OS-$ENV:GITHUB_RUN_NUMBER"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,10 @@ jobs:
           STEP_CONTEXT: ${{ toJson(steps) }}
         run: |
           echo "JOB_CONTEXT: $JOB_CONTEXT"
-          echo "GH_CONTEXT: $GH_CONTEXT"
+          #echo "GH_CONTEXT: $GH_CONTEXT"
           echo "STEP_CONTEXT: $STEP_CONTEXT"
           echo "JOB_ID: $JOB_ID"
+          echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
+          echo "GITHUB_RUN_NUMBER: $GITHUB_RUN_NUMBER"
           cd tests/pytest
           python3 live_test.py --log-commands --job-id "$JOB_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - run: cargo test
       - name: Integration Test
         env:
-          JOB_CONTEXT: ${{ toJson(jobs) }}
+          JOB_CONTEXT: ${{ toJson(job) }}
           STEP_CONTEXT: ${{ toJson(steps) }}
         run: |
           echo "JOB_CONTEXT: $JOB_CONTEXT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
       CLOUDTRUTH_API_KEY: ${{ secrets.CI_ACCT_READWRITE_CT_API_KEY }}
       # JOB_ID: ${{ job.id }}
       JOB_ID: "fake-jobid"
-      JOB_CONTEXT: ${{ toJson(jobs) }}
       GH_CONTEXT: ${{ toJson(github) }}
 
     strategy:
@@ -88,9 +87,13 @@ jobs:
       - run: cargo build
       - run: cargo test
       - name: Integration Test
+        env:
+          JOB_CONTEXT: ${{ toJson(jobs) }}
+          STEP_CONTEXT: ${{ toJson(steps) }}
         run: |
           echo "JOB_CONTEXT: $JOB_CONTEXT"
           echo "GH_CONTEXT: $GH_CONTEXT"
+          echo "STEP_CONTEXT: $STEP_CONTEXT"
           echo "JOB_ID: $JOB_ID"
           cd tests/pytest
           python3 live_test.py --log-commands --job-id "$JOB_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,7 @@ jobs:
 
     env:
       CLOUDTRUTH_API_KEY: ${{ secrets.CI_ACCT_READWRITE_CT_API_KEY }}
+      JOB_ID: ${{ job.id }}
 
     strategy:
       fail-fast: false
@@ -84,8 +85,7 @@ jobs:
       - run: cargo build
       - run: cargo test
       - name: Integration Test
-        env:
-          JOB_ID: ${{ job.id }}
         run: |
+          echo "JOB_ID: $JOB_ID"
           cd tests/pytest
           python3 live_test.py --log-commands --job-id "$JOB_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,5 +86,5 @@ jobs:
       - name: Integration Test
         run: |
           cd tests/pytest
-          JOB_ID=${{ job_id }}
+          JOB_ID=${{ my_job }}
           python3 live_test.py --log-commands --job-id "$JOB_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,6 @@ jobs:
 
     env:
       CLOUDTRUTH_API_KEY: ${{ secrets.CI_ACCT_READWRITE_CT_API_KEY }}
-      # JOB_ID: ${{ job.id }}
-      # JOB_ID: "fake-jobid"
-      GH_CONTEXT: ${{ toJson(github) }}
 
     strategy:
       fail-fast: false
@@ -88,21 +85,8 @@ jobs:
       - run: cargo test
       - name: Integration Test
         env:
-          JOB_CONTEXT: ${{ toJson(job) }}
-          STEP_CONTEXT: ${{ toJson(steps) }}
-          MATRIX_CONTEXT: ${{ toJson(matrix) }}
-          ENV_CONTEXT: ${{ toJson(env) }}
-          RUNNER_CONTEXT: ${{ toJson(runner) }}
+          OS: ${{ runner.os }}
+        if: runner.os != 'Windows'
         run: |
-          echo "JOB_CONTEXT: $JOB_CONTEXT"
-          #echo "JOBS_CONTEXT: $JOBS_CONTEXT"
-          #echo "GH_CONTEXT: $GH_CONTEXT"
-          echo "STEP_CONTEXT: $STEP_CONTEXT"
-          echo "MATRIX_CONTEXT: $MATRIX_CONTEXT"
-          echo "ENV_CONTEXT: $ENV_CONTEXT"
-          echo "RUNNER_CONTEXT: $RUNNER_CONTEXT"
-          echo "JOB_ID: $JOB_ID"
-          echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
-          echo "GITHUB_RUN_NUMBER: $GITHUB_RUN_NUMBER"
           cd tests/pytest
-          python3 live_test.py --log-commands --job-id "$JOB_ID"
+          python3 live_test.py --log-commands --job-id "${OS}-${GITHUB_RUN_NUMBER}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,8 @@ jobs:
       - run: cargo build
       - run: cargo test
       - name: Integration Test
+        env:
+          JOB_ID: ${{ job.id }}
         run: |
           cd tests/pytest
-          JOB_ID=${{ my_job }}
           python3 live_test.py --log-commands --job-id "$JOB_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,8 @@ jobs:
       CLOUDTRUTH_API_KEY: ${{ secrets.CI_ACCT_READWRITE_CT_API_KEY }}
       # JOB_ID: ${{ job.id }}
       JOB_ID: "fake-jobid"
-      JOB_CONTEXT: ${{ toJson(job) }}
+      JOB_CONTEXT: ${{ toJson(jobs) }}
+      GH_CONTEXT: ${{ toJson(github) }}
 
     strategy:
       fail-fast: false
@@ -89,6 +90,7 @@ jobs:
       - name: Integration Test
         run: |
           echo "JOB_CONTEXT: $JOB_CONTEXT"
+          echo "GH_CONTEXT: $GH_CONTEXT"
           echo "JOB_ID: $JOB_ID"
           cd tests/pytest
           python3 live_test.py --log-commands --job-id "$JOB_ID"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,5 +85,5 @@ jobs:
       - run: cargo test
       - run: |
           cd tests/pytest
-          JOB_ID=${{ jobs.job_id }}
+          JOB_ID=${{ job.id }}
           python3 live_test.py --log-commands --job-id "${JOB_ID}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
       # JOB_ID: ${{ job.id }}
       # JOB_ID: "fake-jobid"
       GH_CONTEXT: ${{ toJson(github) }}
-      JOBS_CONTEXT: ${{ toJson(jobs) }}
 
     strategy:
       fail-fast: false
@@ -91,11 +90,17 @@ jobs:
         env:
           JOB_CONTEXT: ${{ toJson(job) }}
           STEP_CONTEXT: ${{ toJson(steps) }}
+          MATRIX_CONTEXT: ${{ toJson(matrix) }}
+          ENV_CONTEXT: ${{ toJson(env) }}
+          RUNNER_CONTEXT: ${{ toJson(runner) }}
         run: |
           echo "JOB_CONTEXT: $JOB_CONTEXT"
-          echo "JOBS_CONTEXT: $JOBS_CONTEXT"
+          #echo "JOBS_CONTEXT: $JOBS_CONTEXT"
           #echo "GH_CONTEXT: $GH_CONTEXT"
           echo "STEP_CONTEXT: $STEP_CONTEXT"
+          echo "MATRIX_CONTEXT: $MATRIX_CONTEXT"
+          echo "ENV_CONTEXT: $ENV_CONTEXT"
+          echo "RUNNER_CONTEXT: $RUNNER_CONTEXT"
           echo "JOB_ID: $JOB_ID"
           echo "GITHUB_RUN_ID: $GITHUB_RUN_ID"
           echo "GITHUB_RUN_NUMBER: $GITHUB_RUN_NUMBER"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,9 @@ jobs:
     name: Test
     runs-on: ${{ matrix.os }}
 
+    env:
+      CLOUDTRUTH_API_KEY: ${{ secrets.CI_ACCT_READWRITE_CT_API_KEY }}
+
     strategy:
       fail-fast: false
       matrix:
@@ -80,3 +83,7 @@ jobs:
 
       - run: cargo build
       - run: cargo test
+      - run: |
+          cd tests/pytest
+          JOB_ID=${{ jobs.job_id }}
+          python3 live_test.py --log-commands --job-id "${JOB_ID}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,8 @@ jobs:
 
       - run: cargo build
       - run: cargo test
-      - run: |
+      - name: Integration Test
+        run: |
           cd tests/pytest
-          JOB_ID=${{ job.id }}
-          python3 live_test.py --log-commands --job-id "${JOB_ID}"
+          JOB_ID=${{ job_id }}
+          python3 live_test.py --log-commands --job-id "$JOB_ID"

--- a/tests/pytest/live_test.py
+++ b/tests/pytest/live_test.py
@@ -112,7 +112,6 @@ def live_test(*args):
         env[CT_API_KEY] = args.api_key
     env[CT_TEST_LOG_COMMANDS] = str(int(args.log_commands))
     env[CT_TEST_LOG_OUTPUT] = str(int(args.log_output))
-    env["NO_COLOR"] = "true"  # avoids possible issues on Windows
     if args.job_id:
         env[CT_TEST_JOB_ID] = args.job_id
 

--- a/tests/pytest/live_test.py
+++ b/tests/pytest/live_test.py
@@ -6,7 +6,7 @@ import traceback
 import unittest
 
 from testcase import CT_API_KEY, CT_URL
-from testcase import CT_TEST_LOG_COMMANDS, CT_TEST_LOG_OUTPUT
+from testcase import CT_TEST_JOB_ID, CT_TEST_LOG_COMMANDS, CT_TEST_LOG_OUTPUT
 from testcase import DEFAULT_SERVER_URL
 
 
@@ -67,6 +67,12 @@ def parse_args(*args) -> argparse.Namespace:
         action="store_true",
         help="Print the output to stdout."
     )
+    parser.add_argument(
+        "--job-id",
+        type=str,
+        dest="job_id",
+        help="Job Identifier to use as a suffix on project and environment names"
+    )
     # TODO: Rick Porter 5/21 - add test case filtering
     return parser.parse_args(*args)
 
@@ -106,6 +112,8 @@ def live_test(*args):
         env[CT_API_KEY] = args.api_key
     env[CT_TEST_LOG_COMMANDS] = str(int(args.log_commands))
     env[CT_TEST_LOG_OUTPUT] = str(int(args.log_output))
+    if args.job_id:
+        env[CT_TEST_JOB_ID] = args.job_id
 
     test_directory = '.'
     suite = unittest.TestLoader().discover(test_directory, pattern=args.file_filter)

--- a/tests/pytest/live_test.py
+++ b/tests/pytest/live_test.py
@@ -82,14 +82,14 @@ def debugTestRunner(enable_debug: bool, verbosity: int, failfast: bool):
     class DebugTestResult(unittest.TextTestResult):
         def addError(self, test, err):
             # called before tearDown()
+            traceback.print_exception(*err)
             if enable_debug:
-                traceback.print_exception(*err)
                 pdb.post_mortem(err[2])
             super(DebugTestResult, self).addError(test, err)
 
         def addFailure(self, test, err):
+            traceback.print_exception(*err)
             if enable_debug:
-                traceback.print_exception(*err)
                 pdb.post_mortem(err[2])
             super(DebugTestResult, self).addFailure(test, err)
 

--- a/tests/pytest/live_test.py
+++ b/tests/pytest/live_test.py
@@ -112,6 +112,7 @@ def live_test(*args):
         env[CT_API_KEY] = args.api_key
     env[CT_TEST_LOG_COMMANDS] = str(int(args.log_commands))
     env[CT_TEST_LOG_OUTPUT] = str(int(args.log_output))
+    env["NO_COLOR"] = "true"  # avoids possible issues on Windows
     if args.job_id:
         env[CT_TEST_JOB_ID] = args.job_id
 

--- a/tests/pytest/live_test.py
+++ b/tests/pytest/live_test.py
@@ -121,7 +121,13 @@ def live_test(*args):
     runner = debugTestRunner(
         enable_debug=args.debug, verbosity=args.verbosity, failfast=args.failfast
     )
-    runner.run(suite)
+    test_result = runner.run(suite)
+    rval = 0
+    if len(test_result.errors):
+        rval += 1
+    if len(test_result.failures):
+        rval += 2
+    return rval
 
 
 if __name__ == "__main__":

--- a/tests/pytest/test_args.py
+++ b/tests/pytest/test_args.py
@@ -11,10 +11,10 @@ class TestTopLevelArgs(TestCase):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
         printenv = " run -i none -- printenv"
-        proj1 = "test-arg-project-1"
-        proj2 = "test-arg-proj2"
-        env1 = "dev a"
-        env2 = "dev B"
+        proj1 = self.make_name("test-arg-project-1")
+        proj2 = self.make_name("test-arg-proj2")
+        env1 = self.make_name("dev a")
+        env2 = self.make_name("dev B")
 
         self.create_project(cmd_env, proj1)
         self.create_project(cmd_env, proj2)
@@ -80,8 +80,8 @@ class TestTopLevelArgs(TestCase):
     def test_resolution(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = "test-unknown-proj"
-        env_name = "test-env-unknown"
+        proj_name = self.make_name("test-unknown-proj")
+        env_name = self.make_name("test-env-unknown")
         checked_commands = ["param ls -v", "templates ls -v", "run -i none -c printenv"]
         unchecked_commands = ["config ls -v", "proj ls -v", "env ls -v", "completions bash"]
         missing_proj = f"The '{proj_name}' project could not be found in your account."

--- a/tests/pytest/test_args.py
+++ b/tests/pytest/test_args.py
@@ -10,7 +10,7 @@ class TestTopLevelArgs(TestCase):
     def test_arg_priority(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        printenv = " run -i none -- printenv"
+        printenv = f" run -i none -- {self.get_display_env_command()}"
         proj1 = self.make_name("test-arg-project-1")
         proj2 = self.make_name("test-arg-proj2")
         env1 = self.make_name("dev a")
@@ -82,7 +82,11 @@ class TestTopLevelArgs(TestCase):
         cmd_env = self.get_cmd_env()
         proj_name = self.make_name("test-unknown-proj")
         env_name = self.make_name("test-env-unknown")
-        checked_commands = ["param ls -v", "templates ls -v", "run -i none -c printenv"]
+        checked_commands = [
+            "param ls -v",
+            "templates ls -v",
+            f"run -i none -c {self.get_display_env_command()}",
+        ]
         unchecked_commands = ["config ls -v", "proj ls -v", "env ls -v", "completions bash"]
         missing_proj = f"The '{proj_name}' project could not be found in your account."
         missing_env = f"The '{env_name}' environment could not be found in your account."

--- a/tests/pytest/test_environments.py
+++ b/tests/pytest/test_environments.py
@@ -66,13 +66,13 @@ class TestEnvironments(TestCase):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
         # set the proj/env to 'default', and do not expose secrets
-        param_cmd = base_cmd + f"--project {DEFAULT_PROJ_NAME} --env {DEFAULT_ENV_NAME} param ls -v"
+        param_cmd = base_cmd + f"--project '{DEFAULT_PROJ_NAME}' --env '{DEFAULT_ENV_NAME}' param ls -v"
 
         # get an original snapshot (do not expose secrets)
         before = self.run_cli(cmd_env, param_cmd)
 
         # attempt to delete the default project and see failure
-        result = self.run_cli(cmd_env, base_cmd + f"environment delete {DEFAULT_ENV_NAME} --confirm")
+        result = self.run_cli(cmd_env, base_cmd + f"environment delete '{DEFAULT_ENV_NAME}' --confirm")
         self.assertNotEqual(result.return_value, 0)
         self.assertIn("Cannot delete the default environment", result.err())
 

--- a/tests/pytest/test_environments.py
+++ b/tests/pytest/test_environments.py
@@ -7,7 +7,7 @@ class TestEnvironments(TestCase):
         # verify `env_name` does not yet exist
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        env_name = "test-env-name"
+        env_name = self.make_name("test-env-name")
         sub_cmd = base_cmd + "environments "
         result = self.run_cli(cmd_env, sub_cmd + "ls -v")
         self.assertEqual(result.return_value, 0)

--- a/tests/pytest/test_parameters.py
+++ b/tests/pytest/test_parameters.py
@@ -11,7 +11,7 @@ class TestParameters(TestCase):
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = "test-param-basic"
+        proj_name = self.make_name("test-param-basic")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -129,7 +129,7 @@ my_param,cRaZy value,default,this is just a test description
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = "test-param-secret"
+        proj_name = self.make_name("test-param-secret")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -272,8 +272,8 @@ my_param,super-SENSITIVE-vAluE,default,my secret value
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
 
-        proj_name1 = "proj-sep1"
-        proj_name2 = "proj-sep2"
+        proj_name1 = self.make_name("proj-sep1")
+        proj_name2 = self.make_name("proj-sep2")
 
         self.create_project(cmd_env, proj_name1)
         self.create_project(cmd_env, proj_name2)
@@ -331,7 +331,7 @@ SNA=fu
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = "test-param-export"
+        proj_name = self.make_name("test-param-export")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -449,7 +449,7 @@ FIRST_PARAM=posix_compliant_value
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = "test-secret-switch"
+        proj_name = self.make_name("test-secret-switch")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 

--- a/tests/pytest/test_projects.py
+++ b/tests/pytest/test_projects.py
@@ -7,7 +7,7 @@ class TestProjects(TestCase):
         # verify `proj_name` does not yet exist
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = "test-proj-name"
+        proj_name = self.make_name("test-proj-name")
         sub_cmd = base_cmd + "projects "
         result = self.run_cli(cmd_env, sub_cmd + "ls -v")
         self.assertEqual(result.return_value, 0)

--- a/tests/pytest/test_run.py
+++ b/tests/pytest/test_run.py
@@ -12,7 +12,7 @@ class TestRun(TestCase):
         env_value = "env_value"
 
         sub_cmd = base_cmd + f"--project {proj_name} run "
-        print_env = " -c printenv"
+        print_env = f" -c {self.get_display_env_command()}"
 
         self.create_project(cmd_env, proj_name)
 
@@ -40,7 +40,7 @@ class TestRun(TestCase):
         ct_str = f"{param_name}={ct_value}"
 
         sub_cmd = base_cmd + f"--project {proj_name} run "
-        print_env = " -- printenv"
+        print_env = f" -- {self.get_display_env_command()}"
 
         cmd_env[param_name] = env_value  # add to the run environment
         self.create_project(cmd_env, proj_name)
@@ -75,7 +75,7 @@ class TestRun(TestCase):
         cmd_env = self.get_cmd_env()
         proj_name = self.make_name("run-permissive-proj")
         sub_cmd = base_cmd + f"--project {proj_name} run "
-        print_env = " -- printenv"
+        print_env = f" -- {self.get_display_env_command()}"
 
         # make sure we have something that normally gets removed
         if CT_URL not in cmd_env:

--- a/tests/pytest/test_run.py
+++ b/tests/pytest/test_run.py
@@ -7,7 +7,7 @@ class TestRun(TestCase):
     def test_run_inheritance_env_only(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = "run-env-proj"
+        proj_name = self.make_name("run-env-proj")
         param_name = "SOME_PARAM_NAME"
         env_value = "env_value"
 
@@ -32,9 +32,9 @@ class TestRun(TestCase):
     def test_run_inheritance_coordination(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = "run-inherit-proj"
+        proj_name = self.make_name("run-inherit-proj")
         param_name = "SOME_PARAM_NAME"
-        env_value = "env_value"
+        env_value = self.make_name("env_value")
         ct_value="ct_value"
         env_str = f"{param_name}={env_value}"
         ct_str = f"{param_name}={ct_value}"
@@ -73,7 +73,7 @@ class TestRun(TestCase):
     def test_run_permissive(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = "run-permissive-proj"
+        proj_name = self.make_name("run-permissive-proj")
         sub_cmd = base_cmd + f"--project {proj_name} run "
         print_env = " -- printenv"
 

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -91,12 +91,12 @@ class TestCase(unittest.TestCase):
     def tearDown(self) -> None:
         # tear down any possibly lingering projects -- they should have been deleted
         for proj in self._projects:
-            cmd = self._base_cmd + f"proj del '{proj}' --confirm"
+            cmd = self._base_cmd + f"proj del \"{proj}\" --confirm"
             subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         # tear down any possibly lingering environments -- they should have been deleted
         for env in self._environments:
-            cmd = self._base_cmd + f"env del '{env}' --confirm"
+            cmd = self._base_cmd + f"env del \"{env}\" --confirm"
             subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         super().tearDown()
@@ -148,6 +148,9 @@ class TestCase(unittest.TestCase):
         return deepcopy(os.environ)
 
     def run_cli(self, env: Dict[str, str], cmd) -> Result:
+        # FIXME: this is experimental to try to sneak past Windows
+        cmd = cmd.replace("'", "\"")
+
         if self.log_commands:
             print(cmd)
 

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -148,7 +148,7 @@ class TestCase(unittest.TestCase):
         return deepcopy(os.environ)
 
     def run_cli(self, env: Dict[str, str], cmd) -> Result:
-        # FIXME: this is experimental to try to sneak past Windows
+        # WARNING: DOS prompt does not like the single quotes, so use double
         cmd = cmd.replace("'", "\"")
 
         if self.log_commands:
@@ -180,8 +180,8 @@ class TestCase(unittest.TestCase):
         )
         result = Result(
             return_value=process.returncode,
-            stdout=process.stdout.decode("utf-8").split("\n"),
-            stderr=process.stderr.decode("utf-8").split("\n"),
+            stdout=process.stdout.decode("utf-8").replace("\r", "").split("\n"),
+            stderr=process.stderr.decode("utf-8").replace("\r", "").split("\n"),
         )
 
         if self.log_output:

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -19,7 +19,7 @@ DEFAULT_SERVER_URL = "https://api.cloudtruth.com/graphql"
 DEFAULT_PROJ_NAME = "default"
 DEFAULT_ENV_NAME = "default"
 
-AUTO_DESCRIPTION = "Automated testing via `live_test`"
+AUTO_DESCRIPTION = "Automated testing via live_test"
 
 CT_TEST_LOG_COMMANDS = "CT_LIVE_TEST_LOG_COMMANDS"
 CT_TEST_LOG_OUTPUT = "CT_LIVE_TEST_LOG_OUTPUT"

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -91,12 +91,12 @@ class TestCase(unittest.TestCase):
     def tearDown(self) -> None:
         # tear down any possibly lingering projects -- they should have been deleted
         for proj in self._projects:
-            cmd = self._base_cmd + f"proj del {proj} --confirm"
+            cmd = self._base_cmd + f"proj del '{proj}' --confirm"
             subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         # tear down any possibly lingering environments -- they should have been deleted
         for env in self._environments:
-            cmd = self._base_cmd + f"env del {env} --confirm"
+            cmd = self._base_cmd + f"env del '{env}' --confirm"
             subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
         super().tearDown()

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -185,8 +185,8 @@ class TestCase(unittest.TestCase):
         )
         result = Result(
             return_value=process.returncode,
-            stdout=process.stdout.decode("utf-8").replace("\r", "").split("\n"),
-            stderr=process.stderr.decode("utf-8").replace("\r", "").split("\n"),
+            stdout=process.stdout.decode("us-ascii", errors="ignore").replace("\r", "").split("\n"),
+            stderr=process.stderr.decode("us-ascii", errors="ignore").replace("\r", "").split("\n"),
         )
 
         if self.log_output:

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -147,6 +147,11 @@ class TestCase(unittest.TestCase):
     def get_cmd_env(self):
         return deepcopy(os.environ)
 
+    def get_display_env_command(self) -> str:
+        if os.name == "nt":
+            return "SET"
+        return "printenv"
+
     def run_cli(self, env: Dict[str, str], cmd) -> Result:
         # WARNING: DOS prompt does not like the single quotes, so use double
         cmd = cmd.replace("'", "\"")


### PR DESCRIPTION
Here are some supporting items:
1. Added optional job-id suffix to project and environment names to support simultaneous runs
2. Track and automatically cleanup projects and environments
3. Windows adjustments: double quotes, line endings, output decoding, printenv/set