### PR TITLE
Fix issue with empty default project

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -568,7 +568,10 @@ fn process_parameters_command(
             println!(
                 "No {}parameters found in project {}",
                 qualifier,
-                resolved.proj_name.clone().unwrap()
+                resolved
+                    .proj_name
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_PROJ_NAME.to_string())
             );
         } else if !subcmd_args.is_present(VALUES_FLAG) {
             let list = details


### PR DESCRIPTION
I unsuccessfully tried to simplify the code (only filling in the default project/environment in the `resolve_ids()` function, but that yielded some strange results in the integration tests that I did not feel like chasing down.

I also looked for other cases where this might be an issue, and could not find any.