### PR TITLE
Check the release tag contains the cargo version

### DIFF
--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -130,6 +130,7 @@ jobs:
           path: artifacts
 
       - name: Cargo and tag version alignment
+        if: runner.os != 'Windows'
         run: |
           CARGO_VERSION=$(grep "version = " Cargo.toml | head -n 1 | cut -d'"' -f2)
           TAG_VERSION=${GITHUB_REF#refs/tags/}

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -134,6 +134,8 @@ jobs:
         run: |
           CARGO_VERSION=$(grep "version = " Cargo.toml | head -n 1 | cut -d'"' -f2)
           TAG_VERSION=${GITHUB_REF#refs/tags/}
+          echo "CARGO_VERSION=${CARGO_VERSION}"
+          echo "TAG_VERSION=${TAG_VERSION}"
           echo "${TAG_VERSION}" | grep "${CARGO_VERSION}"
 
       - name: Install prerequisites

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -129,6 +129,12 @@ jobs:
           name: artifacts
           path: artifacts
 
+      - name: Cargo and tag version alignment
+        run: |
+          CARGO_VERSION=$(grep "version = " Cargo.toml | head -n 1 | cut -d'"' -f2)
+          TAG_VERSION=${GITHUB_REF#refs/tags/}
+          echo "${TAG_VERSION}" | grep "${CARGO_VERSION}"
+
       - name: Install prerequisites
         shell: bash
         run: |

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -76,6 +76,19 @@ jobs:
           # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
           echo CT_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
 
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Cargo and tag version alignment
+        env:
+          TAG_VERSION: ${{ env.CT_VERSION }}
+        run: |
+          CARGO_VERSION=$(grep "version = " Cargo.toml | head -n 1 | cut -d'"' -f2)
+          echo "CARGO_VERSION=${CARGO_VERSION}"
+          echo "TAG_VERSION=${TAG_VERSION}"
+          echo "${TAG_VERSION}" | grep "${CARGO_VERSION}"
+
       - name: Create GitHub release
         id: release
         uses: actions/create-release@v1
@@ -128,15 +141,6 @@ jobs:
         with:
           name: artifacts
           path: artifacts
-
-      - name: Cargo and tag version alignment
-        if: runner.os != 'Windows'
-        run: |
-          CARGO_VERSION=$(grep "version = " Cargo.toml | head -n 1 | cut -d'"' -f2)
-          TAG_VERSION=${GITHUB_REF#refs/tags/}
-          echo "CARGO_VERSION=${CARGO_VERSION}"
-          echo "TAG_VERSION=${TAG_VERSION}"
-          echo "${TAG_VERSION}" | grep "${CARGO_VERSION}"
 
       - name: Install prerequisites
         shell: bash

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -76,19 +76,6 @@ jobs:
           # See: https://github.community/t5/GitHub-Actions/How-to-get-just-the-tag-name/m-p/32167/highlight/true#M1027
           echo CT_VERSION=${GITHUB_REF#refs/tags/} >> $GITHUB_ENV
 
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-
-      - name: Cargo and tag version alignment
-        env:
-          TAG_VERSION: ${{ env.CT_VERSION }}
-        run: |
-          CARGO_VERSION=$(grep "version = " Cargo.toml | head -n 1 | cut -d'"' -f2)
-          echo "CARGO_VERSION=${CARGO_VERSION}"
-          echo "TAG_VERSION=${TAG_VERSION}"
-          echo "${TAG_VERSION}" | grep "${CARGO_VERSION}"
-
       - name: Create GitHub release
         id: release
         uses: actions/create-release@v1
@@ -110,6 +97,19 @@ jobs:
         with:
           name: artifacts
           path: artifacts
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+
+      - name: Cargo and tag version alignment
+        env:
+          TAG_VERSION: ${{ env.CT_VERSION }}
+        run: |
+          CARGO_VERSION=$(grep "version = " Cargo.toml | head -n 1 | cut -d'"' -f2)
+          echo "CARGO_VERSION=${CARGO_VERSION}"
+          echo "TAG_VERSION=${TAG_VERSION}"
+          echo "${TAG_VERSION}" | grep "${CARGO_VERSION}"
 
   build-release:
     name: Build Release


### PR DESCRIPTION
Make sure the Cargo.toml version agrees with the tag version. Without these changes, some of the assets do not have the right name, so the draft-release will fail during download.