### PR TITLE
Deprecate support for CT_API_KEY

### DIFF
--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,7 +1,5 @@
 use crate::config::profiles::Profile;
-use crate::config::{
-    CT_API_KEY, CT_ENVIRONMENT, CT_OLD_API_KEY, CT_PROJECT, CT_REQ_TIMEOUT, CT_SERVER_URL,
-};
+use crate::config::{CT_API_KEY, CT_ENVIRONMENT, CT_PROJECT, CT_REQ_TIMEOUT, CT_SERVER_URL};
 use std::env;
 
 pub struct ConfigEnv {}
@@ -9,8 +7,7 @@ pub struct ConfigEnv {}
 impl ConfigEnv {
     pub(crate) fn load_profile() -> Profile {
         Profile {
-            api_key: ConfigEnv::get_override(CT_API_KEY)
-                .or_else(|| ConfigEnv::get_override(CT_OLD_API_KEY)),
+            api_key: ConfigEnv::get_override(CT_API_KEY),
             description: None,
             environment: ConfigEnv::get_override(CT_ENVIRONMENT),
             project: ConfigEnv::get_override(CT_PROJECT),
@@ -49,7 +46,6 @@ mod tests {
     fn remove_env_vars() {
         env::remove_var(CT_API_KEY);
         env::remove_var(CT_ENVIRONMENT);
-        env::remove_var(CT_OLD_API_KEY);
         env::remove_var(CT_PROJECT);
         env::remove_var(CT_REQ_TIMEOUT);
         env::remove_var(CT_SERVER_URL);
@@ -84,55 +80,6 @@ mod tests {
                 environment: Some("my_environment".to_string()),
                 project: Some("skunkworks".to_string()),
                 request_timeout: Some(500),
-                server_url: Some("http://localhost:7001/graphql".to_string()),
-                source_profile: None
-            },
-            ConfigEnv::load_profile()
-        );
-    }
-
-    #[test]
-    #[serial]
-    fn create_profile_new_env_takes_precedence() {
-        remove_env_vars();
-        env::set_var(CT_API_KEY, "new_key");
-        env::set_var(CT_ENVIRONMENT, "my_env");
-        env::set_var(CT_OLD_API_KEY, "old_key");
-        env::set_var(CT_PROJECT, "skunkworks");
-        env::set_var(CT_REQ_TIMEOUT, "10");
-        env::set_var(CT_SERVER_URL, "http://localhost:7001/graphql");
-
-        assert_eq!(
-            Profile {
-                api_key: Some("new_key".to_string()),
-                description: None,
-                environment: Some("my_env".to_string()),
-                project: Some("skunkworks".to_string()),
-                request_timeout: Some(10),
-                server_url: Some("http://localhost:7001/graphql".to_string()),
-                source_profile: None
-            },
-            ConfigEnv::load_profile()
-        );
-    }
-
-    #[test]
-    #[serial]
-    fn create_profile_from_old_env() {
-        remove_env_vars();
-        env::set_var(CT_ENVIRONMENT, "my_environ");
-        env::set_var(CT_PROJECT, "skunkworks");
-        env::set_var(CT_OLD_API_KEY, "old_key");
-        env::set_var(CT_REQ_TIMEOUT, "28");
-        env::set_var(CT_SERVER_URL, "http://localhost:7001/graphql");
-
-        assert_eq!(
-            Profile {
-                api_key: Some("old_key".to_string()),
-                description: None,
-                environment: Some("my_environ".to_string()),
-                project: Some("skunkworks".to_string()),
-                request_timeout: Some(28),
                 server_url: Some("http://localhost:7001/graphql".to_string()),
                 source_profile: None
             },

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -32,8 +32,7 @@ pub const DEFAULT_ENV_NAME: &str = "default";
 pub const DEFAULT_PROF_NAME: &str = "default";
 
 /*************************************************************************
- Environment variables.
- All should start with (CLOUDTRUTH_xxx), with the exception of the old API key.
+ Environment variables - all should start with (CLOUDTRUTH_).
 ************************************************************************/
 /// Environment variable name used to specify the CloudTruth API value, so it does not need to be
 /// specified on the command line.

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,7 +90,7 @@ fn help_message(message: String) -> Result<()> {
 /// Insures the configuration is valid.
 ///
 /// If there are errors, it will print the error/help and exit.
-/// If only warnings happen (e.g. using old API key name), it will print the warning and keep going.
+/// If only warnings happen, it will print the warning and keep going.
 fn check_config() -> Result<()> {
     if let Some(issues) = Config::global().validate() {
         // print the warnings first, so the user sees them (even when errors are present)
@@ -934,7 +934,7 @@ fn main() -> Result<()> {
 #[cfg(test)]
 mod main_test {
     use crate::cli;
-    use crate::config::{CT_API_KEY, CT_OLD_API_KEY, CT_SERVER_URL};
+    use crate::config::{CT_API_KEY, CT_SERVER_URL};
     use assert_cmd::prelude::*;
     use predicates::prelude::predicate::str::*;
     use std::process::Command;
@@ -1004,7 +1004,6 @@ mod main_test {
             println!("need_api_key test: {}", cmd_args.join(" "));
             let mut cmd = cmd();
             cmd.env(CT_API_KEY, "")
-                .env(CT_OLD_API_KEY, "")
                 .args(cmd_args)
                 .assert()
                 .failure()


### PR DESCRIPTION
This deprecates the old option, and the user must use the CLOUDTRUTH_API_KEY to set the API key via an environment variable.