### PR TITLE
Add ability to view integrations

### DIFF
--- a/graphql/integration_queries.graphql
+++ b/graphql/integration_queries.graphql
@@ -8,10 +8,6 @@ query IntegrationsQuery($organizationId: ID) {
           id
           fqn
           name
-          parent {
-            __typename
-            name
-          }
         }
       }
     }

--- a/graphql/integration_queries.graphql
+++ b/graphql/integration_queries.graphql
@@ -1,0 +1,19 @@
+query IntegrationsQuery($organizationId: ID) {
+  viewer {
+    id
+    organization(id: $organizationId) {
+      integrations {
+        nodes {
+          __typename
+          id
+          fqn
+          name
+          parent {
+            __typename
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,18 @@ pub fn build_cli() -> App<'static, 'static> {
                 ])
         )
         .subcommand(
+            SubCommand::with_name("integrations")
+                .visible_aliases(&["integration", "integrate", "integ", "int"])
+                .about("Work with CloudTruth integrations")
+                .subcommands(vec![
+                    SubCommand::with_name("list")
+                        .visible_alias("ls")
+                        .about("List CloudTruth integrations")
+                        .arg(values_flag().help("Display integration information/values"))
+                        .arg(table_format_options().help("Format for integration values data")),
+                ])
+        )
+        .subcommand(
             SubCommand::with_name("parameters")
                 .visible_aliases(&["parameter", "params", "param", "p"])
                 .about("Work with CloudTruth parameters")

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -18,7 +18,6 @@ pub struct IntegrationDetails {
     pub id: String,
     pub integration_type: String,
     pub name: String,
-    pub parent: String,
 }
 
 /// This is the interface that is implemented to retrieve integration information.
@@ -73,16 +72,11 @@ impl IntegrationsIntf for Integrations {
             let mut integrations: Vec<IntegrationDetails> = Vec::new();
 
             for n in nodes.iter() {
-                let mut parent_name = "None".to_string();
-                if let Some(parent) = &n.parent {
-                    parent_name = parent.name.clone();
-                }
                 integrations.push(IntegrationDetails {
                     fqn: n.fqn.clone(),
                     id: n.id.clone(),
                     integration_type: n.on.to_string(),
                     name: n.name.clone(),
-                    parent: parent_name,
                 });
             }
             Ok(integrations)

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,5 +1,5 @@
 use crate::graphql::prelude::graphql_request;
-use crate::graphql::{GraphQLError, GraphQLResult};
+use crate::graphql::{GraphQLError, GraphQLResult, NO_ORG_ERROR};
 use crate::integrations::integrations_query::IntegrationsQueryViewerOrganizationIntegrationsNodesOn;
 use graphql_client::*;
 
@@ -67,7 +67,7 @@ impl IntegrationsIntf for Integrations {
             let nodes = data
                 .viewer
                 .organization
-                .expect("Primary organization not found")
+                .expect(NO_ORG_ERROR)
                 .integrations
                 .nodes;
             let mut integrations: Vec<IntegrationDetails> = Vec::new();

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,0 +1,106 @@
+use crate::graphql::prelude::graphql_request;
+use crate::graphql::{GraphQLError, GraphQLResult};
+use crate::integrations::integrations_query::IntegrationsQueryViewerOrganizationIntegrationsNodesOn;
+use graphql_client::*;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/integration_queries.graphql",
+    response_derives = "Debug"
+)]
+pub struct IntegrationsQuery;
+
+/// This holds the common information for Integrations, including an `integration_type` that
+/// indicates the provider.
+pub struct IntegrationDetails {
+    pub fqn: String,
+    pub id: String,
+    pub integration_type: String,
+    pub name: String,
+    pub parent: String,
+}
+
+/// This is the interface that is implemented to retrieve integration information.
+///
+/// This layer of abstraction is done to allow for mocking in unittest, and to potentially allow
+/// for future implementations.
+pub trait IntegrationsIntf {
+    /// Gets a list of `IntegrationDetails` for all integration types.
+    fn get_integration_details(
+        &self,
+        org_id: Option<&str>,
+    ) -> GraphQLResult<Vec<IntegrationDetails>>;
+}
+
+/// The `Integrations` structure implements the `IntegrationsIntf` to get the information from
+/// the GraphQL server.
+pub struct Integrations {}
+
+impl Integrations {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Converts the typename into a String value without the trailing `Integration`
+impl ToString for IntegrationsQueryViewerOrganizationIntegrationsNodesOn {
+    fn to_string(&self) -> String {
+        let result = format!("{:?}", self);
+        result.replace("Integration", "")
+    }
+}
+
+impl IntegrationsIntf for Integrations {
+    fn get_integration_details(
+        &self,
+        org_id: Option<&str>,
+    ) -> GraphQLResult<Vec<IntegrationDetails>> {
+        let query = IntegrationsQuery::build_query(integrations_query::Variables {
+            organization_id: org_id.map(|id| id.to_string()),
+        });
+        let response_body = graphql_request::<_, integrations_query::ResponseData>(&query)?;
+
+        if let Some(errors) = response_body.errors {
+            Err(GraphQLError::ResponseError(errors))
+        } else if let Some(data) = response_body.data {
+            let nodes = data
+                .viewer
+                .organization
+                .expect("Primary organization not found")
+                .integrations
+                .nodes;
+            let mut integrations: Vec<IntegrationDetails> = Vec::new();
+
+            for n in nodes.iter() {
+                let mut parent_name = "None".to_string();
+                if let Some(parent) = &n.parent {
+                    parent_name = parent.name.clone();
+                }
+                integrations.push(IntegrationDetails {
+                    fqn: n.fqn.clone(),
+                    id: n.id.clone(),
+                    integration_type: n.on.to_string(),
+                    name: n.name.clone(),
+                    parent: parent_name,
+                });
+            }
+            Ok(integrations)
+        } else {
+            Err(GraphQLError::MissingDataError)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn integration_type_to_string() {
+        let mut value = IntegrationsQueryViewerOrganizationIntegrationsNodesOn::AwsIntegration;
+        assert_eq!("Aws".to_string(), format!("{}", value.to_string()));
+        value = IntegrationsQueryViewerOrganizationIntegrationsNodesOn::GithubIntegration;
+        assert_eq!("Github".to_string(), format!("{}", value.to_string()));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,15 +501,9 @@ fn process_integrations_command(
                 Cell::new("Name").with_style(Attr::Bold),
                 Cell::new("Type").with_style(Attr::Bold),
                 Cell::new("FQN").with_style(Attr::Bold),
-                Cell::new("Parent").with_style(Attr::Bold),
             ]));
             for entry in details {
-                table.add_row(row![
-                    entry.name,
-                    entry.integration_type,
-                    entry.fqn,
-                    entry.parent,
-                ]);
+                table.add_row(row![entry.name, entry.integration_type, entry.fqn,]);
             }
             table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
 

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -20,6 +20,7 @@ SUBCOMMANDS:
     config          Configuration options for this application [aliases: configuration]
     environments    Work with CloudTruth environments [aliases: environment, envs, env, e]
     help            Prints this message or the help of the given subcommand(s)
+    integrations    Work with CloudTruth integrations [aliases: integration, integrate, integ, int]
     parameters      Work with CloudTruth parameters [aliases: parameter, params, param, p]
     projects        Work with CloudTruth projects [aliases: project, proj]
     run             Run a shell with the parameters in place [aliases: run, r]
@@ -138,6 +139,34 @@ OPTIONS:
 
 ARGS:
     <NAME>    Environment name
+============================================================
+cloudtruth-integrations 
+Work with CloudTruth integrations
+
+USAGE:
+    cloudtruth integrations [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    help    Prints this message or the help of the given subcommand(s)
+    list    List CloudTruth integrations [aliases: ls]
+========================================
+cloudtruth-integrations-list 
+List CloudTruth integrations
+
+USAGE:
+    cloudtruth integrations list [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -v, --values     Display integration information/values
+    -V, --version    Prints version information
+
+OPTIONS:
+    -f, --format <format>    Format for integration values data [default: table]  [possible values: table, csv]
 ============================================================
 cloudtruth-parameters 
 Work with CloudTruth parameters

--- a/tests/pytest/test_args.py
+++ b/tests/pytest/test_args.py
@@ -67,6 +67,7 @@ class TestTopLevelArgs(TestCase):
         for (subcmd, aliases) in {
             "config": ["configuration"],
             "environments": ["environment", "envs", "env", "e"],
+            "integrations": ["integration", "integrate", "int"],
             "parameters": ["parameter", "params", "param", "p"],
             "projects": ["project", "proj"],
             "run": ["r"],


### PR DESCRIPTION
Sample output (with single integration):
```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations -h
cloudtruth-integrations 
Work with CloudTruth integrations

USAGE:
    cloudtruth integrations [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    help    Prints this message or the help of the given subcommand(s)
    list    List CloudTruth integrations [aliases: ls]
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations list -h
cloudtruth-integrations-list 
List CloudTruth integrations

USAGE:
    cloudtruth integrations list [FLAGS] [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -v, --values     Display integration information/values
    -V, --version    Prints version information

OPTIONS:
    -f, --format <format>    Format for integration values data [default: table]  [possible values: table, csv]
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations list
Rick Porter
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations list -v
+-------------+--------+---------------------+--------+
| Name        | Type   | FQN                 | Parent |
+-------------+--------+---------------------+--------+
| Rick Porter | Github | GitHub::Rick Porter | None   |
+-------------+--------+---------------------+--------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations list -v -f csv
Name,Type,FQN,Parent
Rick Porter,Github,GitHub::Rick Porter,None
(new-host-4):~/cloudtruth-cli $
```