### PR TITLE
Add 'integrations delete' capability for AWS and GitHub

### DIFF
--- a/graphql/integration_queries.graphql
+++ b/graphql/integration_queries.graphql
@@ -8,10 +8,6 @@ query IntegrationsQuery($organizationId: ID) {
           id
           fqn
           name
-          parent {
-            __typename
-            name
-          }
         }
       }
     }

--- a/graphql/integration_queries.graphql
+++ b/graphql/integration_queries.graphql
@@ -1,0 +1,19 @@
+query IntegrationsQuery($organizationId: ID) {
+  viewer {
+    id
+    organization(id: $organizationId) {
+      integrations {
+        nodes {
+          __typename
+          id
+          fqn
+          name
+          parent {
+            __typename
+            name
+          }
+        }
+      }
+    }
+  }
+}

--- a/graphql/integration_queries.graphql
+++ b/graphql/integration_queries.graphql
@@ -13,3 +13,27 @@ query IntegrationsQuery($organizationId: ID) {
     }
   }
 }
+
+mutation DeleteAwsIntegrationMutation($integrationId: ID!) {
+  deleteAwsIntegration(input: { id: $integrationId }) {
+    clientMutationId
+    deletedAwsIntegrationId
+
+    errors {
+      path
+      message
+    }
+  }
+}
+
+mutation DeleteGithubIntegrationMutation($integrationId: ID!) {
+  deleteGithubIntegration(input: { id: $integrationId }) {
+    clientMutationId
+    deletedGithubIntegrationId
+
+    errors {
+      path
+      message
+    }
+  }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,6 +117,23 @@ pub fn build_cli() -> App<'static, 'static> {
                 .visible_aliases(&["integration", "integrate", "integ", "int"])
                 .about("Work with CloudTruth integrations")
                 .subcommands(vec![
+                    SubCommand::with_name("delete")
+                        .visible_alias("del")
+                        .about("Delete specified CloudTruth integration")
+                        .arg(Arg::with_name("NAME")
+                            .index(1)
+                            .required(true)
+                            .help("Integration name"))
+                        .arg(Arg::with_name("confirm")
+                            .long("confirm")
+                            .help("Avoid confirmation prompt"))
+                        .arg(Arg::with_name("TYPE")
+                            .short("t")
+                            .long("type")
+                            .takes_value(true)
+                            .possible_values(&["aws", "github"])
+                            .help(concat!("Integration type, only needed to disambiguate ",
+                                "integrations with the same name"))),
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth integrations")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,18 @@ pub fn build_cli() -> App<'static, 'static> {
                 ])
         )
         .subcommand(
+            SubCommand::with_name("integrations")
+                .visible_aliases(&["integration", "integrate", "integ", "int"])
+                .about("Work with CloudTruth integrations")
+                .subcommands(vec![
+                    SubCommand::with_name("list")
+                        .visible_alias("ls")
+                        .about("List CloudTruth integrations")
+                        .arg(values_flag().help("Display integration information/values"))
+                        .arg(table_format_options().help("Format for integration values data")),
+                ])
+        )
+        .subcommand(
             SubCommand::with_name("parameters")
                 .visible_aliases(&["parameter", "params", "param", "p"])
                 .about("Work with CloudTruth parameters")

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -51,6 +51,7 @@ pub enum Operation {
 #[derive(Clone, Debug)]
 pub enum Resource {
     Environment,
+    Integration,
     Parameter,
     Project,
     Template,
@@ -60,7 +61,9 @@ pub type GraphQLResult<T> = std::result::Result<T, GraphQLError>;
 
 #[derive(Clone, Debug)]
 pub enum GraphQLError {
+    AmbiguousIntegrationError(String, String),
     EnvironmentNotFoundError(String),
+    IntegrationTypeError(String),
     MissingDataError,
     NetworkError(Arc<reqwest::Error>),
     ParameterNotFoundError(String),
@@ -117,8 +120,14 @@ impl GraphQLError {
 impl fmt::Display for GraphQLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
+            GraphQLError::AmbiguousIntegrationError(name, integration_types) => {
+                write!(f, "Found integration named '{}' for types: {}", name, integration_types)
+            }
             GraphQLError::EnvironmentNotFoundError(name) => {
                 write!(f, "Unable to find environment '{}'.", name)
+            }
+            GraphQLError::IntegrationTypeError(type_name) => {
+                write!(f, "Unable to process integration type '{}'.", type_name)
             }
             GraphQLError::MissingDataError => write!(
                 f,

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,7 +1,23 @@
 use crate::graphql::prelude::graphql_request;
-use crate::graphql::{GraphQLError, GraphQLResult, NO_ORG_ERROR};
+use crate::graphql::{GraphQLError, GraphQLResult, Operation, Resource, NO_ORG_ERROR};
 use crate::integrations::integrations_query::IntegrationsQueryViewerOrganizationIntegrationsNodesOn;
 use graphql_client::*;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/integration_queries.graphql",
+    response_derives = "Debug"
+)]
+pub struct DeleteAwsIntegrationMutation;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/integration_queries.graphql",
+    response_derives = "Debug"
+)]
+pub struct DeleteGithubIntegrationMutation;
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -30,6 +46,29 @@ pub trait IntegrationsIntf {
         &self,
         org_id: Option<&str>,
     ) -> GraphQLResult<Vec<IntegrationDetails>>;
+
+    /// Gets a single `IntegrationDetails` object for the specified name.
+    fn get_details_by_name(
+        &self,
+        org_id: Option<&str>,
+        int_name: Option<&str>,
+        int_type: Option<&str>,
+    ) -> GraphQLResult<Option<IntegrationDetails>>;
+
+    /// Deletes the integration by ID.
+    fn delete_integration(
+        &self,
+        integration_id: String,
+        integration_type: String,
+    ) -> GraphQLResult<Option<String>>;
+}
+
+/// Converts the typename into a String value without the trailing `Integration`
+impl ToString for IntegrationsQueryViewerOrganizationIntegrationsNodesOn {
+    fn to_string(&self) -> String {
+        let result = format!("{:?}", self);
+        result.replace("Integration", "")
+    }
 }
 
 /// The `Integrations` structure implements the `IntegrationsIntf` to get the information from
@@ -40,13 +79,63 @@ impl Integrations {
     pub fn new() -> Self {
         Self {}
     }
-}
 
-/// Converts the typename into a String value without the trailing `Integration`
-impl ToString for IntegrationsQueryViewerOrganizationIntegrationsNodesOn {
-    fn to_string(&self) -> String {
-        let result = format!("{:?}", self);
-        result.replace("Integration", "")
+    pub fn delete_aws_integration(&self, integration_id: String) -> GraphQLResult<Option<String>> {
+        let query =
+            DeleteAwsIntegrationMutation::build_query(delete_aws_integration_mutation::Variables {
+                integration_id,
+            });
+        let response_body =
+            graphql_request::<_, delete_aws_integration_mutation::ResponseData>(&query)?;
+
+        if let Some(errors) = response_body.errors {
+            Err(GraphQLError::build_query_error(
+                errors,
+                Resource::Integration,
+                Operation::Delete,
+            ))
+        } else if let Some(data) = response_body.data {
+            let logical_errors = data.delete_aws_integration.errors;
+            if !logical_errors.is_empty() {
+                Err(GraphQLError::build_logical_error(to_user_errors!(
+                    logical_errors
+                )))
+            } else {
+                Ok(data.delete_aws_integration.deleted_aws_integration_id)
+            }
+        } else {
+            Err(GraphQLError::MissingDataError)
+        }
+    }
+
+    pub fn delete_github_integration(
+        &self,
+        integration_id: String,
+    ) -> GraphQLResult<Option<String>> {
+        let query = DeleteGithubIntegrationMutation::build_query(
+            delete_github_integration_mutation::Variables { integration_id },
+        );
+        let response_body =
+            graphql_request::<_, delete_github_integration_mutation::ResponseData>(&query)?;
+
+        if let Some(errors) = response_body.errors {
+            Err(GraphQLError::build_query_error(
+                errors,
+                Resource::Integration,
+                Operation::Delete,
+            ))
+        } else if let Some(data) = response_body.data {
+            let logical_errors = data.delete_github_integration.errors;
+            if !logical_errors.is_empty() {
+                Err(GraphQLError::build_logical_error(to_user_errors!(
+                    logical_errors
+                )))
+            } else {
+                Ok(data.delete_github_integration.deleted_github_integration_id)
+            }
+        } else {
+            Err(GraphQLError::MissingDataError)
+        }
     }
 }
 
@@ -82,6 +171,58 @@ impl IntegrationsIntf for Integrations {
             Ok(integrations)
         } else {
             Err(GraphQLError::MissingDataError)
+        }
+    }
+
+    fn get_details_by_name(
+        &self,
+        org_id: Option<&str>,
+        int_name: Option<&str>,
+        int_type: Option<&str>,
+    ) -> GraphQLResult<Option<IntegrationDetails>> {
+        // TODO: Rick Porter 5/21 - change to use a query for a single element
+        // this is an interim query that gets the whole list, and does filtering on the CLI
+        let all_entries = self.get_integration_details(org_id)?;
+        let mut found: Option<IntegrationDetails> = None;
+        let mut integration_types: Vec<String> = Vec::new();
+
+        // walk the list of integration details looking for matches (and duplicates)
+        for entry in all_entries {
+            if int_name.unwrap() != entry.name.as_str() {
+                continue;
+            }
+
+            if int_type.is_none() {
+                integration_types.push(entry.integration_type.clone());
+                found = Some(entry);
+            } else if int_type == Some(entry.integration_type.as_str()) {
+                found = Some(entry);
+                break;
+            }
+        }
+
+        if integration_types.len() > 1 {
+            let multiples = integration_types.join(", ");
+            Err(GraphQLError::AmbiguousIntegrationError(
+                int_name.unwrap().to_string(),
+                multiples,
+            ))
+        } else {
+            Ok(found)
+        }
+    }
+
+    fn delete_integration(
+        &self,
+        integration_id: String,
+        integration_type: String,
+    ) -> GraphQLResult<Option<String>> {
+        if integration_type.to_lowercase() == "aws" {
+            self.delete_aws_integration(integration_id)
+        } else if integration_type.to_lowercase() == "github" {
+            self.delete_github_integration(integration_id)
+        } else {
+            Err(GraphQLError::IntegrationTypeError(integration_type))
         }
     }
 }

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -18,7 +18,6 @@ pub struct IntegrationDetails {
     pub id: String,
     pub integration_type: String,
     pub name: String,
-    pub parent: String,
 }
 
 /// This is the interface that is implemented to retrieve integration information.
@@ -73,16 +72,11 @@ impl IntegrationsIntf for Integrations {
             let mut integrations: Vec<IntegrationDetails> = Vec::new();
 
             for n in nodes.iter() {
-                let mut parent_name = "None".to_string();
-                if let Some(parent) = &n.parent {
-                    parent_name = parent.name.clone();
-                }
                 integrations.push(IntegrationDetails {
                     fqn: n.fqn.clone(),
                     id: n.id.clone(),
                     integration_type: n.on.to_string(),
                     name: n.name.clone(),
-                    parent: parent_name,
                 });
             }
             Ok(integrations)

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,5 +1,5 @@
 use crate::graphql::prelude::graphql_request;
-use crate::graphql::{GraphQLError, GraphQLResult};
+use crate::graphql::{GraphQLError, GraphQLResult, NO_ORG_ERROR};
 use crate::integrations::integrations_query::IntegrationsQueryViewerOrganizationIntegrationsNodesOn;
 use graphql_client::*;
 
@@ -67,7 +67,7 @@ impl IntegrationsIntf for Integrations {
             let nodes = data
                 .viewer
                 .organization
-                .expect("Primary organization not found")
+                .expect(NO_ORG_ERROR)
                 .integrations
                 .nodes;
             let mut integrations: Vec<IntegrationDetails> = Vec::new();

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,0 +1,106 @@
+use crate::graphql::prelude::graphql_request;
+use crate::graphql::{GraphQLError, GraphQLResult};
+use crate::integrations::integrations_query::IntegrationsQueryViewerOrganizationIntegrationsNodesOn;
+use graphql_client::*;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/integration_queries.graphql",
+    response_derives = "Debug"
+)]
+pub struct IntegrationsQuery;
+
+/// This holds the common information for Integrations, including an `integration_type` that
+/// indicates the provider.
+pub struct IntegrationDetails {
+    pub fqn: String,
+    pub id: String,
+    pub integration_type: String,
+    pub name: String,
+    pub parent: String,
+}
+
+/// This is the interface that is implemented to retrieve integration information.
+///
+/// This layer of abstraction is done to allow for mocking in unittest, and to potentially allow
+/// for future implementations.
+pub trait IntegrationsIntf {
+    /// Gets a list of `IntegrationDetails` for all integration types.
+    fn get_integration_details(
+        &self,
+        org_id: Option<&str>,
+    ) -> GraphQLResult<Vec<IntegrationDetails>>;
+}
+
+/// The `Integrations` structure implements the `IntegrationsIntf` to get the information from
+/// the GraphQL server.
+pub struct Integrations {}
+
+impl Integrations {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+/// Converts the typename into a String value without the trailing `Integration`
+impl ToString for IntegrationsQueryViewerOrganizationIntegrationsNodesOn {
+    fn to_string(&self) -> String {
+        let result = format!("{:?}", self);
+        result.replace("Integration", "")
+    }
+}
+
+impl IntegrationsIntf for Integrations {
+    fn get_integration_details(
+        &self,
+        org_id: Option<&str>,
+    ) -> GraphQLResult<Vec<IntegrationDetails>> {
+        let query = IntegrationsQuery::build_query(integrations_query::Variables {
+            organization_id: org_id.map(|id| id.to_string()),
+        });
+        let response_body = graphql_request::<_, integrations_query::ResponseData>(&query)?;
+
+        if let Some(errors) = response_body.errors {
+            Err(GraphQLError::ResponseError(errors))
+        } else if let Some(data) = response_body.data {
+            let nodes = data
+                .viewer
+                .organization
+                .expect("Primary organization not found")
+                .integrations
+                .nodes;
+            let mut integrations: Vec<IntegrationDetails> = Vec::new();
+
+            for n in nodes.iter() {
+                let mut parent_name = "None".to_string();
+                if let Some(parent) = &n.parent {
+                    parent_name = parent.name.clone();
+                }
+                integrations.push(IntegrationDetails {
+                    fqn: n.fqn.clone(),
+                    id: n.id.clone(),
+                    integration_type: n.on.to_string(),
+                    name: n.name.clone(),
+                    parent: parent_name,
+                });
+            }
+            Ok(integrations)
+        } else {
+            Err(GraphQLError::MissingDataError)
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn integration_type_to_string() {
+        let mut value = IntegrationsQueryViewerOrganizationIntegrationsNodesOn::AwsIntegration;
+        assert_eq!("Aws".to_string(), format!("{}", value.to_string()));
+        value = IntegrationsQueryViewerOrganizationIntegrationsNodesOn::GithubIntegration;
+        assert_eq!("Github".to_string(), format!("{}", value.to_string()));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -501,15 +501,9 @@ fn process_integrations_command(
                 Cell::new("Name").with_style(Attr::Bold),
                 Cell::new("Type").with_style(Attr::Bold),
                 Cell::new("FQN").with_style(Attr::Bold),
-                Cell::new("Parent").with_style(Attr::Bold),
             ]));
             for entry in details {
-                table.add_row(row![
-                    entry.name,
-                    entry.integration_type,
-                    entry.fqn,
-                    entry.parent,
-                ]);
+                table.add_row(row![entry.name, entry.integration_type, entry.fqn,]);
             }
             table.set_format(*format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -484,7 +484,30 @@ fn process_integrations_command(
     integrations: &impl IntegrationsIntf,
     org_id: Option<&str>,
 ) -> Result<()> {
-    if let Some(subcmd_args) = subcmd_args.subcommand_matches("list") {
+    if let Some(subcmd_args) = subcmd_args.subcommand_matches("delete") {
+        let int_name = subcmd_args.value_of("NAME");
+        let int_type = subcmd_args.value_of("TYPE");
+        let details = integrations.get_details_by_name(org_id, int_name, int_type)?;
+
+        if let Some(details) = details {
+            let mut confirmed = subcmd_args.is_present("confirm");
+            if !confirmed {
+                confirmed = user_confirm(format!("Delete integration '{}'", int_name.unwrap()));
+            }
+
+            if !confirmed {
+                warning_message(format!("Integration '{}' not deleted!", int_name.unwrap()))?;
+            } else {
+                integrations.delete_integration(details.id, details.integration_type)?;
+                println!("Deleted integration '{}'", int_name.unwrap());
+            }
+        } else {
+            warning_message(format!(
+                "Integration '{}' does not exist!",
+                int_name.unwrap()
+            ))?;
+        }
+    } else if let Some(subcmd_args) = subcmd_args.subcommand_matches("list") {
         let details = integrations.get_integration_details(org_id)?;
         if details.is_empty() {
             println!("No integrations found");

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -20,6 +20,7 @@ SUBCOMMANDS:
     config          Configuration options for this application [aliases: configuration]
     environments    Work with CloudTruth environments [aliases: environment, envs, env, e]
     help            Prints this message or the help of the given subcommand(s)
+    integrations    Work with CloudTruth integrations [aliases: integration, integrate, integ, int]
     parameters      Work with CloudTruth parameters [aliases: parameter, params, param, p]
     projects        Work with CloudTruth projects [aliases: project, proj]
     run             Run a shell with the parameters in place [aliases: run, r]
@@ -138,6 +139,34 @@ OPTIONS:
 
 ARGS:
     <NAME>    Environment name
+============================================================
+cloudtruth-integrations 
+Work with CloudTruth integrations
+
+USAGE:
+    cloudtruth integrations [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    help    Prints this message or the help of the given subcommand(s)
+    list    List CloudTruth integrations [aliases: ls]
+========================================
+cloudtruth-integrations-list 
+List CloudTruth integrations
+
+USAGE:
+    cloudtruth integrations list [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -v, --values     Display integration information/values
+    -V, --version    Prints version information
+
+OPTIONS:
+    -f, --format <format>    Format for integration values data [default: table]  [possible values: table, csv]
 ============================================================
 cloudtruth-parameters 
 Work with CloudTruth parameters

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -151,8 +151,27 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
-    list    List CloudTruth integrations [aliases: ls]
+    delete    Delete specified CloudTruth integration [aliases: del]
+    help      Prints this message or the help of the given subcommand(s)
+    list      List CloudTruth integrations [aliases: ls]
+========================================
+cloudtruth-integrations-delete 
+Delete specified CloudTruth integration
+
+USAGE:
+    cloudtruth integrations delete [FLAGS] [OPTIONS] <NAME>
+
+FLAGS:
+        --confirm    Avoid confirmation prompt
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -t, --type <TYPE>    Integration type, only needed to disambiguate integrations with the same name [possible values:
+                         aws, github]
+
+ARGS:
+    <NAME>    Integration name
 ========================================
 cloudtruth-integrations-list 
 List CloudTruth integrations

--- a/tests/pytest/test_args.py
+++ b/tests/pytest/test_args.py
@@ -67,6 +67,7 @@ class TestTopLevelArgs(TestCase):
         for (subcmd, aliases) in {
             "config": ["configuration"],
             "environments": ["environment", "envs", "env", "e"],
+            "integrations": ["integration", "integrate", "int"],
             "parameters": ["parameter", "params", "param", "p"],
             "projects": ["project", "proj"],
             "run": ["r"],


### PR DESCRIPTION
Example output:
```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations -h
cloudtruth-integrations 
Work with CloudTruth integrations

USAGE:
    cloudtruth integrations [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    delete    Delete specified CloudTruth integration [aliases: del]
    help      Prints this message or the help of the given subcommand(s)
    list      List CloudTruth integrations [aliases: ls]
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations ls -v
+-------------+--------+---------------------+
| Name        | Type   | FQN                 |
+-------------+--------+---------------------+
| Rick Porter | Github | GitHub::Rick Porter |
+-------------+--------+---------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations del -h
cloudtruth-integrations-delete 
Delete specified CloudTruth integration

USAGE:
    cloudtruth integrations delete [FLAGS] [OPTIONS] <NAME>

FLAGS:
        --confirm    Avoid confirmation prompt
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -t, --type <TYPE>    Integration type, only needed to disambiguate integrations with the same name [possible values:
                         aws, github]

ARGS:
    <NAME>    Integration name
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations del "Rick Porter"
Delete integration 'Rick Porter'? (y/n) n
Integration 'Rick Porter' not deleted!
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations del "Rick Porter"
Delete integration 'Rick Porter'? (y/n) y
Deleted integration 'Rick Porter'
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations ls -v
No integrations found
(new-host-4):~/cloudtruth-cli $
```