### PR TITLE
Add 'quick' check to make sure CLI is not unintentionally changing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ endif
 
 precommit_test:
 	cargo test
+	make -C tests $@
 
 test: precommit_test
 	make -C tests

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,12 +23,16 @@ workflow-prerelease:
 live_test:
 	python3 pytest/live_test.py
 
+precommit_test:
+	python3 cli_walk.py check
+
 help: targets
 
 targets:
 	@echo ""
-	@echo "clean         - remove generated docker files"
-	@echo "live_test     - run tests against live service"
-	@echo "prerequisites - install prerequisites"
-	@echo "workflow-*    - build workflow files and docker files from templates"
+	@echo "clean          - remove generated docker files"
+	@echo "live_test      - run tests against live service"
+	@echo "precommit_test - makes sure cli parameters have not changed"
+	@echo "prerequisites  - install prerequisites"
+	@echo "workflow-*     - build workflow files and docker files from templates"
 	@echo ""

--- a/tests/cli_walk.py
+++ b/tests/cli_walk.py
@@ -1,0 +1,127 @@
+import argparse
+import difflib
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+
+SUBCOMMANDS = "SUBCOMMANDS:"  # NOTE: the ':' is important to denote the start of the section
+SUBCOMMAND_RE = re.compile(r"^\W+(?P<subcommand>\S+)\W+")
+SEPARATOR = "===================="
+MAX_SEP_LEVELS = 3
+
+
+def parse_args(*args) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Walk a CLI with all subcommands, and print the help to the specified file."
+    )
+    parser.add_argument(
+        dest="purpose",
+        type=str,
+        choices=["check", "generate"],
+        help="Action to perform",
+    )
+    parser.add_argument(
+        "-x",
+        "--executable",
+        dest="executable",
+        type=str,
+        help="Cli executable to run",
+    )
+    parser.add_argument(
+        "-f",
+        "--file",
+        dest="file",
+        type=str,
+        default="help.txt",
+        help="File for checking against, or reading from"
+    )
+    return parser.parse_args(*args)
+
+
+def get_cli_base_cmd() -> str:
+    """
+    Returns the path to the executable (presumably).
+    """
+    # walk back up looking for top of projects, and goto `target/debug/cloudtruth`
+    curr = Path(__file__).absolute()
+    subdir = Path("target") / "debug"
+    match = False
+    while not match and curr:
+        possible = curr.parent / subdir
+        match = possible.exists()
+        curr = curr.parent
+
+    if not match:
+        return "cloudtruth"
+
+    for filename in ("cloudtruth", "cloudtruth.exe"):
+        file = possible / filename
+        if file.exists():
+            return str(file)
+
+    # this is a little odd... no executable found in "local" directories
+    return "cloudtruth"
+
+
+def find_subcommands(help_str: str) -> List[str]:
+    subcommands = []
+
+    subsection = False
+    lines = help_str.split("\n")
+    for line in lines:
+        if not subsection:
+            subsection = SUBCOMMANDS in line
+            continue
+
+        match  = SUBCOMMAND_RE.search(line)
+        if match:
+            subcommands.append(match.group("subcommand"))
+
+    return subcommands
+
+
+def walk_output(cmd: str, sep_levels: int) -> str:
+    help_cmd = f"{cmd} -h"
+    sub_proc = subprocess.run(help_cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    help_str = sub_proc.stdout.decode("us-ascii", errors="ignore").replace("\r", "")
+    result = help_str
+
+    # recursively go through all the subcommands
+    subcommands = find_subcommands(help_str)
+    for sub_cmd in subcommands:
+        sub_help = walk_output(cmd + " " + sub_cmd, sep_levels - 1)
+        if sub_help:
+            result += sep_levels * SEPARATOR + "\n" + sub_help
+
+    return result
+
+
+def walk_cli(*args):
+    result = -1
+    args = parse_args(*args)
+
+    cmd = args.executable or get_cli_base_cmd()
+    current = walk_output(cmd, MAX_SEP_LEVELS)
+    if args.purpose == "check":
+        with open(args.file) as fp:
+            last = fp.read().splitlines()[:-1]  # remove line-endings and extra newline
+            current = current.splitlines()
+            if current != last:
+                diff = difflib.unified_diff(last, current, "Previous", "Current")
+                print("Detected CLI changes:")
+                print("\n".join(diff))
+                print("You can run 'python3 cli_walk.py generate' if the changes are intentional.")
+            else:
+                result = 0
+    elif args.purpose == "generate":
+        with open(args.file, mode="w") as fp:
+            print(current, file=fp)
+            result = 0
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(walk_cli(sys.argv[1:]))

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,0 +1,366 @@
+cloudtruth 0.5.0
+CloudTruth <support@cloudtruth.com>
+A command-line interface to the CloudTruth configuration management service.
+
+USAGE:
+    cloudtruth [OPTIONS] <SUBCOMMAND>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -k, --api-key <api_key>    CloudTruth API key
+    -e, --env <env>            The CloudTruth environment to work with
+        --profile <profile>    The configuration profile from the application configuration file to use
+        --project <project>    The CloudTruth project to work with
+
+SUBCOMMANDS:
+    completions     Generate shell completions for this application
+    config          Configuration options for this application [aliases: configuration]
+    environments    Work with CloudTruth environments [aliases: environment, envs, env, e]
+    help            Prints this message or the help of the given subcommand(s)
+    parameters      Work with CloudTruth parameters [aliases: parameter, params, param, p]
+    projects        Work with CloudTruth projects [aliases: project, proj]
+    run             Run a shell with the parameters in place [aliases: run, r]
+    templates       Work with CloudTruth templates [aliases: template, t]
+============================================================
+cloudtruth-completions 
+Generate shell completions for this application
+
+USAGE:
+    cloudtruth completions <SHELL>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <SHELL>     [possible values: zsh, bash, fish, powershell, elvish]
+============================================================
+cloudtruth-config 
+Configuration options for this application
+
+USAGE:
+    cloudtruth config [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    edit    Edit your configuration data for this application
+    help    Prints this message or the help of the given subcommand(s)
+    list    List CloudTruth profiles in the local config file [aliases: ls]
+========================================
+cloudtruth-config-edit 
+Edit your configuration data for this application
+
+USAGE:
+    cloudtruth config edit
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+========================================
+cloudtruth-config-list 
+List CloudTruth profiles in the local config file
+
+USAGE:
+    cloudtruth config list [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -s, --secrets    Display API key values
+    -v, --values     Display profile information/values
+    -V, --version    Prints version information
+
+OPTIONS:
+    -f, --format <format>    Display profile value info format [default: table]  [possible values: table, csv]
+============================================================
+cloudtruth-environments 
+Work with CloudTruth environments
+
+USAGE:
+    cloudtruth environments [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    delete    Delete specified CloudTruth environment [aliases: del]
+    help      Prints this message or the help of the given subcommand(s)
+    list      List CloudTruth environments [aliases: ls]
+    set       Create/update a CloudTruth environment
+========================================
+cloudtruth-environments-delete 
+Delete specified CloudTruth environment
+
+USAGE:
+    cloudtruth environments delete [FLAGS] <NAME>
+
+FLAGS:
+        --confirm    Avoid confirmation prompt
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <NAME>    Environment name
+========================================
+cloudtruth-environments-list 
+List CloudTruth environments
+
+USAGE:
+    cloudtruth environments list [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -v, --values     Display environment information/values
+    -V, --version    Prints version information
+
+OPTIONS:
+    -f, --format <format>    Format for environment values data [default: table]  [possible values: table, csv]
+========================================
+cloudtruth-environments-set 
+Create/update a CloudTruth environment
+
+USAGE:
+    cloudtruth environments set [OPTIONS] <NAME>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -d, --desc <description>    Environment's description
+    -p, --parent <parent>       Environment's parent name (only used for create)
+
+ARGS:
+    <NAME>    Environment name
+============================================================
+cloudtruth-parameters 
+Work with CloudTruth parameters
+
+USAGE:
+    cloudtruth parameters [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    delete    Delete the parameter from the project [aliases: del]
+    export    Export selected parameters to a known output format. Exported parameters are limited to alphanumeric
+              and underscore  in key names. Formats available are: dotenv, docker, and shell.
+    get       Gets value for parameter in the selected environment
+    help      Prints this message or the help of the given subcommand(s)
+    list      List CloudTruth parameters [aliases: ls]
+    set       Set a static value in the selected project/environment for an existing parameter or creates a new one
+              if needed
+========================================
+cloudtruth-parameters-delete 
+Delete the parameter from the project
+
+USAGE:
+    cloudtruth parameters delete <KEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <KEY>    
+========================================
+cloudtruth-parameters-export 
+Export selected parameters to a known output format. Exported parameters are limited to alphanumeric and underscore  in
+key names. Formats available are: dotenv, docker, and shell.
+
+USAGE:
+    cloudtruth parameters export [FLAGS] [OPTIONS] <FORMAT>
+
+FLAGS:
+        --export     Add 'export' to each declaration
+    -h, --help       Prints help information
+    -s, --secrets    Display the secret parameter values
+    -V, --version    Prints version information
+
+OPTIONS:
+        --contains <contains>          Return parameters with keys containing search
+        --ends-with <ends_with>        Return parameters with keys ending with search
+        --starts-with <starts_with>    Return parameters starting with search
+
+ARGS:
+    <FORMAT>     [possible values: docker, dotenv, shell]
+========================================
+cloudtruth-parameters-get 
+Gets value for parameter in the selected environment
+
+USAGE:
+    cloudtruth parameters get <KEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <KEY>    
+========================================
+cloudtruth-parameters-list 
+List CloudTruth parameters
+
+USAGE:
+    cloudtruth parameters list [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -s, --secrets    Display the secret parameter values
+    -v, --values     Display parameter information/values
+    -V, --version    Prints version information
+
+OPTIONS:
+    -f, --format <format>    Format for parameter values data [default: table]  [possible values: table, csv]
+========================================
+cloudtruth-parameters-set 
+Set a static value in the selected project/environment for an existing parameter or creates a new one if needed
+
+USAGE:
+    cloudtruth parameters set [FLAGS] [OPTIONS] <KEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -p, --prompt     Set the value using unecho'd terminal
+    -V, --version    Prints version information
+
+OPTIONS:
+    -d, --desc <description>    Parameter description
+    -i, --input <input-file>    Read the value from the input file
+        --secret <secret>       Flags whether this is a secret parameter [possible values: true, false]
+    -v, --value <value>         Parameter value
+
+ARGS:
+    <KEY>    
+============================================================
+cloudtruth-projects 
+Work with CloudTruth projects
+
+USAGE:
+    cloudtruth projects [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    delete    Delete specified CloudTruth project [aliases: del]
+    help      Prints this message or the help of the given subcommand(s)
+    list      List CloudTruth projects [aliases: ls]
+    set       Create/update a CloudTruth project
+========================================
+cloudtruth-projects-delete 
+Delete specified CloudTruth project
+
+USAGE:
+    cloudtruth projects delete [FLAGS] <NAME>
+
+FLAGS:
+        --confirm    Avoid confirmation prompt
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <NAME>    Project name
+========================================
+cloudtruth-projects-list 
+List CloudTruth projects
+
+USAGE:
+    cloudtruth projects list [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -v, --values     Display project information/values
+    -V, --version    Prints version information
+
+OPTIONS:
+    -f, --format <format>    Format for project values data [default: table]  [possible values: table, csv]
+========================================
+cloudtruth-projects-set 
+Create/update a CloudTruth project
+
+USAGE:
+    cloudtruth projects set [OPTIONS] <NAME>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -d, --desc <description>    Project's description
+
+ARGS:
+    <NAME>    Project name
+============================================================
+cloudtruth-run 
+Run a shell with the parameters in place
+
+USAGE:
+    cloudtruth run [FLAGS] [OPTIONS] [-- <arguments>...]
+
+FLAGS:
+    -h, --help          Prints help information
+    -p, --permissive    Allow CloudTruth application variables through
+    -V, --version       Prints version information
+
+OPTIONS:
+    -c, --command <command>        Run this command
+    -i, --inherit <inheritance>    Handle the relationship between local and CloudTruth environments [default: overlay]
+                                   [possible values: none, underlay, overlay, exclusive]
+    -r, --remove <remove>...       Remove the variables from the CloudTruth environment for this run
+    -s, --set <set>...             Set the variables in this run, even possibly overriding the CloudTruth environment
+
+ARGS:
+    <arguments>...    Treat the rest of the arguments as the command
+============================================================
+cloudtruth-templates 
+Work with CloudTruth templates
+
+USAGE:
+    cloudtruth templates [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    get     Get an evaluated template from CloudTruth
+    help    Prints this message or the help of the given subcommand(s)
+    list    List CloudTruth templates [aliases: ls]
+========================================
+cloudtruth-templates-get 
+Get an evaluated template from CloudTruth
+
+USAGE:
+    cloudtruth templates get <KEY>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <KEY>    
+========================================
+cloudtruth-templates-list 
+List CloudTruth templates
+
+USAGE:
+    cloudtruth templates list [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -v, --values     Display template information/values
+    -V, --version    Prints version information
+
+OPTIONS:
+    -f, --format <format>    Format for template values data [default: table]  [possible values: table, csv]
+

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -125,7 +125,7 @@ class TestCase(unittest.TestCase):
         space to allow for easier consumption.
         """
         # walk back up looking for top of projects, and goto `target/debug/cloudtruth`
-        curr = Path(__file__)
+        curr = Path(__file__).absolute()
         subdir = Path("target") / "debug"
         match = False
         while not match and curr:


### PR DESCRIPTION
The cli_walk.py walks the entire CLI tree (based on output format) and prints the help. The `cli_walk.py check` fails if anything has changed in the cli.  This will be useful when trying to see differences between 2 versions.