### PR TITLE
Remove 'integrations delete' code

### DIFF
--- a/graphql/integration_queries.graphql
+++ b/graphql/integration_queries.graphql
@@ -13,30 +13,6 @@ query IntegrationsQuery($organizationId: ID) {
   }
 }
 
-mutation DeleteAwsIntegrationMutation($integrationId: ID!) {
-  deleteAwsIntegration(input: { id: $integrationId }) {
-    clientMutationId
-    deletedAwsIntegrationId
-
-    errors {
-      path
-      message
-    }
-  }
-}
-
-mutation DeleteGithubIntegrationMutation($integrationId: ID!) {
-  deleteGithubIntegration(input: { id: $integrationId }) {
-    clientMutationId
-    deletedGithubIntegrationId
-
-    errors {
-      path
-      message
-    }
-  }
-}
-
 query IntegrationNodeQuery($entryId: ID!) {
   node(id: $entryId) {
     __typename

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -138,15 +138,6 @@ pub fn build_cli() -> App<'static, 'static> {
                 .visible_aliases(&["integration", "integrate", "integ", "int"])
                 .about("Work with CloudTruth integrations")
                 .subcommands(vec![
-                    SubCommand::with_name("delete")
-                        .visible_alias("del")
-                        .about("Delete specified CloudTruth integration")
-                        .arg(Arg::with_name("NAME")
-                            .index(1)
-                            .required(true)
-                            .help("Integration name"))
-                        .arg(confirm_flag())
-                        .arg(integration_type_option()),
                     SubCommand::with_name("explore")
                         .visible_aliases(&["exp", "ex", "e"])
                         .about("Explore specific integration options")

--- a/src/graphql.rs
+++ b/src/graphql.rs
@@ -63,7 +63,6 @@ pub type GraphQLResult<T> = std::result::Result<T, GraphQLError>;
 pub enum GraphQLError {
     AmbiguousIntegrationError(String, String),
     EnvironmentNotFoundError(String),
-    IntegrationTypeError(String),
     MissingDataError,
     NetworkError(Arc<reqwest::Error>),
     ParameterNotFoundError(String),
@@ -125,9 +124,6 @@ impl fmt::Display for GraphQLError {
             }
             GraphQLError::EnvironmentNotFoundError(name) => {
                 write!(f, "Unable to find environment '{}'.", name)
-            }
-            GraphQLError::IntegrationTypeError(type_name) => {
-                write!(f, "Unable to process integration type '{}'.", type_name)
             }
             GraphQLError::MissingDataError => write!(
                 f,

--- a/src/main.rs
+++ b/src/main.rs
@@ -485,30 +485,7 @@ fn process_integrations_command(
     integrations: &impl IntegrationsIntf,
     org_id: Option<&str>,
 ) -> Result<()> {
-    if let Some(subcmd_args) = subcmd_args.subcommand_matches("delete") {
-        let int_name = subcmd_args.value_of("NAME");
-        let int_type = subcmd_args.value_of("TYPE");
-        let details = integrations.get_details_by_name(org_id, int_name, int_type)?;
-
-        if let Some(details) = details {
-            let mut confirmed = subcmd_args.is_present(CONFIRM_FLAG);
-            if !confirmed {
-                confirmed = user_confirm(format!("Delete integration '{}'", int_name.unwrap()));
-            }
-
-            if !confirmed {
-                warning_message(format!("Integration '{}' not deleted!", int_name.unwrap()))?;
-            } else {
-                integrations.delete_integration(details.id, details.integration_type)?;
-                println!("Deleted integration '{}'", int_name.unwrap());
-            }
-        } else {
-            warning_message(format!(
-                "Integration '{}' does not exist!",
-                int_name.unwrap()
-            ))?;
-        }
-    } else if let Some(subcmd_args) = subcmd_args.subcommand_matches("explore") {
+    if let Some(subcmd_args) = subcmd_args.subcommand_matches("explore") {
         let int_name = subcmd_args.value_of("NAME");
         let int_type = subcmd_args.value_of("TYPE");
         let path = subcmd_args.value_of("PATH");

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -151,27 +151,9 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    delete     Delete specified CloudTruth integration [aliases: del]
     explore    Explore specific integration options [aliases: exp, ex, e]
     help       Prints this message or the help of the given subcommand(s)
     list       List CloudTruth integrations [aliases: ls]
-========================================
-cloudtruth-integrations-delete 
-Delete specified CloudTruth integration
-
-USAGE:
-    cloudtruth integrations delete [FLAGS] [OPTIONS] <NAME>
-
-FLAGS:
-    -y, --yes        Avoid confirmation prompt
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-    -t, --type <TYPE>    Integration type, only used to disambiguate duplicate names [possible values: aws, github]
-
-ARGS:
-    <NAME>    Integration name
 ========================================
 cloudtruth-integrations-explore 
 Explore specific integration options


### PR DESCRIPTION
Creating integrations requires much "venue" specific code, and sometimes visiting websites for that venue. So, we're not going to implement the `integrations create`. To keep things symmetric, this removes the `integrations delete` from the CLI.