### PR TITLE
Fix 'param del' failure message

### DIFF
--- a/client/docs/ProjectsApi.md
+++ b/client/docs/ProjectsApi.md
@@ -188,7 +188,7 @@ Name | Type | Description  | Required | Notes
 
 ## projects_parameters_destroy
 
-> crate::models::Parameter projects_parameters_destroy(id, project_pk)
+> projects_parameters_destroy(id, project_pk)
 
 
 ### Parameters
@@ -201,7 +201,7 @@ Name | Type | Description  | Required | Notes
 
 ### Return type
 
-[**crate::models::Parameter**](Parameter.md)
+ (empty response body)
 
 ### Authorization
 
@@ -210,7 +210,7 @@ Name | Type | Description  | Required | Notes
 ### HTTP request headers
 
 - **Content-Type**: Not defined
-- **Accept**: application/json
+- **Accept**: Not defined
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/client/src/apis/projects_api.rs
+++ b/client/src/apis/projects_api.rs
@@ -54,11 +54,6 @@ pub enum ProjectsParametersCreateError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum ProjectsParametersDestroyError {
-    Status400(),
-    Status404(),
-    Status422(),
-    Status415(),
-    Status507(),
     UnknownValue(serde_json::Value),
 }
 
@@ -517,7 +512,7 @@ pub fn projects_parameters_destroy(
     configuration: &configuration::Configuration,
     id: &str,
     project_pk: &str,
-) -> Result<crate::models::Parameter, Error<ProjectsParametersDestroyError>> {
+) -> Result<(), Error<ProjectsParametersDestroyError>> {
     let local_var_client = &configuration.client;
 
     let local_var_uri_str = format!(
@@ -552,7 +547,7 @@ pub fn projects_parameters_destroy(
     let local_var_content = local_var_resp.text()?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        serde_json::from_str(&remove_null_values(&local_var_content)).map_err(Error::from)
+        Ok(())
     } else {
         let local_var_entity: Option<ProjectsParametersDestroyError> =
             serde_json::from_str(&local_var_content).ok();

--- a/openapi.yml
+++ b/openapi.yml
@@ -2190,29 +2190,8 @@ paths:
       - JWTAuth: []
       - ApiKeyAuth: []
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Parameter'
-          description: ''
-        '400':
-          description: While checking pre-conditions, a dynamic value was encountered
-            that could not be resolved.
-        '404':
-          description: While checking pre-conditions, a dynamic value was encountered
-            that could not be resolved.
-        '422':
-          description: 'A pre-condition to modifying the `secret` setting of the parameter
-            failed, for example setting `secret: false` and having a dynamic value
-            that resolves to a value that is a secret.  In this case it would be unsafe
-            to allow the `secret` setting to change.'
-        '415':
-          description: While checking pre-conditions, a dynamic value was encountered
-            that has an invalid content type.
-        '507':
-          description: While checking pre-conditions, a dynamic value was encountered
-            that was too large to process.
+        '204':
+          description: No response body
   /api/v1/projects/{project_pk}/template-preview/:
     post:
       operationId: projects_template_preview_create

--- a/patch_client.py
+++ b/patch_client.py
@@ -147,6 +147,11 @@ def add_remove_null_call(content: str, func_name: str) -> str:
         "serde_json::from_str(&remove_null_values(&local_var_content)).map_err(Error::from)",
         1,
     )
+
+    # this insures we're not trying to change something that does not exist
+    if "remove_null_values" not in new_func:
+        raise Exception(f"Did not find 'remove_null_values()' call in {func_name}" )
+
     if orig_func != new_func:
         print(f"Updating {func_name} with call to 'remove_null_values()'")
     return content.replace(orig_func, new_func)
@@ -185,7 +190,6 @@ def parameter_null_fix(client_dir: str) -> None:
     temp = add_function(filename, temp, "remove_null_value()", REMOVE_NULL_FUNCTION)
     for function in (
         "projects_parameters_create",
-        "projects_parameters_destroy",
         "projects_parameters_list",
         "projects_parameters_partial_update",
         "projects_parameters_retrieve",

--- a/tests/pytest/test_parameters.py
+++ b/tests/pytest/test_parameters.py
@@ -121,6 +121,7 @@ my_param,cRaZy value,default,static,false,this is just a test description
         # delete the parameter
         result = self.run_cli(cmd_env, sub_cmd + f"delete {key1}")
         self.assertEqual(result.return_value, 0)
+        self.assertIn(f"Successfully removed parameter '{key1}'", result.out())
 
         # make sure it is gone
         result = self.run_cli(cmd_env, sub_cmd + "list --values --secrets")
@@ -266,6 +267,7 @@ my_param,super-SENSITIVE-vAluE,default,static,true,my secret value
         # delete the parameter
         result = self.run_cli(cmd_env, sub_cmd + f"delete {key1}")
         self.assertEqual(result.return_value, 0)
+        self.assertIn(f"Successfully removed parameter '{key1}'", result.out())
 
         # make sure it is gone
         result = self.run_cli(cmd_env, sub_cmd + "list --values --secrets")


### PR DESCRIPTION
This aligns the OpenApi spec with what is returned by `projects_parameters_destroy()`

Updated the client patch to not update the destroy method with the code to `remove_null_values()` call.

Updated testing to check the output on delete for both normal and secret parameters.