### PR TITLE
Add 'integrations delete' capability for AWS and GitHub

### DIFF
--- a/graphql/integration_queries.graphql
+++ b/graphql/integration_queries.graphql
@@ -13,3 +13,27 @@ query IntegrationsQuery($organizationId: ID) {
     }
   }
 }
+
+mutation DeleteAwsIntegrationMutation($integrationId: ID!) {
+  deleteAwsIntegration(input: { id: $integrationId }) {
+    clientMutationId
+    deletedAwsIntegrationId
+
+    errors {
+      path
+      message
+    }
+  }
+}
+
+mutation DeleteGithubIntegrationMutation($integrationId: ID!) {
+  deleteGithubIntegration(input: { id: $integrationId }) {
+    clientMutationId
+    deletedGithubIntegrationId
+
+    errors {
+      path
+      message
+    }
+  }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -117,6 +117,23 @@ pub fn build_cli() -> App<'static, 'static> {
                 .visible_aliases(&["integration", "integrate", "integ", "int"])
                 .about("Work with CloudTruth integrations")
                 .subcommands(vec![
+                    SubCommand::with_name("delete")
+                        .visible_alias("del")
+                        .about("Delete specified CloudTruth integration")
+                        .arg(Arg::with_name("NAME")
+                            .index(1)
+                            .required(true)
+                            .help("Integration name"))
+                        .arg(Arg::with_name("confirm")
+                            .long("confirm")
+                            .help("Avoid confirmation prompt"))
+                        .arg(Arg::with_name("TYPE")
+                            .short("t")
+                            .long("type")
+                            .takes_value(true)
+                            .possible_values(&["aws", "github"])
+                            .help(concat!("Integration type, only needed to disambiguate ",
+                                "integrations with the same name"))),
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth integrations")

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -51,6 +51,7 @@ pub enum Operation {
 #[derive(Clone, Debug)]
 pub enum Resource {
     Environment,
+    Integration,
     Parameter,
     Project,
     Template,
@@ -60,7 +61,9 @@ pub type GraphQLResult<T> = std::result::Result<T, GraphQLError>;
 
 #[derive(Clone, Debug)]
 pub enum GraphQLError {
+    AmbiguousIntegrationError(String, String),
     EnvironmentNotFoundError(String),
+    IntegrationTypeError(String),
     MissingDataError,
     NetworkError(Arc<reqwest::Error>),
     ParameterNotFoundError(String),
@@ -117,8 +120,14 @@ impl GraphQLError {
 impl fmt::Display for GraphQLError {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
+            GraphQLError::AmbiguousIntegrationError(name, integration_types) => {
+                write!(f, "Found integration named '{}' for types: {}", name, integration_types)
+            }
             GraphQLError::EnvironmentNotFoundError(name) => {
                 write!(f, "Unable to find environment '{}'.", name)
+            }
+            GraphQLError::IntegrationTypeError(type_name) => {
+                write!(f, "Unable to process integration type '{}'.", type_name)
             }
             GraphQLError::MissingDataError => write!(
                 f,

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,7 +1,23 @@
 use crate::graphql::prelude::graphql_request;
-use crate::graphql::{GraphQLError, GraphQLResult, NO_ORG_ERROR};
+use crate::graphql::{GraphQLError, GraphQLResult, Operation, Resource, NO_ORG_ERROR};
 use crate::integrations::integrations_query::IntegrationsQueryViewerOrganizationIntegrationsNodesOn;
 use graphql_client::*;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/integration_queries.graphql",
+    response_derives = "Debug"
+)]
+pub struct DeleteAwsIntegrationMutation;
+
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/integration_queries.graphql",
+    response_derives = "Debug"
+)]
+pub struct DeleteGithubIntegrationMutation;
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -30,6 +46,29 @@ pub trait IntegrationsIntf {
         &self,
         org_id: Option<&str>,
     ) -> GraphQLResult<Vec<IntegrationDetails>>;
+
+    /// Gets a single `IntegrationDetails` object for the specified name.
+    fn get_details_by_name(
+        &self,
+        org_id: Option<&str>,
+        int_name: Option<&str>,
+        int_type: Option<&str>,
+    ) -> GraphQLResult<Option<IntegrationDetails>>;
+
+    /// Deletes the integration by ID.
+    fn delete_integration(
+        &self,
+        integration_id: String,
+        integration_type: String,
+    ) -> GraphQLResult<Option<String>>;
+}
+
+/// Converts the typename into a String value without the trailing `Integration`
+impl ToString for IntegrationsQueryViewerOrganizationIntegrationsNodesOn {
+    fn to_string(&self) -> String {
+        let result = format!("{:?}", self);
+        result.replace("Integration", "")
+    }
 }
 
 /// The `Integrations` structure implements the `IntegrationsIntf` to get the information from
@@ -40,13 +79,63 @@ impl Integrations {
     pub fn new() -> Self {
         Self {}
     }
-}
 
-/// Converts the typename into a String value without the trailing `Integration`
-impl ToString for IntegrationsQueryViewerOrganizationIntegrationsNodesOn {
-    fn to_string(&self) -> String {
-        let result = format!("{:?}", self);
-        result.replace("Integration", "")
+    pub fn delete_aws_integration(&self, integration_id: String) -> GraphQLResult<Option<String>> {
+        let query =
+            DeleteAwsIntegrationMutation::build_query(delete_aws_integration_mutation::Variables {
+                integration_id,
+            });
+        let response_body =
+            graphql_request::<_, delete_aws_integration_mutation::ResponseData>(&query)?;
+
+        if let Some(errors) = response_body.errors {
+            Err(GraphQLError::build_query_error(
+                errors,
+                Resource::Integration,
+                Operation::Delete,
+            ))
+        } else if let Some(data) = response_body.data {
+            let logical_errors = data.delete_aws_integration.errors;
+            if !logical_errors.is_empty() {
+                Err(GraphQLError::build_logical_error(to_user_errors!(
+                    logical_errors
+                )))
+            } else {
+                Ok(data.delete_aws_integration.deleted_aws_integration_id)
+            }
+        } else {
+            Err(GraphQLError::MissingDataError)
+        }
+    }
+
+    pub fn delete_github_integration(
+        &self,
+        integration_id: String,
+    ) -> GraphQLResult<Option<String>> {
+        let query = DeleteGithubIntegrationMutation::build_query(
+            delete_github_integration_mutation::Variables { integration_id },
+        );
+        let response_body =
+            graphql_request::<_, delete_github_integration_mutation::ResponseData>(&query)?;
+
+        if let Some(errors) = response_body.errors {
+            Err(GraphQLError::build_query_error(
+                errors,
+                Resource::Integration,
+                Operation::Delete,
+            ))
+        } else if let Some(data) = response_body.data {
+            let logical_errors = data.delete_github_integration.errors;
+            if !logical_errors.is_empty() {
+                Err(GraphQLError::build_logical_error(to_user_errors!(
+                    logical_errors
+                )))
+            } else {
+                Ok(data.delete_github_integration.deleted_github_integration_id)
+            }
+        } else {
+            Err(GraphQLError::MissingDataError)
+        }
     }
 }
 
@@ -82,6 +171,58 @@ impl IntegrationsIntf for Integrations {
             Ok(integrations)
         } else {
             Err(GraphQLError::MissingDataError)
+        }
+    }
+
+    fn get_details_by_name(
+        &self,
+        org_id: Option<&str>,
+        int_name: Option<&str>,
+        int_type: Option<&str>,
+    ) -> GraphQLResult<Option<IntegrationDetails>> {
+        // TODO: Rick Porter 5/21 - change to use a query for a single element
+        // this is an interim query that gets the whole list, and does filtering on the CLI
+        let all_entries = self.get_integration_details(org_id)?;
+        let mut found: Option<IntegrationDetails> = None;
+        let mut integration_types: Vec<String> = Vec::new();
+
+        // walk the list of integration details looking for matches (and duplicates)
+        for entry in all_entries {
+            if int_name.unwrap() != entry.name.as_str() {
+                continue;
+            }
+
+            if int_type.is_none() {
+                integration_types.push(entry.integration_type.clone());
+                found = Some(entry);
+            } else if int_type == Some(entry.integration_type.as_str()) {
+                found = Some(entry);
+                break;
+            }
+        }
+
+        if integration_types.len() > 1 {
+            let multiples = integration_types.join(", ");
+            Err(GraphQLError::AmbiguousIntegrationError(
+                int_name.unwrap().to_string(),
+                multiples,
+            ))
+        } else {
+            Ok(found)
+        }
+    }
+
+    fn delete_integration(
+        &self,
+        integration_id: String,
+        integration_type: String,
+    ) -> GraphQLResult<Option<String>> {
+        if integration_type.to_lowercase() == "aws" {
+            self.delete_aws_integration(integration_id)
+        } else if integration_type.to_lowercase() == "github" {
+            self.delete_github_integration(integration_id)
+        } else {
+            Err(GraphQLError::IntegrationTypeError(integration_type))
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -484,7 +484,30 @@ fn process_integrations_command(
     integrations: &impl IntegrationsIntf,
     org_id: Option<&str>,
 ) -> Result<()> {
-    if let Some(subcmd_args) = subcmd_args.subcommand_matches("list") {
+    if let Some(subcmd_args) = subcmd_args.subcommand_matches("delete") {
+        let int_name = subcmd_args.value_of("NAME");
+        let int_type = subcmd_args.value_of("TYPE");
+        let details = integrations.get_details_by_name(org_id, int_name, int_type)?;
+
+        if let Some(details) = details {
+            let mut confirmed = subcmd_args.is_present("confirm");
+            if !confirmed {
+                confirmed = user_confirm(format!("Delete integration '{}'", int_name.unwrap()));
+            }
+
+            if !confirmed {
+                warning_message(format!("Integration '{}' not deleted!", int_name.unwrap()))?;
+            } else {
+                integrations.delete_integration(details.id, details.integration_type)?;
+                println!("Deleted integration '{}'", int_name.unwrap());
+            }
+        } else {
+            warning_message(format!(
+                "Integration '{}' does not exist!",
+                int_name.unwrap()
+            ))?;
+        }
+    } else if let Some(subcmd_args) = subcmd_args.subcommand_matches("list") {
         let details = integrations.get_integration_details(org_id)?;
         if details.is_empty() {
             println!("No integrations found");

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -151,8 +151,27 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    help    Prints this message or the help of the given subcommand(s)
-    list    List CloudTruth integrations [aliases: ls]
+    delete    Delete specified CloudTruth integration [aliases: del]
+    help      Prints this message or the help of the given subcommand(s)
+    list      List CloudTruth integrations [aliases: ls]
+========================================
+cloudtruth-integrations-delete 
+Delete specified CloudTruth integration
+
+USAGE:
+    cloudtruth integrations delete [FLAGS] [OPTIONS] <NAME>
+
+FLAGS:
+        --confirm    Avoid confirmation prompt
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -t, --type <TYPE>    Integration type, only needed to disambiguate integrations with the same name [possible values:
+                         aws, github]
+
+ARGS:
+    <NAME>    Integration name
 ========================================
 cloudtruth-integrations-list 
 List CloudTruth integrations


### PR DESCRIPTION
Cherry-picked commit from other branch. Could not figure out how to get rebase/merge conflicts resolved.

Example output:
```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations -h
cloudtruth-integrations 
Work with CloudTruth integrations

USAGE:
    cloudtruth integrations [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    delete    Delete specified CloudTruth integration [aliases: del]
    help      Prints this message or the help of the given subcommand(s)
    list      List CloudTruth integrations [aliases: ls]
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations ls -v
+-------------+--------+---------------------+
| Name        | Type   | FQN                 |
+-------------+--------+---------------------+
| Rick Porter | Github | GitHub::Rick Porter |
+-------------+--------+---------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations del -h
cloudtruth-integrations-delete 
Delete specified CloudTruth integration

USAGE:
    cloudtruth integrations delete [FLAGS] [OPTIONS] <NAME>

FLAGS:
        --confirm    Avoid confirmation prompt
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -t, --type <TYPE>    Integration type, only needed to disambiguate integrations with the same name [possible values:
                         aws, github]

ARGS:
    <NAME>    Integration name
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations del "Rick Porter"
Delete integration 'Rick Porter'? (y/n) n
Integration 'Rick Porter' not deleted!
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations del "Rick Porter"
Delete integration 'Rick Porter'? (y/n) y
Deleted integration 'Rick Porter'
(new-host-4):~/cloudtruth-cli $ cargo run -q -- integrations ls -v
No integrations found
(new-host-4):~/cloudtruth-cli $
```