### PR TITLE
Add --secrets option to templates

### DIFF
--- a/graphql/template_queries.graphql
+++ b/graphql/template_queries.graphql
@@ -1,9 +1,9 @@
-query GetTemplateByNameQuery($organizationId: ID, $projectName: String, $environmentName: String, $templateName: String!) {
+query GetTemplateByNameQuery($organizationId: ID, $projectName: String, $environmentName: String, $templateName: String!, $showSecrets: Boolean!) {
   viewer {
     organization(id: $organizationId) {
       project(name: $projectName) {
         template(name: $templateName) {
-          evaluated(environmentName: $environmentName)
+          evaluated(environmentName: $environmentName, showSecret: $showSecrets)
         }
       }
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -242,6 +242,7 @@ pub fn build_cli() -> App<'static, 'static> {
             .subcommands(vec![
                 SubCommand::with_name("get")
                     .about("Get an evaluated template from CloudTruth")
+                    .arg(secrets_display_flag())
                     .arg(Arg::with_name("KEY").required(true).index(1)),
                 SubCommand::with_name("list")
                     .visible_alias("ls")

--- a/src/main.rs
+++ b/src/main.rs
@@ -848,7 +848,9 @@ fn process_templates_command(
         let proj_name = resolved.proj_name.clone();
         let template_name = subcmd_args.value_of("KEY").unwrap();
         let env_name = resolved.env_name.as_deref();
-        let body = templates.get_body_by_name(org_id, proj_name, env_name, template_name)?;
+        let show_secrets = subcmd_args.is_present(SECRETS_FLAG);
+        let body =
+            templates.get_body_by_name(org_id, proj_name, env_name, template_name, show_secrets)?;
 
         if let Some(body) = body {
             println!("{}", body)

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -38,12 +38,14 @@ impl Templates {
         project_name: Option<String>,
         environment_name: Option<&str>,
         template_name: &str,
+        show_secrets: bool,
     ) -> GraphQLResult<Option<String>> {
         let query = GetTemplateByNameQuery::build_query(get_template_by_name_query::Variables {
             organization_id: organization_id.map(|id| id.to_string()),
             project_name: project_name.clone(),
             environment_name: environment_name.map(|name| name.to_string()),
             template_name: template_name.to_string(),
+            show_secrets,
         });
         let response_body = graphql_request::<_, get_template_by_name_query::ResponseData>(&query)?;
 

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -390,10 +390,11 @@ cloudtruth-templates-get
 Get an evaluated template from CloudTruth
 
 USAGE:
-    cloudtruth templates get <KEY>
+    cloudtruth templates get [FLAGS] <KEY>
 
 FLAGS:
     -h, --help       Prints help information
+    -s, --secrets    
     -V, --version    Prints version information
 
 ARGS:


### PR DESCRIPTION
When server started requiring templates to have a `showSecret` flag to display the secrets, the CLI was not updated.