### PR TITLE
Allow setting dynamic parameters from the CLI

### DIFF
--- a/graphql/parameter_queries.graphql
+++ b/graphql/parameter_queries.graphql
@@ -30,10 +30,15 @@ query GetParameterByNameQuery($organizationId: ID, $envName: String, $projectNam
           id
           environmentValue(environmentName: $envName) {
             parameterValue
+            jmesPath
+            integrationFile {
+              fqn
+            }
           }
           keyName
           isSecret
           description
+          hasDynamicValue
         }
       }
     }
@@ -73,6 +78,11 @@ query ParametersDetailQuery($organizationId: ID, $environmentId: ID, $projectNam
             description
             environmentValue(environmentId: $environmentId) {
               parameterValue
+              jmesPath
+              integrationFile {
+                name
+                fqn
+              }
               inheritedFrom {
                 name
               }
@@ -80,6 +90,7 @@ query ParametersDetailQuery($organizationId: ID, $environmentId: ID, $projectNam
                 name
               }
             }
+            hasDynamicValue
           }
         }
       }
@@ -87,8 +98,8 @@ query ParametersDetailQuery($organizationId: ID, $environmentId: ID, $projectNam
   }
 }
 
-mutation UpsertParameterMutation($projectId: ID, $environmentName: String, $keyName: String!, $value: String, $secret: Boolean, $description: String) {
-  upsertParameter(input: { keyName: $keyName, value: $value, environmentName: $environmentName, projectId: $projectId, isSecret: $secret , description: $description}) {
+mutation UpsertParameterMutation($projectId: ID, $environmentName: String, $keyName: String!, $value: String, $secret: Boolean, $description: String, $fqn: String, $jmesPath: String) {
+  upsertParameter(input: { keyName: $keyName, value: $value, environmentName: $environmentName, projectId: $projectId, isSecret: $secret , description: $description, jmesPath: $jmesPath, integrationFileFqn: $fqn}) {
     clientMutationId
     parameter {
       id

--- a/graphql/parameter_queries.graphql
+++ b/graphql/parameter_queries.graphql
@@ -31,6 +31,12 @@ query GetParameterByNameQuery($organizationId: ID, $envName: String, $projectNam
           environmentValue(environmentName: $envName) {
             parameterValue
             jmesPath
+            environment {
+              name
+            }
+            inheritedFrom {
+              name
+            }
             integrationFile {
               fqn
             }

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -2552,7 +2552,9 @@ input UpsertParameterInput {
   clientMutationId: String
   description: String
   environmentName: String
+  integrationFileFqn: String
   isSecret: Boolean
+  jmesPath: String
   keyName: String!
   organizationId: ID @deprecated(reason: "Use project_id instead")
   projectId: ID

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -207,7 +207,7 @@ pub fn build_cli() -> App<'static, 'static> {
                         .arg(table_format_options().help("Format for parameter values data"))
                         .arg(secrets_display_flag().help("Display the secret parameter values")),
                     SubCommand::with_name("set")
-                        .about(concat!("Set a static value in the selected project/environment for ",
+                        .about(concat!("Set a value in the selected project/environment for ",
                             "an existing parameter or creates a new one if needed"))
                         .arg(Arg::with_name("KEY").required(true).index(1))
                         .arg(Arg::with_name("description")
@@ -215,15 +215,25 @@ pub fn build_cli() -> App<'static, 'static> {
                             .short("d")
                             .long("desc")
                             .help("Parameter description"))
+                        .arg(Arg::with_name("FQN")
+                            .short("f")
+                            .long("fqn")
+                            .takes_value(true)
+                            .help("Fully Qualified Name (FQN) reference for dynamic parameter."))
                         .arg(Arg::with_name("input-file")
                             .short("i")
                             .long("input")
                             .takes_value(true)
-                            .help("Read the value from the input file"))
+                            .help("Read the static value from the local input file"))
+                        .arg(Arg::with_name("JMES")
+                            .short("j")
+                            .long("jmes")
+                            .takes_value(true)
+                            .help("JMES path within FQN for dynamic parameter"))
                         .arg(Arg::with_name("prompt")
                             .short("p")
                             .long("prompt")
-                            .help("Set the value using unecho'd terminal"))
+                            .help("Set the static value using unecho'd terminal"))
                         .arg(Arg::with_name("secret")
                             .long("secret")
                             .takes_value(true)
@@ -233,7 +243,7 @@ pub fn build_cli() -> App<'static, 'static> {
                             .short("v")
                             .long("value")
                             .takes_value(true)
-                            .help("Parameter value")),
+                            .help("Static parameter value")),
                 ]),
         )
         .subcommand(SubCommand::with_name("templates")

--- a/src/main.rs
+++ b/src/main.rs
@@ -675,6 +675,10 @@ fn process_parameters_command(
         let org_id = resolved.org_id.as_deref();
         let env_name = resolved.env_name.as_deref();
         let proj_name = resolved.proj_name.clone();
+        let prompt_user = subcmd_args.is_present("prompt");
+        let filename = subcmd_args.value_of("input-file");
+        let mut fqn = subcmd_args.value_of("FQN").map(|f| f.to_string());
+        let mut jmes_path = subcmd_args.value_of("JMES").map(|j| j.to_string());
         let mut value = subcmd_args.value_of("value").map(|v| v.to_string());
         let mut description = subcmd_args.value_of("description").map(|v| v.to_string());
         let mut secret: Option<bool> = match subcmd_args.value_of("secret") {
@@ -683,31 +687,58 @@ fn process_parameters_command(
             _ => None,
         };
 
+        // make sure the user did not over-specify
+        if (jmes_path.is_some() || fqn.is_some())
+            && (value.is_some() || prompt_user || filename.is_some())
+        {
+            error_message(
+                concat!(
+                    "Conflicting arguments: cannot specify prompt/input-file/value, ",
+                    "and fqn/jmes-path"
+                )
+                .to_string(),
+            )?;
+            process::exit(7);
+        }
+
         // if user asked to be prompted
-        if subcmd_args.is_present("prompt") {
+        if prompt_user {
             println!("Please enter the '{}' value: ", key);
             value = Some(read_password()?);
-        } else if let Some(filename) = subcmd_args.value_of("input-file") {
+        } else if let Some(filename) = filename {
             value = Some(fs::read_to_string(filename).expect("Failed to read value from file."));
         }
 
         // make sure there is at least one parameter to updated
-        if description.is_none() && secret.is_none() && value.is_none() {
+        if description.is_none()
+            && secret.is_none()
+            && value.is_none()
+            && jmes_path.is_none()
+            && fqn.is_none()
+        {
             warn_user(
                 concat!(
                     "Nothing changed. Please provide at least one of: ",
-                    "description, secret, or value."
+                    "description, secret, or value/fqn/jmes-path."
                 )
                 .to_string(),
             )?;
         } else {
-            // get the original value, so that is not lost
+            // get the original values, so that is not lost
             if let Ok(Some(original)) =
                 parameters.get_parameter_full(org_id, env_name, proj_name.clone(), &key)
             {
-                if value.is_none() {
+                // use original values
+                if value.is_none() && jmes_path.is_none() && fqn.is_none() {
                     if let Some(env_value) = original.environment_value {
-                        value = env_value.parameter_value;
+                        if original.has_dynamic_value {
+                            jmes_path = env_value.jmes_path;
+                            if let Some(file) = env_value.integration_file {
+                                fqn = Some(file.fqn);
+                            }
+                        } else {
+                            value = env_value.parameter_value;
+                        }
                     }
                 }
                 if description.is_none() {
@@ -725,6 +756,8 @@ fn process_parameters_command(
                 value.as_deref(),
                 description.as_deref(),
                 secret,
+                fqn.as_deref(),
+                jmes_path.as_deref(),
             )?;
 
             if updated_id.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -741,7 +741,17 @@ fn process_parameters_command(
                     } else {
                         value = Some(original.value)
                     }
+                } else if value.is_none() {
+                    // no value was specified, but at least one of fqn/jmes was... allows individual
+                    // FQN/JMES to be set.
+                    if fqn.is_none() {
+                        fqn = Some(original.fqn)
+                    }
+                    if jmes_path.is_none() {
+                        jmes_path = Some(original.jmes_path)
+                    }
                 }
+
                 if description.is_none() {
                     description = Some(original.description);
                 }

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -205,8 +205,8 @@ SUBCOMMANDS:
     get       Gets value for parameter in the selected environment
     help      Prints this message or the help of the given subcommand(s)
     list      List CloudTruth parameters [aliases: ls]
-    set       Set a static value in the selected project/environment for an existing parameter or creates a new one
-              if needed
+    set       Set a value in the selected project/environment for an existing parameter or creates a new one if
+              needed
 ========================================
 cloudtruth-parameters-delete 
 Delete the parameter from the project
@@ -271,21 +271,23 @@ OPTIONS:
     -f, --format <format>    Format for parameter values data [default: table]  [possible values: table, csv]
 ========================================
 cloudtruth-parameters-set 
-Set a static value in the selected project/environment for an existing parameter or creates a new one if needed
+Set a value in the selected project/environment for an existing parameter or creates a new one if needed
 
 USAGE:
     cloudtruth parameters set [FLAGS] [OPTIONS] <KEY>
 
 FLAGS:
     -h, --help       Prints help information
-    -p, --prompt     Set the value using unecho'd terminal
+    -p, --prompt     Set the static value using unecho'd terminal
     -V, --version    Prints version information
 
 OPTIONS:
+    -f, --fqn <FQN>             Fully Qualified Name (FQN) reference for dynamic parameter.
+    -j, --jmes <JMES>           JMES path within FQN for dynamic parameter
     -d, --desc <description>    Parameter description
-    -i, --input <input-file>    Read the value from the input file
+    -i, --input <input-file>    Read the static value from the local input file
         --secret <secret>       Flags whether this is a secret parameter [possible values: true, false]
-    -v, --value <value>         Parameter value
+    -v, --value <value>         Static parameter value
 
 ARGS:
     <KEY>    


### PR DESCRIPTION
Sample output:
```
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int ls -v
+-------------+--------+---------------------+
| Name        | Type   | FQN                 |
+-------------+--------+---------------------+
| Rick Porter | Github | GitHub::Rick Porter |
+-------------+--------+---------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int ex "Rick Porter" repositories -v
+------------------------------------+--------------------------------------------------------------------------------+
| Name                               | FQN                                                                            |
+------------------------------------+--------------------------------------------------------------------------------+
| repositories                       | GitHub::Rick Porter::repositories                                              |
|   rickporter-tuono/cloudtruth_test | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test |
|   rickporter-tuono/hello-world     | GitHub::Rick Porter::repositories::252050021::rickporter-tuono/hello-world     |
+------------------------------------+--------------------------------------------------------------------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- int ex "Rick Porter" repositories::rickporter-tuono/cloudtruth_test::main::production.json -v
+---------------------------------------+-------------------------------------------------------------------------------------------------------+
| Name                                  | FQN                                                                                                   |
+---------------------------------------+-------------------------------------------------------------------------------------------------------+
| production.json                       | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Apollo.Arsenal }}                | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Apollo.Captain Comet }}          | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Apollo.Plastic Man }}            | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Green Arrow.Animal Man }}        | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Green Arrow.Doctor Fate }}       | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Green Arrow.Orion }}             | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Green Arrow.Red Tornado }}       | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Green Lantern.Apollo }}          | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Green Lantern.Doctor Mid-Nite }} | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Green Lantern.Jonah Hex }}       | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Green Lantern.Superman }}        | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Spectre.Mr. Terrific }}          | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Spectre.Nite Owl }}              | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Spectre.Ragman }}                | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
|   {{ Spectre.Speedy }}                | GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json |
+---------------------------------------+-------------------------------------------------------------------------------------------------------+
(new-host-4):~/cloudtruth-cli $ 
(new-host-4):~/cloudtruth-cli $ 
(new-host-4):~/cloudtruth-cli $ cargo run -q -- param ls -v
+-----------------+-----------------------------------------+---------+---------------------------------+
| Name            | Value                                   | Source  | Description                     |
+-----------------+-----------------------------------------+---------+---------------------------------+
| ANOTHER_VALUE   | uninteresting                           | default | set just description            |
| MY_DYN_PARAM    | Chuck Norris' preferred IDE is hexedit. | default |                                 |
| MY_KEY_NAME     | my_value                                | default | dummy key name/value            |
| MY_SECRET       | *****                                   | default | something to test secret hiding |
| new_param_value | third value                             | default | fresh description               |
+-----------------+-----------------------------------------+---------+---------------------------------+
(new-host-4):~/cloudtruth-cli $ cargo run -q -- param set -h
cloudtruth-parameters-set 
Set a value in the selected project/environment for an existing parameter or creates a new one if needed

USAGE:
    cloudtruth parameters set [FLAGS] [OPTIONS] <KEY>

FLAGS:
    -h, --help       Prints help information
    -p, --prompt     Set the static value using unecho'd terminal
    -V, --version    Prints version information

OPTIONS:
    -f, --fqn <FQN>             Fully Qualified Name (FQN) reference for dynamic parameter.
    -j, --jmes <JMES>           JMES path within FQN for dynamic parameter
    -d, --desc <description>    Parameter description
    -i, --input <input-file>    Read the static value from the local input file
        --secret <secret>       Flags whether this is a secret parameter [possible values: true, false]
    -v, --value <value>         Static parameter value

ARGS:
    <KEY>    
(new-host-4):~/cloudtruth-cli $ cargo run -q -- param set SPECTRE -f "GitHub::Rick Porter::repositories::366193154::rickporter-tuono/cloudtruth_test::main::production.json" -j "Spectre.Speedy" -d "Dynamic value set from cli"
Successfully updated parameter 'SPECTRE' in project 'default' for environment 'default'.
(new-host-4):~/cloudtruth-cli $ cargo run -q -- param ls -v
+-----------------+----------------------------------------------------------------------------------------------------------+---------+---------------------------------+
| Name            | Value                                                                                                    | Source  | Description                     |
+-----------------+----------------------------------------------------------------------------------------------------------+---------+---------------------------------+
| ANOTHER_VALUE   | uninteresting                                                                                            | default | set just description            |
| MY_DYN_PARAM    | Chuck Norris' preferred IDE is hexedit.                                                                  | default |                                 |
| MY_KEY_NAME     | my_value                                                                                                 | default | dummy key name/value            |
| MY_SECRET       | *****                                                                                                    | default | something to test secret hiding |
| SPECTRE         | Anonymous methods and anonymous types are really all called Chuck Norris. They just don't like to boast. | default | Dynamic value set from cli      |
| new_param_value | third value                                                                                              | default | fresh description               |
+-----------------+----------------------------------------------------------------------------------------------------------+---------+---------------------------------+
(new-host-4):~/cloudtruth-cli $
```