### PR TITLE
Add 'integrations explore' to query integrations for FQNs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,6 +216,7 @@ dependencies = [
  "rpassword",
  "rusty-hook",
  "serde",
+ "serde_json",
  "serde_yaml",
  "serial_test",
  "subprocess",
@@ -1440,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ prettytable-rs = "0.8.0"
 reqwest = { version = "0.11.0", features = ["blocking", "json"] }
 rpassword = "5.0.1"
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.64"
 serde_yaml = "0.8"
 subprocess = "0.1"
 termcolor = "1.1"

--- a/graphql/integration_queries.graphql
+++ b/graphql/integration_queries.graphql
@@ -1,6 +1,5 @@
 query IntegrationsQuery($organizationId: ID) {
   viewer {
-    id
     organization(id: $organizationId) {
       integrations {
         nodes {
@@ -34,6 +33,63 @@ mutation DeleteGithubIntegrationMutation($integrationId: ID!) {
     errors {
       path
       message
+    }
+  }
+}
+
+query IntegrationNodeQuery($entryId: ID!) {
+  node(id: $entryId) {
+    __typename
+    ... on GithubIntegration {
+      id
+      name
+      fqn
+      entries {
+        __typename
+        id
+        name
+        fqn
+      }
+    }
+    ... on AwsIntegration {
+      id
+      name
+      fqn
+      entries {
+        __typename
+        id
+        name
+        fqn
+      }
+    }
+    ... on IntegrationFileTree {
+      id
+      name
+      fqn
+      entries {
+        __typename
+        id
+        name
+        fqn
+      }
+    }
+    ... on IntegrationFile {
+      id
+      name
+      fqn
+      mimeType
+      json
+    }
+    ... on IntegrationServiceTree {
+      id
+      name
+      fqn
+      entries {
+        __typename
+        id
+        name
+        fqn
+      }
     }
   }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -26,6 +26,22 @@ fn secrets_display_flag() -> Arg<'static, 'static> {
     Arg::with_name("secrets").short("s").long("secrets")
 }
 
+fn confirm_flag() -> Arg<'static, 'static> {
+    Arg::with_name("confirm")
+        .long("confirm")
+        .help("Avoid confirmation prompt")
+}
+
+fn integration_type_option() -> Arg<'static, 'static> {
+    Arg::with_name("TYPE")
+        .short("t")
+        .long("type")
+        .takes_value(true)
+        .case_insensitive(true)
+        .possible_values(&["aws", "github"])
+        .help("Integration type, only used to disambiguate duplicate names")
+}
+
 pub fn build_cli() -> App<'static, 'static> {
     app_from_crate!()
         .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -86,9 +102,7 @@ pub fn build_cli() -> App<'static, 'static> {
                             .index(1)
                             .required(true)
                             .help("Environment name"))
-                        .arg(Arg::with_name("confirm")
-                            .long("confirm")
-                            .help("Avoid confirmation prompt")),
+                        .arg(confirm_flag()),
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth environments")
@@ -124,16 +138,25 @@ pub fn build_cli() -> App<'static, 'static> {
                             .index(1)
                             .required(true)
                             .help("Integration name"))
-                        .arg(Arg::with_name("confirm")
-                            .long("confirm")
-                            .help("Avoid confirmation prompt"))
-                        .arg(Arg::with_name("TYPE")
-                            .short("t")
-                            .long("type")
+                        .arg(confirm_flag())
+                        .arg(integration_type_option()),
+                    SubCommand::with_name("explore")
+                        .visible_aliases(&["exp", "ex", "e"])
+                        .about("Explore specific integration options")
+                        .arg(Arg::with_name("NAME")
+                            .index(1)
                             .takes_value(true)
-                            .possible_values(&["aws", "github"])
-                            .help(concat!("Integration type, only needed to disambiguate ",
-                                "integrations with the same name"))),
+                            .required(true)
+                            .help("Integration name"))
+                        .arg(Arg::with_name("PATH")
+                            .index(2)
+                            .takes_value(true)
+                            .required(false)
+                            .help("Path within the integration")
+                        )
+                        .arg(table_format_options().help("Format integration values data."))
+                        .arg(values_flag().help("Display integration values"))
+                        .arg(integration_type_option()),
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth integrations")
@@ -287,9 +310,7 @@ pub fn build_cli() -> App<'static, 'static> {
                             .index(1)
                             .required(true)
                             .help("Project name"))
-                        .arg(Arg::with_name("confirm")
-                            .long("confirm")
-                            .help("Avoid confirmation prompt")),
+                        .arg(confirm_flag()),
                     SubCommand::with_name("list")
                         .visible_alias("ls")
                         .about("List CloudTruth projects")

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,7 +1,14 @@
 use crate::graphql::prelude::graphql_request;
 use crate::graphql::{GraphQLError, GraphQLResult, Operation, Resource, NO_ORG_ERROR};
+use crate::integrations::integration_node_query::*;
 use crate::integrations::integrations_query::IntegrationsQueryViewerOrganizationIntegrationsNodesOn;
+use crate::integrations::IntegrationNodeQueryNodeOn::AwsIntegration;
+use crate::integrations::IntegrationNodeQueryNodeOn::GithubIntegration;
+use crate::integrations::IntegrationNodeQueryNodeOn::IntegrationFile;
+use crate::integrations::IntegrationNodeQueryNodeOn::IntegrationFileTree;
+use crate::integrations::IntegrationNodeQueryNodeOn::IntegrationServiceTree;
 use graphql_client::*;
+use std::fmt::Debug;
 
 #[derive(GraphQLQuery)]
 #[graphql(
@@ -27,13 +34,39 @@ pub struct DeleteGithubIntegrationMutation;
 )]
 pub struct IntegrationsQuery;
 
-/// This holds the common information for Integrations, including an `integration_type` that
-/// indicates the provider.
+#[derive(GraphQLQuery)]
+#[graphql(
+    schema_path = "graphql/schema.graphql",
+    query_path = "graphql/integration_queries.graphql",
+    response_derives = "Debug"
+)]
+pub struct IntegrationNodeQuery;
+
+/// This holds the common information for Integrations.
+#[derive(Debug)]
 pub struct IntegrationDetails {
     pub fqn: String,
     pub id: String,
     pub integration_type: String,
     pub name: String,
+}
+
+/// Provides basic information about the integration entries
+#[derive(Debug)]
+pub struct IntegrationEntry {
+    pub fqn: String,
+    pub id: String,
+    pub name: String,
+}
+
+/// Provides information about the current node, and its' children
+#[derive(Debug)]
+pub struct IntegrationNode {
+    pub fqn: String,
+    pub id: String,
+    pub name: String,
+    /// `entries` are a list of "children" in the integration.
+    pub entries: Vec<IntegrationEntry>,
 }
 
 /// This is the interface that is implemented to retrieve integration information.
@@ -61,6 +94,9 @@ pub trait IntegrationsIntf {
         integration_id: String,
         integration_type: String,
     ) -> GraphQLResult<Option<String>>;
+
+    /// Get the integration node by ID
+    fn get_integration_node(&self, entry_id: String) -> GraphQLResult<Option<IntegrationNode>>;
 }
 
 /// Converts the typename into a String value without the trailing `Integration`
@@ -68,6 +104,132 @@ impl ToString for IntegrationsQueryViewerOrganizationIntegrationsNodesOn {
     fn to_string(&self) -> String {
         let result = format!("{:?}", self);
         result.replace("Integration", "")
+    }
+}
+
+impl From<&IntegrationNodeQueryNodeOnAwsIntegration> for IntegrationNode {
+    fn from(node: &IntegrationNodeQueryNodeOnAwsIntegration) -> Self {
+        let mut entries: Vec<IntegrationEntry> = Vec::new();
+        for e in node.entries.iter() {
+            entries.push(IntegrationEntry::from(e));
+        }
+        IntegrationNode {
+            fqn: node.fqn.clone(),
+            id: node.id.clone(),
+            name: node.name.clone(),
+            entries,
+        }
+    }
+}
+
+impl From<&IntegrationNodeQueryNodeOnGithubIntegration> for IntegrationNode {
+    fn from(node: &IntegrationNodeQueryNodeOnGithubIntegration) -> Self {
+        let mut entries: Vec<IntegrationEntry> = Vec::new();
+        for e in node.entries.iter() {
+            entries.push(IntegrationEntry::from(e));
+        }
+        IntegrationNode {
+            fqn: node.fqn.clone(),
+            id: node.id.clone(),
+            name: node.name.clone(),
+            entries,
+        }
+    }
+}
+
+impl From<&IntegrationNodeQueryNodeOnIntegrationServiceTree> for IntegrationNode {
+    fn from(node: &IntegrationNodeQueryNodeOnIntegrationServiceTree) -> Self {
+        let mut entries: Vec<IntegrationEntry> = Vec::new();
+        for e in node.entries.iter() {
+            entries.push(IntegrationEntry::from(e));
+        }
+        IntegrationNode {
+            fqn: node.fqn.clone(),
+            id: node.id.clone(),
+            name: node.name.clone(),
+            entries,
+        }
+    }
+}
+
+impl From<&IntegrationNodeQueryNodeOnIntegrationFileTree> for IntegrationNode {
+    fn from(node: &IntegrationNodeQueryNodeOnIntegrationFileTree) -> Self {
+        let mut entries: Vec<IntegrationEntry> = Vec::new();
+        for e in node.entries.iter() {
+            entries.push(IntegrationEntry::from(e));
+        }
+        IntegrationNode {
+            fqn: node.fqn.clone(),
+            id: node.id.clone(),
+            name: node.name.clone(),
+            entries,
+        }
+    }
+}
+
+impl From<&IntegrationNodeQueryNodeOnIntegrationFile> for IntegrationNode {
+    fn from(node: &IntegrationNodeQueryNodeOnIntegrationFile) -> Self {
+        IntegrationNode {
+            fqn: node.fqn.clone(),
+            id: node.id.clone(),
+            name: node.name.clone(),
+            // IntegrationFile's do NOT have entries...TODO: use json?
+            entries: vec![],
+        }
+    }
+}
+
+impl From<&IntegrationNodeQueryNodeOnAwsIntegrationEntries> for IntegrationEntry {
+    fn from(entry: &IntegrationNodeQueryNodeOnAwsIntegrationEntries) -> Self {
+        IntegrationEntry {
+            fqn: entry.fqn.clone(),
+            id: entry.id.clone(),
+            name: entry.name.clone(),
+        }
+    }
+}
+
+impl From<&IntegrationNodeQueryNodeOnGithubIntegrationEntries> for IntegrationEntry {
+    fn from(entry: &IntegrationNodeQueryNodeOnGithubIntegrationEntries) -> Self {
+        IntegrationEntry {
+            fqn: entry.fqn.clone(),
+            id: entry.id.clone(),
+            name: entry.name.clone(),
+        }
+    }
+}
+
+impl From<&IntegrationNodeQueryNodeOnIntegrationServiceTreeEntries> for IntegrationEntry {
+    fn from(entry: &IntegrationNodeQueryNodeOnIntegrationServiceTreeEntries) -> Self {
+        IntegrationEntry {
+            fqn: entry.fqn.clone(),
+            id: entry.id.clone(),
+            name: entry.name.clone(),
+        }
+    }
+}
+
+impl From<&IntegrationNodeQueryNodeOnIntegrationFileTreeEntries> for IntegrationEntry {
+    fn from(entry: &IntegrationNodeQueryNodeOnIntegrationFileTreeEntries) -> Self {
+        IntegrationEntry {
+            fqn: entry.fqn.clone(),
+            id: entry.id.clone(),
+            name: entry.name.clone(),
+        }
+    }
+}
+
+impl IntegrationNode {
+    /// Method to get a potential match in this node, for an entry matching the name.
+    pub fn get_id_for_name(&self, name: String) -> Option<String> {
+        let mut result = None;
+        for e in self.entries.iter() {
+            if name == e.name {
+                result = Some(e.id.clone());
+                break;
+            }
+        }
+        result
     }
 }
 
@@ -185,6 +347,7 @@ impl IntegrationsIntf for Integrations {
         let all_entries = self.get_integration_details(org_id)?;
         let mut found: Option<IntegrationDetails> = None;
         let mut integration_types: Vec<String> = Vec::new();
+        let int_type_name = int_type.unwrap_or_default();
 
         // walk the list of integration details looking for matches (and duplicates)
         for entry in all_entries {
@@ -192,10 +355,10 @@ impl IntegrationsIntf for Integrations {
                 continue;
             }
 
-            if int_type.is_none() {
+            if int_type_name.is_empty() {
                 integration_types.push(entry.integration_type.clone());
                 found = Some(entry);
-            } else if int_type == Some(entry.integration_type.as_str()) {
+            } else if int_type_name.to_lowercase() == entry.integration_type.to_lowercase() {
                 found = Some(entry);
                 break;
             }
@@ -223,6 +386,37 @@ impl IntegrationsIntf for Integrations {
             self.delete_github_integration(integration_id)
         } else {
             Err(GraphQLError::IntegrationTypeError(integration_type))
+        }
+    }
+
+    fn get_integration_node(&self, entry_id: String) -> GraphQLResult<Option<IntegrationNode>> {
+        let query =
+            IntegrationNodeQuery::build_query(integration_node_query::Variables { entry_id });
+        let response_body = graphql_request::<_, integration_node_query::ResponseData>(&query)?;
+
+        if let Some(errors) = response_body.errors {
+            Err(GraphQLError::ResponseError(errors))
+        } else if let Some(data) = response_body.data {
+            if let Some(node) = data.node {
+                if let AwsIntegration(aws) = &node.on {
+                    Ok(Some(IntegrationNode::from(aws)))
+                } else if let GithubIntegration(gh) = &node.on {
+                    Ok(Some(IntegrationNode::from(gh)))
+                } else if let IntegrationServiceTree(st) = &node.on {
+                    Ok(Some(IntegrationNode::from(st)))
+                } else if let IntegrationFileTree(st) = &node.on {
+                    Ok(Some(IntegrationNode::from(st)))
+                } else if let IntegrationFile(f) = &node.on {
+                    Ok(Some(IntegrationNode::from(f)))
+                } else {
+                    dbg!(&node);
+                    panic!("Unhandled type")
+                }
+            } else {
+                Ok(None)
+            }
+        } else {
+            Err(GraphQLError::MissingDataError)
         }
     }
 }

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -151,9 +151,10 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    delete    Delete specified CloudTruth integration [aliases: del]
-    help      Prints this message or the help of the given subcommand(s)
-    list      List CloudTruth integrations [aliases: ls]
+    delete     Delete specified CloudTruth integration [aliases: del]
+    explore    Explore specific integration options [aliases: exp, ex, e]
+    help       Prints this message or the help of the given subcommand(s)
+    list       List CloudTruth integrations [aliases: ls]
 ========================================
 cloudtruth-integrations-delete 
 Delete specified CloudTruth integration
@@ -167,11 +168,29 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -t, --type <TYPE>    Integration type, only needed to disambiguate integrations with the same name [possible values:
-                         aws, github]
+    -t, --type <TYPE>    Integration type, only used to disambiguate duplicate names [possible values: aws, github]
 
 ARGS:
     <NAME>    Integration name
+========================================
+cloudtruth-integrations-explore 
+Explore specific integration options
+
+USAGE:
+    cloudtruth integrations explore [FLAGS] [OPTIONS] <NAME> [PATH]
+
+FLAGS:
+    -h, --help       Prints help information
+    -v, --values     Display integration values
+    -V, --version    Prints version information
+
+OPTIONS:
+    -t, --type <TYPE>        Integration type, only used to disambiguate duplicate names [possible values: aws, github]
+    -f, --format <format>    Format integration values data. [default: table]  [possible values: table, csv]
+
+ARGS:
+    <NAME>    Integration name
+    <PATH>    Path within the integration
 ========================================
 cloudtruth-integrations-list 
 List CloudTruth integrations


### PR DESCRIPTION
Example output:
```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int ls -v
+-------------+--------+---------------------+
| Name        | Type   | FQN                 |
+-------------+--------+---------------------+
| Rick Porter | Github | GitHub::Rick Porter |
+-------------+--------+---------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int -h
cloudtruth-integrations 
Work with CloudTruth integrations

USAGE:
    cloudtruth integrations [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    delete     Delete specified CloudTruth integration [aliases: del]
    explore    Explore specific integration options [aliases: exp, ex, e]
    help       Prints this message or the help of the given subcommand(s)
    list       List CloudTruth integrations [aliases: ls]
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int exp -h
cloudtruth-integrations-explore 
Explore specific integration options

USAGE:
    cloudtruth integrations explore [FLAGS] [OPTIONS] <NAME> [PATH]

FLAGS:
    -h, --help       Prints help information
    -v, --values     Display integration values
    -V, --version    Prints version information

OPTIONS:
    -t, --type <TYPE>        Integration type, only used to disambiguate duplicate names [possible values: aws, github]
    -f, --format <format>    Format integration values data. [default: table]  [possible values: table, csv]

ARGS:
    <NAME>    Integration name
    <PATH>    Path within the integration
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int exp "Rick Porter"
Rick Porter
  repositories
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int exp "Rick Porter" repositories
repositories
  rickporter-tuono/cloudtruth_test
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int exp "Rick Porter" repositories::rickporter-tuono/cloudtruth_test -v
+----------------------------------+--------------------------------------------------------------------------------------+
| Name                             | FQN                                                                                  |
+----------------------------------+--------------------------------------------------------------------------------------+
| rickporter-tuono/cloudtruth_test | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test       |
|   main                           | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main |
+----------------------------------+--------------------------------------------------------------------------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int exp "Rick Porter" repositories::rickporter-tuono/cloudtruth_test::main -v
+---------------------+---------------------------------------------------------------------------------------------------------+
| Name                | FQN                                                                                                     |
+---------------------+---------------------------------------------------------------------------------------------------------+
| main                | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main                    |
|   more_config       | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::more_config/      |
|   .gitignore        | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::.gitignore        |
|   README.md         | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::README.md         |
|   big_text_file.txt | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::big_text_file.txt |
|   config.json       | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::config.json       |
|   config.yaml       | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::config.yaml       |
|   image             | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::image             |
|   production.json   | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json   |
|   production.yaml   | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.yaml   |
|   staging.json      | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::staging.json      |
|   staging.yaml      | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::staging.yaml      |
|   test_value.txt    | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::test_value.txt    |
+---------------------+---------------------------------------------------------------------------------------------------------+
(new-host-4):~/cloudtruth-cli $
```