### PR TITLE
Improve environment testing and code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -442,18 +442,18 @@ fn process_environment_command(
                     "Environment '{}' not updated: same description",
                     env_name.unwrap()
                 ))?;
+            } else if parent_name.is_some() && parent_name.unwrap() != details.parent.as_str() {
+                error_message(format!(
+                    "Environment '{}' parent cannot be updated.",
+                    env_name.unwrap()
+                ))?;
+                process::exit(6);
             } else if description.is_none() {
                 warning_message(format!(
                     "Environment '{}' not updated: no description provided",
                     env_name.unwrap()
                 ))?;
             } else {
-                if parent_name.is_some() && parent_name.unwrap() != details.parent.as_str() {
-                    warning_message(format!(
-                        "Environment '{}' parent cannot be updated.",
-                        env_name.unwrap()
-                    ))?;
-                }
                 environments.update_environment(details.id, description)?;
                 println!("Updated environment '{}'", env_name.unwrap());
             }

--- a/tests/pytest/test_args.py
+++ b/tests/pytest/test_args.py
@@ -60,7 +60,7 @@ class TestTopLevelArgs(TestCase):
         self.delete_environment(cmd_env, env1)
         self.delete_environment(cmd_env, env2)
 
-    def test_missing_subcommand(self):
+    def test_arg_missing_subcommand(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
 
@@ -77,7 +77,7 @@ class TestTopLevelArgs(TestCase):
                 self.assertEqual(result.return_value, 0)
                 self.assertIn(f"No '{subcmd}' sub-command executed", result.err())
 
-    def test_resolution(self):
+    def test_arg_resolution(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
         proj_name = self.make_name("test-unknown-proj")

--- a/tests/pytest/test_environments.py
+++ b/tests/pytest/test_environments.py
@@ -62,7 +62,7 @@ class TestEnvironments(TestCase):
         self.assertEqual(result.return_value, 0)
         self.assertTrue(result.err_contains_value(f"Environment '{env_name}' does not exist"))
 
-    def test_cannot_delete_default(self):
+    def test_environment_cannot_delete_default(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
         # set the proj/env to 'default', and do not expose secrets

--- a/tests/pytest/test_environments.py
+++ b/tests/pytest/test_environments.py
@@ -84,10 +84,10 @@ class TestEnvironments(TestCase):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
 
-        env_name1 = "cloud"
-        env_name2 = "truth"
-        env_name3 = "cli"
-        env_name4 = "gui"
+        env_name1 = self.make_name("cloud")
+        env_name2 = self.make_name("truth")
+        env_name3 = self.make_name("cli")
+        env_name4 = self.make_name("gui")
 
         self.create_environment(cmd_env, env_name1)
         self.create_environment(cmd_env, env_name2, parent=env_name1)
@@ -108,8 +108,8 @@ class TestEnvironments(TestCase):
         self.assertIn("base Environments with children cannot be deleted", result.err())
 
         # attempt to create without an existing parent
-        env_name5 = "general"
-        env_name6 = "truthiness"
+        env_name5 = self.make_name("general")
+        env_name6 = self.make_name("truthiness")
         result = self.run_cli(cmd_env, base_cmd + f"environments set '{env_name5}' --parent '{env_name6}'")
         self.assertNotEqual(result.return_value, 0)
         self.assertIn(f"No parent environment '{env_name6}' found", result.err())

--- a/tests/pytest/test_parameters.py
+++ b/tests/pytest/test_parameters.py
@@ -326,7 +326,7 @@ SNA=fu
         self.delete_project(cmd_env, proj_name1)
         self.delete_project(cmd_env, proj_name2)
 
-    def test_environment_separation(self):
+    def test_parameter_environment_separation(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
 

--- a/tests/pytest/test_parameters.py
+++ b/tests/pytest/test_parameters.py
@@ -268,7 +268,7 @@ my_param,super-SENSITIVE-vAluE,default,my secret value
         # delete the project
         self.delete_project(cmd_env, proj_name)
 
-    def test_project_separation(self):
+    def test_parameter_project_separation(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
 

--- a/tests/pytest/test_parameters.py
+++ b/tests/pytest/test_parameters.py
@@ -330,13 +330,13 @@ SNA=fu
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
 
-        proj_name = "baseball" # self.make_name("test-prj-env-sep")
+        proj_name = self.make_name("baseball")
         self.create_project(cmd_env, proj_name)
 
         env_name1 = DEFAULT_ENV_NAME  # no job-id variation
-        env_name2 = "test-mets" # self.make_name("test-env-foo")
+        env_name2 = self.make_name("test-mets")
         self.create_environment(cmd_env, env_name2)
-        env_name3 = "test-redsox" # self.make_name("test-env-bar")
+        env_name3 = self.make_name("test-redsox")
         self.create_environment(cmd_env, env_name3, parent=env_name2)
 
         var1_name = "base"

--- a/tests/pytest/test_projects.py
+++ b/tests/pytest/test_projects.py
@@ -63,7 +63,7 @@ class TestProjects(TestCase):
         self.assertEqual(result.return_value, 0)
         self.assertTrue(result.err_contains_value(f"Project '{proj_name}' does not exist"))
 
-    def test_cannot_delete_default(self):
+    def test_project_cannot_delete_default(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
         # set the proj/env to 'default', and do not expose secrets

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -206,22 +206,39 @@ class TestCase(unittest.TestCase):
         result = self.run_cli(cmd_env, self._base_cmd + f"proj delete '{proj_name}' --confirm")
         self.assertEqual(result.return_value, 0)
 
-    def create_environment(self, cmd_env, env_name: str) -> None:
-        result = self.run_cli(cmd_env,
-                              self._base_cmd + f"env set '{env_name}' -d '{AUTO_DESCRIPTION}'")
+    def create_environment(self, cmd_env, env_name: str, parent: Optional[str]=None) -> None:
+        cmd = self._base_cmd + f"env set '{env_name}' "
+        if parent:
+            cmd += f"-p '{parent}' "
+        cmd += f"-d '{AUTO_DESCRIPTION}'"
+        result = self.run_cli(cmd_env, cmd)
         self.assertEqual(result.return_value, 0)
 
     def delete_environment(self, cmd_env, env_name: str) -> None:
         result = self.run_cli(cmd_env, self._base_cmd + f"env del '{env_name}' --confirm")
         self.assertEqual(result.return_value, 0)
 
-    def set_param(self, cmd_env, proj: str, name: str, value: str, secret: bool = False):
-        result = self.run_cli(cmd_env,
-                              self._base_cmd + f"--project '{proj}' param set '{name}' " +
-                              f"--value '{value}' --secret '{str(secret).lower()}'")
+    def set_param(
+            self,
+            cmd_env,
+            proj: str,
+            name: str,
+            value: str,
+            secret: bool=False,
+            env: Optional[str]=None,
+    ) -> None:
+        cmd = self._base_cmd + f"--project '{proj}' "
+        if env:
+            cmd += f"--env '{env}' "
+        cmd += f"param set '{name}' --value '{value}' --secret '{str(secret).lower()}'"
+        result = self.run_cli(cmd_env, cmd)
         self.assertEqual(result.return_value, 0)
 
-    def delete_param(self, cmd_env, proj: str, name: str):
-        result = self.run_cli(cmd_env, self._base_cmd + f"--project '{proj}' param delete '{name}'")
+    def delete_param(self, cmd_env, proj: str, name: str, env: Optional[str]=None) -> None:
+        cmd = self._base_cmd + f"--project '{proj}' "
+        if env:
+            cmd += f"--env '{env}' "
+        cmd += f"param delete '{name}'"
+        result = self.run_cli(cmd_env, cmd)
         self.assertEqual(result.return_value, 0)
 


### PR DESCRIPTION
1. CLI now fails when attempting to change parent of existing environment
2. Add test for environment inheritance
3. Add test to verify each environment can have different parameter values