### PR TITLE
Add 'config current' to show where CLI parameters are coming from

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,6 +93,14 @@ pub fn build_cli() -> App<'static, 'static> {
                     .arg(table_format_options().help("Display profile value info format"))
                     .arg(secrets_display_flag().help("Display API key values"))
                     .about("List CloudTruth profiles in the local config file"),
+                SubCommand::with_name("current")
+                    .arg(table_format_options().help("Display table format"))
+                    .arg(secrets_display_flag().help("Display API key values"))
+                    .arg( Arg::with_name("extended")
+                        .hidden(true)
+                        .short("x").
+                        help("Show extended values"))
+                    .about("Show the current arguments and their sources.")
                 ])
         )
         .subcommand(

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -13,12 +13,16 @@ pub struct Profile {
 }
 
 // TODO: Rick Porter 4/21, fix this so don't have to udpate when Profile is updated
+#[derive(Clone, Debug)]
 pub struct ProfileDetails {
     pub api_key: Option<String>,
     pub description: Option<String>,
     pub environment: Option<String>,
     pub name: String,
     pub project: Option<String>,
+    pub parent: Option<String>,
+    pub server_url: Option<String>,
+    pub request_timeout: Option<String>,
 }
 
 impl Default for Profile {

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -50,9 +50,24 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    edit    Edit your configuration data for this application
-    help    Prints this message or the help of the given subcommand(s)
-    list    List CloudTruth profiles in the local config file [aliases: ls]
+    current    Show the current arguments and their sources.
+    edit       Edit your configuration data for this application
+    help       Prints this message or the help of the given subcommand(s)
+    list       List CloudTruth profiles in the local config file [aliases: ls]
+========================================
+cloudtruth-config-current 
+Show the current arguments and their sources.
+
+USAGE:
+    cloudtruth config current [FLAGS] [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -s, --secrets    Display API key values
+    -V, --version    Prints version information
+
+OPTIONS:
+    -f, --format <format>    Display table format [default: table]  [possible values: table, csv, json, yaml]
 ========================================
 cloudtruth-config-edit 
 Edit your configuration data for this application

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -18,12 +18,18 @@ CT_TIMEOUT = "CLOUDTRUTH_REQUEST_TIMEOUT"
 
 DEFAULT_SERVER_URL = "https://api.cloudtruth.io"
 DEFAULT_ENV_NAME = "default"
+DEFAULT_PROFILE_NAME = "default"
 
 AUTO_DESCRIPTION = "Automated testing via live_test"
 
 CT_TEST_LOG_COMMANDS = "CT_LIVE_TEST_LOG_COMMANDS"
 CT_TEST_LOG_OUTPUT = "CT_LIVE_TEST_LOG_OUTPUT"
 CT_TEST_JOB_ID = "CT_LIVE_TEST_JOB_ID"
+
+SRC_ENV = "shell"
+SRC_ARG = "argument"
+SRC_PROFILE = "profile"
+SRC_DEFAULT = "default"
 
 
 @dataclasses.dataclass


### PR DESCRIPTION
Example outputs:
```
(new-host-3):~/cloudtruth-cli $ target/debug/cloudtruth config current 
+-------------+----------------+-----------------+
| Parameter   | Value          | Source          |
+-------------+----------------+-----------------+
| Profile     | local          | shell           |
| API key     | ********       | profile (local) |
| Project     | MyFirstProject | profile (local) |
| Environment | default        | default         |
+-------------+----------------+-----------------+
(new-host-3):~/cloudtruth-cli $ target/debug/cloudtruth --profile stage config current -x
+-----------------+------------------------------------+-----------------+
| Parameter       | Value                              | Source          |
+-----------------+------------------------------------+-----------------+
| Profile         | stage                              | argument        |
| API key         | ********                           | profile (stage) |
| Project         |                                    |                 |
| Environment     | default                            | default         |
| Server URL      | https://api.staging.cloudtruth.io/ | profile (stage) |
| Request timeout | 30                                 | default         |
+-----------------+------------------------------------+-----------------+
(new-host-3):~/cloudtruth-cli $ 

```