### PR TITLE
Add cookies to API requests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ clean:
 	rm -rf client/target/
 
 # client needs to re-generated when the openapi.yaml changes
-client: openapi.yml
+client: openapi.yml patch_client.py
 	docker run --rm \
 		-v "$(shell pwd):/local" \
 		--user "$(shell id -u):$(shell id -g)" \

--- a/client/src/apis/api_api.rs
+++ b/client/src/apis/api_api.rs
@@ -22,7 +22,7 @@ pub enum ApiSchemaRetrieveError {
 
 /// OpenApi3 schema for this API. Format can be selected via content negotiation.  - YAML: application/vnd.oai.openapi - JSON: application/vnd.oai.openapi+json
 pub fn api_schema_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     format: Option<&str>,
     lang: Option<&str>,
 ) -> Result<::std::collections::HashMap<String, serde_json::Value>, Error<ApiSchemaRetrieveError>> {
@@ -49,6 +49,11 @@ pub fn api_schema_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/api_api.rs
+++ b/client/src/apis/api_api.rs
@@ -22,7 +22,7 @@ pub enum ApiSchemaRetrieveError {
 
 /// OpenApi3 schema for this API. Format can be selected via content negotiation.  - YAML: application/vnd.oai.openapi - JSON: application/vnd.oai.openapi+json
 pub fn api_schema_retrieve(
-    configuration: &mut configuration::Configuration,
+    configuration: &configuration::Configuration,
     format: Option<&str>,
     lang: Option<&str>,
 ) -> Result<::std::collections::HashMap<String, serde_json::Value>, Error<ApiSchemaRetrieveError>> {
@@ -49,11 +49,6 @@ pub fn api_schema_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
-    if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
-            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
-        }
-    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/audit_api.rs
+++ b/client/src/apis/audit_api.rs
@@ -36,7 +36,7 @@ pub enum AuditSummaryRetrieveError {
 
 /// A searchable log of all the actions taken by users and service accounts within the organization.
 pub fn audit_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     action: Option<&str>,
     earliest: Option<String>,
     latest: Option<String>,
@@ -103,6 +103,11 @@ pub fn audit_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -120,7 +125,7 @@ pub fn audit_list(
 
 /// Retrieve one record from the audit log.
 pub fn audit_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::AuditTrail, Error<AuditRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -153,6 +158,11 @@ pub fn audit_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -170,7 +180,7 @@ pub fn audit_retrieve(
 
 /// Summary information about the organization's audit trail.
 pub fn audit_summary_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
 ) -> Result<crate::models::AuditTrailSummary, Error<AuditSummaryRetrieveError>> {
     let local_var_client = &configuration.client;
 
@@ -202,6 +212,11 @@ pub fn audit_summary_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/audit_api.rs
+++ b/client/src/apis/audit_api.rs
@@ -94,6 +94,9 @@ pub fn audit_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -141,6 +144,9 @@ pub fn audit_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -187,6 +193,9 @@ pub fn audit_summary_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;

--- a/client/src/apis/audit_api.rs
+++ b/client/src/apis/audit_api.rs
@@ -95,7 +95,8 @@ pub fn audit_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -104,7 +105,7 @@ pub fn audit_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -150,7 +151,8 @@ pub fn audit_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -159,7 +161,7 @@ pub fn audit_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -204,7 +206,8 @@ pub fn audit_summary_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -213,7 +216,7 @@ pub fn audit_summary_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/client/src/apis/configuration.rs
+++ b/client/src/apis/configuration.rs
@@ -19,6 +19,7 @@ pub struct Configuration {
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub cookie: Option<String>,
     // TODO: take an oauth2 token source, similar to the go one
 }
 
@@ -46,6 +47,7 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+            cookie: None,
         }
     }
 }

--- a/client/src/apis/environments_api.rs
+++ b/client/src/apis/environments_api.rs
@@ -81,6 +81,9 @@ pub fn environments_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&environment_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -132,6 +135,9 @@ pub fn environments_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -192,6 +198,9 @@ pub fn environments_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -243,6 +252,9 @@ pub fn environments_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_environment);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -294,6 +306,9 @@ pub fn environments_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -345,6 +360,9 @@ pub fn environments_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&environment);
 
     let local_var_req = local_var_req_builder.build()?;

--- a/client/src/apis/environments_api.rs
+++ b/client/src/apis/environments_api.rs
@@ -82,7 +82,8 @@ pub fn environments_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&environment_create);
 
@@ -92,7 +93,7 @@ pub fn environments_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -141,7 +142,8 @@ pub fn environments_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -150,7 +152,7 @@ pub fn environments_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -209,7 +211,8 @@ pub fn environments_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -218,7 +221,7 @@ pub fn environments_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -268,7 +271,8 @@ pub fn environments_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_environment);
 
@@ -278,7 +282,7 @@ pub fn environments_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -327,7 +331,8 @@ pub fn environments_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -336,7 +341,7 @@ pub fn environments_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -386,7 +391,8 @@ pub fn environments_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&environment);
 
@@ -396,7 +402,7 @@ pub fn environments_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/client/src/apis/environments_api.rs
+++ b/client/src/apis/environments_api.rs
@@ -57,7 +57,7 @@ pub enum EnvironmentsUpdateError {
 }
 
 pub fn environments_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     environment_create: crate::models::EnvironmentCreate,
 ) -> Result<crate::models::Environment, Error<EnvironmentsCreateError>> {
     let local_var_client = &configuration.client;
@@ -91,6 +91,11 @@ pub fn environments_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -107,7 +112,7 @@ pub fn environments_create(
 }
 
 pub fn environments_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<(), Error<EnvironmentsDestroyError>> {
     let local_var_client = &configuration.client;
@@ -144,6 +149,11 @@ pub fn environments_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -160,7 +170,7 @@ pub fn environments_destroy(
 }
 
 pub fn environments_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     name: Option<&str>,
     page: Option<i32>,
     parent__name: Option<&str>,
@@ -207,6 +217,11 @@ pub fn environments_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -223,7 +238,7 @@ pub fn environments_list(
 }
 
 pub fn environments_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     patched_environment: Option<crate::models::PatchedEnvironment>,
 ) -> Result<crate::models::Environment, Error<EnvironmentsPartialUpdateError>> {
@@ -262,6 +277,11 @@ pub fn environments_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -278,7 +298,7 @@ pub fn environments_partial_update(
 }
 
 pub fn environments_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::Environment, Error<EnvironmentsRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -315,6 +335,11 @@ pub fn environments_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -331,7 +356,7 @@ pub fn environments_retrieve(
 }
 
 pub fn environments_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     environment: crate::models::Environment,
 ) -> Result<crate::models::Environment, Error<EnvironmentsUpdateError>> {
@@ -370,6 +395,11 @@ pub fn environments_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/integrations_api.rs
+++ b/client/src/apis/integrations_api.rs
@@ -120,6 +120,9 @@ pub fn integrations_aws_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&aws_integration_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -171,6 +174,9 @@ pub fn integrations_aws_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -231,6 +237,9 @@ pub fn integrations_aws_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -282,6 +291,9 @@ pub fn integrations_aws_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_aws_integration);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -338,6 +350,9 @@ pub fn integrations_aws_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -389,6 +404,9 @@ pub fn integrations_aws_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&aws_integration);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -445,6 +463,9 @@ pub fn integrations_explore_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -492,6 +513,9 @@ pub fn integrations_github_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&git_hub_integration_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -543,6 +567,9 @@ pub fn integrations_github_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -598,6 +625,9 @@ pub fn integrations_github_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -653,6 +683,9 @@ pub fn integrations_github_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;

--- a/client/src/apis/integrations_api.rs
+++ b/client/src/apis/integrations_api.rs
@@ -96,7 +96,7 @@ pub enum IntegrationsGithubRetrieveError {
 
 /// ### Description ###  Establishes an AWS Integration for your CloudTruth organization.  ### Pre-Conditions ###  - An AWS Integration for the account and role cannot already exist. ### Post-Conditions ###  - You must establish an IAM role and trust relationship based on the Role Name and the External ID.
 pub fn integrations_aws_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     aws_integration_create: crate::models::AwsIntegrationCreate,
 ) -> Result<crate::models::AwsIntegration, Error<IntegrationsAwsCreateError>> {
     let local_var_client = &configuration.client;
@@ -130,6 +130,11 @@ pub fn integrations_aws_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -146,7 +151,7 @@ pub fn integrations_aws_create(
 }
 
 pub fn integrations_aws_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<(), Error<IntegrationsAwsDestroyError>> {
     let local_var_client = &configuration.client;
@@ -183,6 +188,11 @@ pub fn integrations_aws_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -199,7 +209,7 @@ pub fn integrations_aws_destroy(
 }
 
 pub fn integrations_aws_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     aws_account_id: Option<&str>,
     aws_role_name: Option<&str>,
     page: Option<i32>,
@@ -246,6 +256,11 @@ pub fn integrations_aws_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -262,7 +277,7 @@ pub fn integrations_aws_list(
 }
 
 pub fn integrations_aws_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     patched_aws_integration: Option<crate::models::PatchedAwsIntegration>,
 ) -> Result<crate::models::AwsIntegration, Error<IntegrationsAwsPartialUpdateError>> {
@@ -301,6 +316,11 @@ pub fn integrations_aws_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -317,7 +337,7 @@ pub fn integrations_aws_partial_update(
 }
 
 pub fn integrations_aws_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     refresh_status: Option<bool>,
 ) -> Result<crate::models::AwsIntegration, Error<IntegrationsAwsRetrieveError>> {
@@ -359,6 +379,11 @@ pub fn integrations_aws_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -375,7 +400,7 @@ pub fn integrations_aws_retrieve(
 }
 
 pub fn integrations_aws_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     aws_integration: crate::models::AwsIntegration,
 ) -> Result<crate::models::AwsIntegration, Error<IntegrationsAwsUpdateError>> {
@@ -414,6 +439,11 @@ pub fn integrations_aws_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -431,7 +461,7 @@ pub fn integrations_aws_update(
 
 /// ### Description ###  Queries a third-party integration to retrieve the data specified by the FQN.  You can start exploring by not specifying an 'fqn', which will return a list of FQNs for the existing third-party integrations. Third-party integrations can be configured via the Integrations section of the web application.
 pub fn integrations_explore_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     fqn: Option<&str>,
     page: Option<i32>,
 ) -> Result<crate::models::PaginatedIntegrationExplorerList, Error<IntegrationsExploreListError>> {
@@ -472,6 +502,11 @@ pub fn integrations_explore_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -489,7 +524,7 @@ pub fn integrations_explore_list(
 
 /// ### Description ###  Establishes a GitHub Integration in your CloudTruth organization.  ### Pre-Conditions ###  - The user must be an Administrator or Owner of your organization. - A GitHub Integration with the `installation_id` cannot  already exist in this organization. - The user must first install the CloudTruth GitHub Application in  their GitHub organization and obtain the `installation_id` of the  application in order to create the integration.  ### Initiating the GitHub Application Installation ###  - Go to `https://github.com/apps/GITHUB_APP_NAME/installations/new?state=<bearer_token>` - On successful installation the browser will return to  `https://APP_URL/app_setup/github` (configured in ctops/bin/github*)  and provide the `installation_id` in the URI. - POST to this api to verify and establish the integration.
 pub fn integrations_github_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     git_hub_integration_create: crate::models::GitHubIntegrationCreate,
 ) -> Result<crate::models::GitHubIntegration, Error<IntegrationsGithubCreateError>> {
     let local_var_client = &configuration.client;
@@ -523,6 +558,11 @@ pub fn integrations_github_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -539,7 +579,7 @@ pub fn integrations_github_create(
 }
 
 pub fn integrations_github_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<(), Error<IntegrationsGithubDestroyError>> {
     let local_var_client = &configuration.client;
@@ -576,6 +616,11 @@ pub fn integrations_github_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -592,7 +637,7 @@ pub fn integrations_github_destroy(
 }
 
 pub fn integrations_github_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     gh_organization_slug: Option<&str>,
     page: Option<i32>,
 ) -> Result<crate::models::PaginatedGitHubIntegrationList, Error<IntegrationsGithubListError>> {
@@ -634,6 +679,11 @@ pub fn integrations_github_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -650,7 +700,7 @@ pub fn integrations_github_list(
 }
 
 pub fn integrations_github_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     refresh_status: Option<bool>,
 ) -> Result<crate::models::GitHubIntegration, Error<IntegrationsGithubRetrieveError>> {
@@ -692,6 +742,11 @@ pub fn integrations_github_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/integrations_api.rs
+++ b/client/src/apis/integrations_api.rs
@@ -121,7 +121,8 @@ pub fn integrations_aws_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&aws_integration_create);
 
@@ -131,7 +132,7 @@ pub fn integrations_aws_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -180,7 +181,8 @@ pub fn integrations_aws_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -189,7 +191,7 @@ pub fn integrations_aws_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -248,7 +250,8 @@ pub fn integrations_aws_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -257,7 +260,7 @@ pub fn integrations_aws_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -307,7 +310,8 @@ pub fn integrations_aws_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_aws_integration);
 
@@ -317,7 +321,7 @@ pub fn integrations_aws_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -371,7 +375,8 @@ pub fn integrations_aws_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -380,7 +385,7 @@ pub fn integrations_aws_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -430,7 +435,8 @@ pub fn integrations_aws_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&aws_integration);
 
@@ -440,7 +446,7 @@ pub fn integrations_aws_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -494,7 +500,8 @@ pub fn integrations_explore_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -503,7 +510,7 @@ pub fn integrations_explore_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -549,7 +556,8 @@ pub fn integrations_github_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&git_hub_integration_create);
 
@@ -559,7 +567,7 @@ pub fn integrations_github_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -608,7 +616,8 @@ pub fn integrations_github_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -617,7 +626,7 @@ pub fn integrations_github_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -671,7 +680,8 @@ pub fn integrations_github_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -680,7 +690,7 @@ pub fn integrations_github_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -734,7 +744,8 @@ pub fn integrations_github_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -743,7 +754,7 @@ pub fn integrations_github_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/client/src/apis/invitations_api.rs
+++ b/client/src/apis/invitations_api.rs
@@ -76,7 +76,7 @@ pub enum InvitationsUpdateError {
 
 /// Accept an invitation to join an organization.  The email address used to log in and accept the invitation must match the email address specified by the inviting user when creating the invitation.  On success the client receives the invitation record as it was updated. The client should then regenerate the JWT with the organization scope and proceed to the default landing page.
 pub fn invitations_accept_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::Invitation, Error<InvitationsAcceptCreateError>> {
     let local_var_client = &configuration.client;
@@ -113,6 +113,11 @@ pub fn invitations_accept_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -130,7 +135,7 @@ pub fn invitations_accept_create(
 
 /// Extend an invitation for someone else to join your organization.
 pub fn invitations_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     invitation_create: crate::models::InvitationCreate,
 ) -> Result<crate::models::Invitation, Error<InvitationsCreateError>> {
     let local_var_client = &configuration.client;
@@ -164,6 +169,11 @@ pub fn invitations_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -180,7 +190,7 @@ pub fn invitations_create(
 }
 
 pub fn invitations_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<(), Error<InvitationsDestroyError>> {
     let local_var_client = &configuration.client;
@@ -217,6 +227,11 @@ pub fn invitations_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -233,7 +248,7 @@ pub fn invitations_destroy(
 }
 
 pub fn invitations_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     email: Option<&str>,
     page: Option<i32>,
     role: Option<&str>,
@@ -285,6 +300,11 @@ pub fn invitations_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -301,7 +321,7 @@ pub fn invitations_list(
 }
 
 pub fn invitations_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     patched_invitation: Option<crate::models::PatchedInvitation>,
 ) -> Result<crate::models::Invitation, Error<InvitationsPartialUpdateError>> {
@@ -340,6 +360,11 @@ pub fn invitations_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -357,7 +382,7 @@ pub fn invitations_partial_update(
 
 /// Re-send an invitation to the recipient.
 pub fn invitations_resend_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::Invitation, Error<InvitationsResendCreateError>> {
     let local_var_client = &configuration.client;
@@ -394,6 +419,11 @@ pub fn invitations_resend_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -410,7 +440,7 @@ pub fn invitations_resend_create(
 }
 
 pub fn invitations_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::Invitation, Error<InvitationsRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -447,6 +477,11 @@ pub fn invitations_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -463,7 +498,7 @@ pub fn invitations_retrieve(
 }
 
 pub fn invitations_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     invitation: crate::models::Invitation,
 ) -> Result<crate::models::Invitation, Error<InvitationsUpdateError>> {
@@ -502,6 +537,11 @@ pub fn invitations_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/invitations_api.rs
+++ b/client/src/apis/invitations_api.rs
@@ -104,6 +104,9 @@ pub fn invitations_accept_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -151,6 +154,9 @@ pub fn invitations_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&invitation_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -202,6 +208,9 @@ pub fn invitations_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -267,6 +276,9 @@ pub fn invitations_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -318,6 +330,9 @@ pub fn invitations_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_invitation);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -370,6 +385,9 @@ pub fn invitations_resend_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -420,6 +438,9 @@ pub fn invitations_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -471,6 +492,9 @@ pub fn invitations_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&invitation);
 
     let local_var_req = local_var_req_builder.build()?;

--- a/client/src/apis/invitations_api.rs
+++ b/client/src/apis/invitations_api.rs
@@ -105,7 +105,8 @@ pub fn invitations_accept_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -114,7 +115,7 @@ pub fn invitations_accept_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -160,7 +161,8 @@ pub fn invitations_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&invitation_create);
 
@@ -170,7 +172,7 @@ pub fn invitations_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -219,7 +221,8 @@ pub fn invitations_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -228,7 +231,7 @@ pub fn invitations_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -292,7 +295,8 @@ pub fn invitations_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -301,7 +305,7 @@ pub fn invitations_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -351,7 +355,8 @@ pub fn invitations_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_invitation);
 
@@ -361,7 +366,7 @@ pub fn invitations_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -411,7 +416,8 @@ pub fn invitations_resend_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -420,7 +426,7 @@ pub fn invitations_resend_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -469,7 +475,8 @@ pub fn invitations_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -478,7 +485,7 @@ pub fn invitations_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -528,7 +535,8 @@ pub fn invitations_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&invitation);
 
@@ -538,7 +546,7 @@ pub fn invitations_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/client/src/apis/memberships_api.rs
+++ b/client/src/apis/memberships_api.rs
@@ -56,7 +56,7 @@ pub enum MembershipsUpdateError {
 }
 
 pub fn memberships_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     membership_create: crate::models::MembershipCreate,
 ) -> Result<crate::models::Membership, Error<MembershipsCreateError>> {
     let local_var_client = &configuration.client;
@@ -90,6 +90,11 @@ pub fn memberships_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -106,7 +111,7 @@ pub fn memberships_create(
 }
 
 pub fn memberships_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<(), Error<MembershipsDestroyError>> {
     let local_var_client = &configuration.client;
@@ -143,6 +148,11 @@ pub fn memberships_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -159,7 +169,7 @@ pub fn memberships_destroy(
 }
 
 pub fn memberships_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     page: Option<i32>,
     role: Option<&str>,
     user: Option<&str>,
@@ -206,6 +216,11 @@ pub fn memberships_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -222,7 +237,7 @@ pub fn memberships_list(
 }
 
 pub fn memberships_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     patched_membership: Option<crate::models::PatchedMembership>,
 ) -> Result<crate::models::Membership, Error<MembershipsPartialUpdateError>> {
@@ -261,6 +276,11 @@ pub fn memberships_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -277,7 +297,7 @@ pub fn memberships_partial_update(
 }
 
 pub fn memberships_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::Membership, Error<MembershipsRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -314,6 +334,11 @@ pub fn memberships_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -330,7 +355,7 @@ pub fn memberships_retrieve(
 }
 
 pub fn memberships_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     membership: crate::models::Membership,
 ) -> Result<crate::models::Membership, Error<MembershipsUpdateError>> {
@@ -369,6 +394,11 @@ pub fn memberships_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/memberships_api.rs
+++ b/client/src/apis/memberships_api.rs
@@ -81,7 +81,8 @@ pub fn memberships_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&membership_create);
 
@@ -91,7 +92,7 @@ pub fn memberships_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -140,7 +141,8 @@ pub fn memberships_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -149,7 +151,7 @@ pub fn memberships_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -208,7 +210,8 @@ pub fn memberships_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -217,7 +220,7 @@ pub fn memberships_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -267,7 +270,8 @@ pub fn memberships_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_membership);
 
@@ -277,7 +281,7 @@ pub fn memberships_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -326,7 +330,8 @@ pub fn memberships_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -335,7 +340,7 @@ pub fn memberships_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -385,7 +390,8 @@ pub fn memberships_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&membership);
 
@@ -395,7 +401,7 @@ pub fn memberships_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/client/src/apis/memberships_api.rs
+++ b/client/src/apis/memberships_api.rs
@@ -80,6 +80,9 @@ pub fn memberships_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&membership_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -131,6 +134,9 @@ pub fn memberships_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -191,6 +197,9 @@ pub fn memberships_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -242,6 +251,9 @@ pub fn memberships_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_membership);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -293,6 +305,9 @@ pub fn memberships_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -344,6 +359,9 @@ pub fn memberships_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&membership);
 
     let local_var_req = local_var_req_builder.build()?;

--- a/client/src/apis/organizations_api.rs
+++ b/client/src/apis/organizations_api.rs
@@ -81,7 +81,8 @@ pub fn organizations_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&organization_create);
 
@@ -91,7 +92,7 @@ pub fn organizations_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -140,7 +141,8 @@ pub fn organizations_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -149,7 +151,7 @@ pub fn organizations_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -203,7 +205,8 @@ pub fn organizations_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -212,7 +215,7 @@ pub fn organizations_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -262,7 +265,8 @@ pub fn organizations_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_organization);
 
@@ -272,7 +276,7 @@ pub fn organizations_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -321,7 +325,8 @@ pub fn organizations_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -330,7 +335,7 @@ pub fn organizations_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -380,7 +385,8 @@ pub fn organizations_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&organization);
 
@@ -390,7 +396,7 @@ pub fn organizations_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/client/src/apis/organizations_api.rs
+++ b/client/src/apis/organizations_api.rs
@@ -80,6 +80,9 @@ pub fn organizations_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&organization_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -131,6 +134,9 @@ pub fn organizations_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -186,6 +192,9 @@ pub fn organizations_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -237,6 +246,9 @@ pub fn organizations_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_organization);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -288,6 +300,9 @@ pub fn organizations_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -339,6 +354,9 @@ pub fn organizations_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&organization);
 
     let local_var_req = local_var_req_builder.build()?;

--- a/client/src/apis/organizations_api.rs
+++ b/client/src/apis/organizations_api.rs
@@ -56,7 +56,7 @@ pub enum OrganizationsUpdateError {
 }
 
 pub fn organizations_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     organization_create: crate::models::OrganizationCreate,
 ) -> Result<crate::models::Organization, Error<OrganizationsCreateError>> {
     let local_var_client = &configuration.client;
@@ -90,6 +90,11 @@ pub fn organizations_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -106,7 +111,7 @@ pub fn organizations_create(
 }
 
 pub fn organizations_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<(), Error<OrganizationsDestroyError>> {
     let local_var_client = &configuration.client;
@@ -143,6 +148,11 @@ pub fn organizations_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -159,7 +169,7 @@ pub fn organizations_destroy(
 }
 
 pub fn organizations_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     name: Option<&str>,
     page: Option<i32>,
 ) -> Result<crate::models::PaginatedOrganizationList, Error<OrganizationsListError>> {
@@ -201,6 +211,11 @@ pub fn organizations_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -217,7 +232,7 @@ pub fn organizations_list(
 }
 
 pub fn organizations_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     patched_organization: Option<crate::models::PatchedOrganization>,
 ) -> Result<crate::models::Organization, Error<OrganizationsPartialUpdateError>> {
@@ -256,6 +271,11 @@ pub fn organizations_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -272,7 +292,7 @@ pub fn organizations_partial_update(
 }
 
 pub fn organizations_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::Organization, Error<OrganizationsRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -309,6 +329,11 @@ pub fn organizations_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -325,7 +350,7 @@ pub fn organizations_retrieve(
 }
 
 pub fn organizations_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     organization: crate::models::Organization,
 ) -> Result<crate::models::Organization, Error<OrganizationsUpdateError>> {
@@ -364,6 +389,11 @@ pub fn organizations_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/projects_api.rs
+++ b/client/src/apis/projects_api.rs
@@ -237,6 +237,9 @@ pub fn projects_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&project_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -284,6 +287,9 @@ pub fn projects_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -339,6 +345,9 @@ pub fn projects_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -435,6 +444,9 @@ pub fn projects_parameter_export_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -486,6 +498,9 @@ pub fn projects_parameters_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&parameter_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -539,6 +554,9 @@ pub fn projects_parameters_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -614,6 +632,9 @@ pub fn projects_parameters_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -667,6 +688,9 @@ pub fn projects_parameters_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_parameter);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -735,6 +759,9 @@ pub fn projects_parameters_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -788,6 +815,9 @@ pub fn projects_parameters_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&parameter);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -848,6 +878,9 @@ pub fn projects_parameters_values_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&value_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -904,6 +937,9 @@ pub fn projects_parameters_values_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -977,6 +1013,9 @@ pub fn projects_parameters_values_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -1038,6 +1077,9 @@ pub fn projects_parameters_values_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_value);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1104,6 +1146,9 @@ pub fn projects_parameters_values_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -1165,6 +1210,9 @@ pub fn projects_parameters_values_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&value);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1213,6 +1261,9 @@ pub fn projects_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_project);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1260,6 +1311,9 @@ pub fn projects_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -1322,6 +1376,9 @@ pub fn projects_template_preview_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&template_preview);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1374,6 +1431,9 @@ pub fn projects_templates_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&template_create);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1427,6 +1487,9 @@ pub fn projects_templates_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -1487,6 +1550,9 @@ pub fn projects_templates_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -1540,6 +1606,9 @@ pub fn projects_templates_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_template);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1603,6 +1672,9 @@ pub fn projects_templates_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -1656,6 +1728,9 @@ pub fn projects_templates_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&template);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1704,6 +1779,9 @@ pub fn projects_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&project);
 
     let local_var_req = local_var_req_builder.build()?;

--- a/client/src/apis/projects_api.rs
+++ b/client/src/apis/projects_api.rs
@@ -213,7 +213,7 @@ fn remove_null_values(input: &str) -> String {
 }
 
 pub fn projects_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     project_create: crate::models::ProjectCreate,
 ) -> Result<crate::models::Project, Error<ProjectsCreateError>> {
     let local_var_client = &configuration.client;
@@ -247,6 +247,11 @@ pub fn projects_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -263,7 +268,7 @@ pub fn projects_create(
 }
 
 pub fn projects_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<(), Error<ProjectsDestroyError>> {
     let local_var_client = &configuration.client;
@@ -296,6 +301,11 @@ pub fn projects_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -312,7 +322,7 @@ pub fn projects_destroy(
 }
 
 pub fn projects_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     name: Option<&str>,
     page: Option<i32>,
 ) -> Result<crate::models::PaginatedProjectList, Error<ProjectsListError>> {
@@ -354,6 +364,11 @@ pub fn projects_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -371,7 +386,7 @@ pub fn projects_list(
 
 /// Exports all parameters in this project in the requested format.  Parameter names and values will be coerced to the proper format (e.g. for a dotenv export, my_parameter will be capitalized to MY_PARAMETER and its value will be in a quoted string).  Note that capitalization is the only name coercion that will be performed on parameter names, names that are invalid for a given format will be omitted.
 pub fn projects_parameter_export_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     project_pk: &str,
     contains: Option<&str>,
     endswith: Option<&str>,
@@ -453,6 +468,11 @@ pub fn projects_parameter_export_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -469,7 +489,7 @@ pub fn projects_parameter_export_list(
 }
 
 pub fn projects_parameters_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     project_pk: &str,
     parameter_create: crate::models::ParameterCreate,
 ) -> Result<crate::models::Parameter, Error<ProjectsParametersCreateError>> {
@@ -508,6 +528,11 @@ pub fn projects_parameters_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&remove_null_values(&local_var_content)).map_err(Error::from)
@@ -524,7 +549,7 @@ pub fn projects_parameters_create(
 }
 
 pub fn projects_parameters_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     project_pk: &str,
 ) -> Result<(), Error<ProjectsParametersDestroyError>> {
@@ -563,6 +588,11 @@ pub fn projects_parameters_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -579,7 +609,7 @@ pub fn projects_parameters_destroy(
 }
 
 pub fn projects_parameters_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     project_pk: &str,
     environment: Option<&str>,
     mask_secrets: Option<bool>,
@@ -641,6 +671,11 @@ pub fn projects_parameters_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&remove_null_values(&local_var_content)).map_err(Error::from)
@@ -657,7 +692,7 @@ pub fn projects_parameters_list(
 }
 
 pub fn projects_parameters_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     project_pk: &str,
     patched_parameter: Option<crate::models::PatchedParameter>,
@@ -698,6 +733,11 @@ pub fn projects_parameters_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&remove_null_values(&local_var_content)).map_err(Error::from)
@@ -714,7 +754,7 @@ pub fn projects_parameters_partial_update(
 }
 
 pub fn projects_parameters_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     project_pk: &str,
     environment: Option<&str>,
@@ -768,6 +808,11 @@ pub fn projects_parameters_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&remove_null_values(&local_var_content)).map_err(Error::from)
@@ -784,7 +829,7 @@ pub fn projects_parameters_retrieve(
 }
 
 pub fn projects_parameters_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     project_pk: &str,
     parameter: crate::models::Parameter,
@@ -825,6 +870,11 @@ pub fn projects_parameters_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&remove_null_values(&local_var_content)).map_err(Error::from)
@@ -842,7 +892,7 @@ pub fn projects_parameters_update(
 
 /// Set the value of a parameter in an environment.
 pub fn projects_parameters_values_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     parameter_pk: &str,
     project_pk: &str,
     value_create: crate::models::ValueCreate,
@@ -888,6 +938,11 @@ pub fn projects_parameters_values_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -905,7 +960,7 @@ pub fn projects_parameters_values_create(
 
 /// Destroy the value of a parameter in an environment.
 pub fn projects_parameters_values_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     parameter_pk: &str,
     project_pk: &str,
@@ -946,6 +1001,11 @@ pub fn projects_parameters_values_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -963,7 +1023,7 @@ pub fn projects_parameters_values_destroy(
 
 ///          Retrieve previously set values of a parameter in one or all environments.         To see all the _effective_ values for a parameter across every environment,         use the Parameters API (see the `values` field).     
 pub fn projects_parameters_values_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     parameter_pk: &str,
     project_pk: &str,
     environment: Option<&str>,
@@ -1022,6 +1082,11 @@ pub fn projects_parameters_values_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1039,7 +1104,7 @@ pub fn projects_parameters_values_list(
 
 /// Update the value of a parameter in an environment.
 pub fn projects_parameters_values_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     parameter_pk: &str,
     project_pk: &str,
@@ -1087,6 +1152,11 @@ pub fn projects_parameters_values_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1104,7 +1174,7 @@ pub fn projects_parameters_values_partial_update(
 
 /// Retrieve the value of a parameter in an environment.
 pub fn projects_parameters_values_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     parameter_pk: &str,
     project_pk: &str,
@@ -1155,6 +1225,11 @@ pub fn projects_parameters_values_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1172,7 +1247,7 @@ pub fn projects_parameters_values_retrieve(
 
 /// Update the value of a parameter in an environment.
 pub fn projects_parameters_values_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     parameter_pk: &str,
     project_pk: &str,
@@ -1220,6 +1295,11 @@ pub fn projects_parameters_values_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1236,7 +1316,7 @@ pub fn projects_parameters_values_update(
 }
 
 pub fn projects_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     patched_project: Option<crate::models::PatchedProject>,
 ) -> Result<crate::models::Project, Error<ProjectsPartialUpdateError>> {
@@ -1271,6 +1351,11 @@ pub fn projects_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1287,7 +1372,7 @@ pub fn projects_partial_update(
 }
 
 pub fn projects_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::Project, Error<ProjectsRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -1320,6 +1405,11 @@ pub fn projects_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1337,7 +1427,7 @@ pub fn projects_retrieve(
 
 /// Endpoint for previewing a template.
 pub fn projects_template_preview_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     project_pk: &str,
     template_preview: crate::models::TemplatePreview,
     environment: Option<&str>,
@@ -1386,6 +1476,11 @@ pub fn projects_template_preview_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1402,7 +1497,7 @@ pub fn projects_template_preview_create(
 }
 
 pub fn projects_templates_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     project_pk: &str,
     template_create: crate::models::TemplateCreate,
 ) -> Result<crate::models::TemplateCreate, Error<ProjectsTemplatesCreateError>> {
@@ -1441,6 +1536,11 @@ pub fn projects_templates_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1457,7 +1557,7 @@ pub fn projects_templates_create(
 }
 
 pub fn projects_templates_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     project_pk: &str,
 ) -> Result<(), Error<ProjectsTemplatesDestroyError>> {
@@ -1496,6 +1596,11 @@ pub fn projects_templates_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -1512,7 +1617,7 @@ pub fn projects_templates_destroy(
 }
 
 pub fn projects_templates_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     project_pk: &str,
     name: Option<&str>,
     page: Option<i32>,
@@ -1559,6 +1664,11 @@ pub fn projects_templates_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1575,7 +1685,7 @@ pub fn projects_templates_list(
 }
 
 pub fn projects_templates_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     project_pk: &str,
     patched_template: Option<crate::models::PatchedTemplate>,
@@ -1616,6 +1726,11 @@ pub fn projects_templates_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1632,7 +1747,7 @@ pub fn projects_templates_partial_update(
 }
 
 pub fn projects_templates_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     project_pk: &str,
     environment: Option<&str>,
@@ -1681,6 +1796,11 @@ pub fn projects_templates_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1697,7 +1817,7 @@ pub fn projects_templates_retrieve(
 }
 
 pub fn projects_templates_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     project_pk: &str,
     template: crate::models::Template,
@@ -1738,6 +1858,11 @@ pub fn projects_templates_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -1754,7 +1879,7 @@ pub fn projects_templates_update(
 }
 
 pub fn projects_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     project: crate::models::Project,
 ) -> Result<crate::models::Project, Error<ProjectsUpdateError>> {
@@ -1789,6 +1914,11 @@ pub fn projects_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/projects_api.rs
+++ b/client/src/apis/projects_api.rs
@@ -238,7 +238,8 @@ pub fn projects_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&project_create);
 
@@ -248,7 +249,7 @@ pub fn projects_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -293,7 +294,8 @@ pub fn projects_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -302,7 +304,7 @@ pub fn projects_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -356,7 +358,8 @@ pub fn projects_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -365,7 +368,7 @@ pub fn projects_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -460,7 +463,8 @@ pub fn projects_parameter_export_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -469,7 +473,7 @@ pub fn projects_parameter_export_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -519,7 +523,8 @@ pub fn projects_parameters_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&parameter_create);
 
@@ -529,7 +534,7 @@ pub fn projects_parameters_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -580,7 +585,8 @@ pub fn projects_parameters_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -589,7 +595,7 @@ pub fn projects_parameters_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -663,7 +669,8 @@ pub fn projects_parameters_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -672,7 +679,7 @@ pub fn projects_parameters_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -724,7 +731,8 @@ pub fn projects_parameters_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_parameter);
 
@@ -734,7 +742,7 @@ pub fn projects_parameters_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -800,7 +808,8 @@ pub fn projects_parameters_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -809,7 +818,7 @@ pub fn projects_parameters_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -861,7 +870,8 @@ pub fn projects_parameters_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&parameter);
 
@@ -871,7 +881,7 @@ pub fn projects_parameters_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -929,7 +939,8 @@ pub fn projects_parameters_values_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&value_create);
 
@@ -939,7 +950,7 @@ pub fn projects_parameters_values_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -993,7 +1004,8 @@ pub fn projects_parameters_values_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1002,7 +1014,7 @@ pub fn projects_parameters_values_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1074,7 +1086,8 @@ pub fn projects_parameters_values_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1083,7 +1096,7 @@ pub fn projects_parameters_values_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1143,7 +1156,8 @@ pub fn projects_parameters_values_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_value);
 
@@ -1153,7 +1167,7 @@ pub fn projects_parameters_values_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1217,7 +1231,8 @@ pub fn projects_parameters_values_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1226,7 +1241,7 @@ pub fn projects_parameters_values_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1286,7 +1301,8 @@ pub fn projects_parameters_values_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&value);
 
@@ -1296,7 +1312,7 @@ pub fn projects_parameters_values_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1342,7 +1358,8 @@ pub fn projects_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_project);
 
@@ -1352,7 +1369,7 @@ pub fn projects_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1397,7 +1414,8 @@ pub fn projects_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1406,7 +1424,7 @@ pub fn projects_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1467,7 +1485,8 @@ pub fn projects_template_preview_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&template_preview);
 
@@ -1477,7 +1496,7 @@ pub fn projects_template_preview_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1527,7 +1546,8 @@ pub fn projects_templates_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&template_create);
 
@@ -1537,7 +1557,7 @@ pub fn projects_templates_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1588,7 +1608,8 @@ pub fn projects_templates_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1597,7 +1618,7 @@ pub fn projects_templates_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1656,7 +1677,8 @@ pub fn projects_templates_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1665,7 +1687,7 @@ pub fn projects_templates_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1717,7 +1739,8 @@ pub fn projects_templates_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_template);
 
@@ -1727,7 +1750,7 @@ pub fn projects_templates_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1788,7 +1811,8 @@ pub fn projects_templates_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -1797,7 +1821,7 @@ pub fn projects_templates_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1849,7 +1873,8 @@ pub fn projects_templates_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&template);
 
@@ -1859,7 +1884,7 @@ pub fn projects_templates_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -1905,7 +1930,8 @@ pub fn projects_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&project);
 
@@ -1915,7 +1941,7 @@ pub fn projects_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/client/src/apis/serviceaccounts_api.rs
+++ b/client/src/apis/serviceaccounts_api.rs
@@ -82,7 +82,8 @@ pub fn serviceaccounts_create(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&service_account_create_request);
 
@@ -92,7 +93,7 @@ pub fn serviceaccounts_create(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -141,7 +142,8 @@ pub fn serviceaccounts_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -150,7 +152,7 @@ pub fn serviceaccounts_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -199,7 +201,8 @@ pub fn serviceaccounts_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -208,7 +211,7 @@ pub fn serviceaccounts_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -258,7 +261,8 @@ pub fn serviceaccounts_partial_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&patched_service_account);
 
@@ -268,7 +272,7 @@ pub fn serviceaccounts_partial_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -317,7 +321,8 @@ pub fn serviceaccounts_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -326,7 +331,7 @@ pub fn serviceaccounts_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -376,7 +381,8 @@ pub fn serviceaccounts_update(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
     local_var_req_builder = local_var_req_builder.json(&service_account);
 
@@ -386,7 +392,7 @@ pub fn serviceaccounts_update(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/client/src/apis/serviceaccounts_api.rs
+++ b/client/src/apis/serviceaccounts_api.rs
@@ -57,7 +57,7 @@ pub enum ServiceaccountsUpdateError {
 
 ///              Creates a new ServiceAccount.  A ServiceAccount is a user record intended             for machine use (such as a build system).  It does not have a username/password             but is instead accessed using an API key.              On creation, the API key will be returned.  This key will only be shown once,             is not stored on any CloudTruth system, and should be treated as a secret.  Should             the key be lost, you will need to delete and recreate the ServiceAccount in order             to generate a new API key.             
 pub fn serviceaccounts_create(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     service_account_create_request: crate::models::ServiceAccountCreateRequest,
 ) -> Result<crate::models::ServiceAccountCreateResponse, Error<ServiceaccountsCreateError>> {
     let local_var_client = &configuration.client;
@@ -91,6 +91,11 @@ pub fn serviceaccounts_create(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -107,7 +112,7 @@ pub fn serviceaccounts_create(
 }
 
 pub fn serviceaccounts_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<(), Error<ServiceaccountsDestroyError>> {
     let local_var_client = &configuration.client;
@@ -144,6 +149,11 @@ pub fn serviceaccounts_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -160,7 +170,7 @@ pub fn serviceaccounts_destroy(
 }
 
 pub fn serviceaccounts_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     page: Option<i32>,
 ) -> Result<crate::models::PaginatedServiceAccountList, Error<ServiceaccountsListError>> {
     let local_var_client = &configuration.client;
@@ -197,6 +207,11 @@ pub fn serviceaccounts_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -213,7 +228,7 @@ pub fn serviceaccounts_list(
 }
 
 pub fn serviceaccounts_partial_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     patched_service_account: Option<crate::models::PatchedServiceAccount>,
 ) -> Result<crate::models::ServiceAccount, Error<ServiceaccountsPartialUpdateError>> {
@@ -252,6 +267,11 @@ pub fn serviceaccounts_partial_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -268,7 +288,7 @@ pub fn serviceaccounts_partial_update(
 }
 
 pub fn serviceaccounts_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::ServiceAccount, Error<ServiceaccountsRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -305,6 +325,11 @@ pub fn serviceaccounts_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -321,7 +346,7 @@ pub fn serviceaccounts_retrieve(
 }
 
 pub fn serviceaccounts_update(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
     service_account: Option<crate::models::ServiceAccount>,
 ) -> Result<crate::models::ServiceAccount, Error<ServiceaccountsUpdateError>> {
@@ -360,6 +385,11 @@ pub fn serviceaccounts_update(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/client/src/apis/serviceaccounts_api.rs
+++ b/client/src/apis/serviceaccounts_api.rs
@@ -81,6 +81,9 @@ pub fn serviceaccounts_create(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&service_account_create_request);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -132,6 +135,9 @@ pub fn serviceaccounts_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -182,6 +188,9 @@ pub fn serviceaccounts_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -233,6 +242,9 @@ pub fn serviceaccounts_partial_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&patched_service_account);
 
     let local_var_req = local_var_req_builder.build()?;
@@ -284,6 +296,9 @@ pub fn serviceaccounts_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -335,6 +350,9 @@ pub fn serviceaccounts_update(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
     local_var_req_builder = local_var_req_builder.json(&service_account);
 
     let local_var_req = local_var_req_builder.build()?;

--- a/client/src/apis/users_api.rs
+++ b/client/src/apis/users_api.rs
@@ -67,7 +67,8 @@ pub fn users_destroy(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -76,7 +77,7 @@ pub fn users_destroy(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -130,7 +131,8 @@ pub fn users_list(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -139,7 +141,7 @@ pub fn users_list(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }
@@ -188,7 +190,8 @@ pub fn users_retrieve(
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder =
+            local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 
     let local_var_req = local_var_req_builder.build()?;
@@ -197,7 +200,7 @@ pub fn users_retrieve(
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/client/src/apis/users_api.rs
+++ b/client/src/apis/users_api.rs
@@ -66,6 +66,9 @@ pub fn users_destroy(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -121,6 +124,9 @@ pub fn users_list(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
@@ -171,6 +177,9 @@ pub fn users_retrieve(
         };
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;

--- a/client/src/apis/users_api.rs
+++ b/client/src/apis/users_api.rs
@@ -38,7 +38,7 @@ pub enum UsersRetrieveError {
 
 /// ### Description ###  Delete the specified user.  This removes all access the User may have to any Organization.  ### Pre-Conditions ###  - The user cannot be the only owner of any Organization. - The bearer token must belong to the user being deleted. - All of the memberships related to the User will be deleted, so all the membership deletion pre-conditions must also be met.
 pub fn users_destroy(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<(), Error<UsersDestroyError>> {
     let local_var_client = &configuration.client;
@@ -75,6 +75,11 @@ pub fn users_destroy(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         Ok(())
@@ -91,7 +96,7 @@ pub fn users_destroy(
 }
 
 pub fn users_list(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     page: Option<i32>,
     _type: Option<&str>,
 ) -> Result<crate::models::PaginatedUserList, Error<UsersListError>> {
@@ -133,6 +138,11 @@ pub fn users_list(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)
@@ -149,7 +159,7 @@ pub fn users_list(
 }
 
 pub fn users_retrieve(
-    configuration: &configuration::Configuration,
+    configuration: &mut configuration::Configuration,
     id: &str,
 ) -> Result<crate::models::User, Error<UsersRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -186,6 +196,11 @@ pub fn users_retrieve(
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
+    if configuration.cookie.is_none() {
+        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+            configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
+        }
+    }
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
         serde_json::from_str(&local_var_content).map_err(Error::from)

--- a/patch_client.py
+++ b/patch_client.py
@@ -224,10 +224,39 @@ def update_gitpush(client_dir: str) -> None:
         file_write_content(filename, temp)
 
 
+def add_cookie_to_config(srcdir: str) -> None:
+    filename = srcdir + "/apis/configuration.rs"
+    temp = file_read_content(filename)
+
+    cookie_param = """\
+    pub cookie: Option<String>,
+"""
+    api_key_param = """\
+    pub api_key: Option<ApiKey>,
+"""
+    cookie_init = """\
+            cookie: None,
+"""
+    api_key_init = """\
+            api_key: None,
+"""
+    if cookie_param not in temp:
+        temp = temp.replace(api_key_param, api_key_param + cookie_param)
+        temp = temp.replace(api_key_init, api_key_init + cookie_init)
+        assert cookie_param in temp, "Did not add cookie param"
+        print(f"Updating {filename} with cookie parameter")
+        file_write_content(filename, temp)
+
+
+def support_cookies(srcdir: str) -> None:
+    add_cookie_to_config(srcdir)
+
+
 if __name__ == "__main__":
     client_dir = os.getcwd() + "/client"
     srcdir = client_dir + "/src"
     allow_snake(srcdir)
     support_api_key(srcdir)
+    support_cookies(srcdir)
     parameter_null_fix(client_dir)
     update_gitpush(client_dir)

--- a/patch_client.py
+++ b/patch_client.py
@@ -22,12 +22,12 @@ API_KEY_TEXT = """\
 """
 ADD_COOKIE_TEXT = """\
     if let Some(ref local_var_cookie) = configuration.cookie {
-        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+        local_var_req_builder = local_var_req_builder.header(reqwest::header::COOKIE, local_var_cookie);
     }
 """
 CACHE_COOKIE_TEXT = """\
     if configuration.cookie.is_none() {
-        if let Some(local_var_header) = local_var_resp.headers().get("set-cookie") {
+        if let Some(local_var_header) = local_var_resp.headers().get(reqwest::header::SET_COOKIE) {
             configuration.cookie = Some(local_var_header.to_str().unwrap().to_string());
         }
     }

--- a/patch_client.py
+++ b/patch_client.py
@@ -28,6 +28,19 @@ fn remove_null_values(input: &str) -> String {
 """  # noqa: W605  - ignore invalid escape sequences, since Rust likes these
 
 
+def file_read_content(filename: str) -> str:
+    f = open(filename, "r")
+    content = f.read()
+    f.close()
+    return content
+
+
+def file_write_content(filename: str, content: str) -> None:
+    f = open(filename, "w")
+    f.write(content)
+    f.close()
+
+
 def allow_snake(srcdir: str) -> None:
     """
     The generated code produces a `parent__name` variable that causes warnings. This stops the
@@ -35,16 +48,11 @@ def allow_snake(srcdir: str) -> None:
     to disable for the entire package.
     """
     filename = f"{srcdir}/lib.rs"
-    f = open(filename, "r")
-    temp = f.read()
-    f.close()
+    temp = file_read_content(filename)
 
     if ALLOW_SNAKE_TEXT not in temp:
         print(f"Updating {filename} to allow snake-case")
-        f = open(filename, "w")
-        f.write(ALLOW_SNAKE_TEXT)
-        f.write(temp)
-        f.close()
+        file_write_content(filename, ALLOW_SNAKE_TEXT + temp)
 
 
 def support_api_key(srcdir: str) -> None:
@@ -58,18 +66,14 @@ def support_api_key(srcdir: str) -> None:
     double = API_KEY_TEXT + API_KEY_TEXT
     filelist = glob.glob(f"{srcdir}/**/*.rs")
     for filename in filelist:
-        f = open(filename, "r")
-        temp = f.read()
-        f.close()
+        temp = file_read_content(filename)
 
         if double not in temp:
             continue
 
         print(f"Updating {filename} with Bearer/Api-Key text")
         temp = temp.replace(double, BEARER_TEXT + API_KEY_TEXT)
-        f = open(filename, "w")
-        f.write(temp)
-        f.close()
+        file_write_content(filename, temp)
 
 
 def cargo_add(filename: str, section: str, dependency: str, value: str) -> None:
@@ -180,9 +184,7 @@ def parameter_null_fix(client_dir: str) -> None:
     cargo_add(cargo_file, "dependencies", "regex", '"1.5.4"')
 
     filename = client_dir + "/src/apis/projects_api.rs"
-    f = open(filename)
-    temp = f.read()
-    f.close()
+    temp = file_read_content(filename)
 
     # make a copy for comparison
     orig = temp
@@ -200,16 +202,12 @@ def parameter_null_fix(client_dir: str) -> None:
 
     # save any changes
     if orig != temp:
-        f = open(filename, "w")
-        f.write(temp)
-        f.close()
+        file_write_content(filename, temp)
 
 
 def update_gitpush(client_dir: str) -> None:
     filename = client_dir + "/git_push.sh"
-    f = open(filename, "r")
-    temp = f.read()
-    f.close()
+    temp = file_read_content(filename)
 
     orig = temp
 
@@ -223,9 +221,7 @@ def update_gitpush(client_dir: str) -> None:
 
     if temp != orig:
         print(f"Updating {filename} with shell fixes")
-        f = open(filename, "w")
-        f.write(temp)
-        f.close()
+        file_write_content(filename, temp)
 
 
 if __name__ == "__main__":

--- a/patch_client.py
+++ b/patch_client.py
@@ -274,12 +274,9 @@ def add_cookie_caches(srcdir: str) -> None:
     """
     This allows cookies to be used in the CLI.
     """
-    """
     filelist = glob.glob(f"{srcdir}/apis/*.rs")
     for filename in filelist:
         add_cookie_cache(filename)
-    """
-    add_cookie_cache(srcdir + "/apis/environments_api.rs")
 
 
 def support_cookies(srcdir: str) -> None:

--- a/patch_client.py
+++ b/patch_client.py
@@ -20,6 +20,11 @@ API_KEY_TEXT = """\
         local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
     };
 """
+ADD_COOKIE_TEXT = """\
+    if let Some(ref local_var_cookie) = configuration.cookie {
+        local_var_req_builder = local_var_req_builder.header("set-cookie", local_var_cookie)
+    }
+"""
 REMOVE_NULL_FUNCTION = """
 fn remove_null_values(input: &str) -> String {
     let re = Regex::new(r#"\"values\":\{\"https://\S+/\":null\}\"#).unwrap();
@@ -248,8 +253,30 @@ def add_cookie_to_config(srcdir: str) -> None:
         file_write_content(filename, temp)
 
 
+def add_cookie_cache(filename: str) -> None:
+    temp = file_read_content(filename)
+
+    if ADD_COOKIE_TEXT in temp or API_KEY_TEXT not in temp:
+        return
+
+    print(f"Updating {filename} with cookie text")
+    temp = temp.replace(API_KEY_TEXT, API_KEY_TEXT + ADD_COOKIE_TEXT)
+    assert ADD_COOKIE_TEXT in temp, f"Failed to add code to use cookies to {filename}"
+    file_write_content(filename, temp)
+
+
+def add_cookie_caches(srcdir: str) -> None:
+    """
+    This allows cookies to be used in the CLI.
+    """
+    filelist = glob.glob(f"{srcdir}/apis/*.rs")
+    for filename in filelist:
+        add_cookie_cache(filename)
+
+
 def support_cookies(srcdir: str) -> None:
     add_cookie_to_config(srcdir)
+    add_cookie_caches(srcdir)
 
 
 if __name__ == "__main__":

--- a/src/environments.rs
+++ b/src/environments.rs
@@ -1,4 +1,4 @@
-use crate::openapi::{extract_details, open_api_config, OpenApiConfig};
+use crate::openapi::{extract_details, OpenApiConfig};
 
 use cloudtruth_restapi::apis::environments_api::*;
 use cloudtruth_restapi::apis::Error;
@@ -8,9 +8,7 @@ use std::collections::HashMap;
 use std::error;
 use std::fmt::{self, Formatter};
 
-pub struct Environments<'a> {
-    rest_cfg: &'a mut OpenApiConfig,
-}
+pub struct Environments {}
 
 #[derive(Debug)]
 pub struct EnvironmentDetails {
@@ -78,12 +76,12 @@ fn bad_request_details(content: &str) -> String {
 }
 
 impl Environments {
-    pub fn new(rest_cfg: &mut OpenApiConfig) -> Self {
-        Self { rest_cfg }
+    pub fn new() -> Self {
+        Self {}
     }
 
     /// Use the environment URL to get the corresponding name.
-    pub fn get_name_from_url(&self, url: &str) -> String {
+    pub fn get_name_from_url(&self, rest_cfg: &mut OpenApiConfig, url: &str) -> String {
         let id = url
             .split('/')
             .filter(|&x| !x.is_empty())
@@ -92,7 +90,7 @@ impl Environments {
         if id.is_empty() {
             "".to_owned()
         } else {
-            let response = environments_retrieve(&mut self.rest_cfg, id);
+            let response = environments_retrieve(rest_cfg, id);
             if let Ok(environment) = response {
                 environment.name
             } else {
@@ -102,8 +100,8 @@ impl Environments {
     }
 
     /// This provides a means to get an entire list of environment URLs to names.
-    pub fn get_url_name_map(&self) -> HashMap<String, String> {
-        let response = environments_list(&mut self.rest_cfg, None, None, None);
+    pub fn get_url_name_map(&self, rest_cfg: &mut OpenApiConfig) -> HashMap<String, String> {
+        let response = environments_list(rest_cfg, None, None, None);
         let mut result: HashMap<String, String> = HashMap::new();
         if let Ok(list) = response {
             if let Some(environments) = list.results {
@@ -117,9 +115,10 @@ impl Environments {
 
     pub fn get_details_by_name(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         env_name: &str,
     ) -> Result<Option<EnvironmentDetails>, EnvironmentError> {
-        let response = environments_list(&mut self.rest_cfg, Some(env_name), None, None);
+        let response = environments_list(rest_cfg, Some(env_name), None, None);
 
         match response {
             Ok(data) => match data.results {
@@ -129,7 +128,8 @@ impl Environments {
                     } else {
                         let env = &list[0];
                         let mut details = EnvironmentDetails::from(env);
-                        details.parent_name = self.get_name_from_url(details.parent_url.as_str());
+                        details.parent_name =
+                            self.get_name_from_url(rest_cfg, details.parent_url.as_str());
                         Ok(Some(details))
                     }
                 }
@@ -148,16 +148,23 @@ impl Environments {
         }
     }
 
-    pub fn get_id(&self, env_name: &str) -> Result<Option<String>, EnvironmentError> {
-        if let Some(details) = self.get_details_by_name(env_name)? {
+    pub fn get_id(
+        &self,
+        rest_cfg: &mut OpenApiConfig,
+        env_name: &str,
+    ) -> Result<Option<String>, EnvironmentError> {
+        if let Some(details) = self.get_details_by_name(rest_cfg, env_name)? {
             Ok(Some(details.id))
         } else {
             Ok(None)
         }
     }
 
-    pub fn get_environment_details(&self) -> Result<Vec<EnvironmentDetails>, EnvironmentError> {
-        let response = environments_list(&mut self.rest_cfg, None, None, None);
+    pub fn get_environment_details(
+        &self,
+        rest_cfg: &mut OpenApiConfig,
+    ) -> Result<Vec<EnvironmentDetails>, EnvironmentError> {
+        let response = environments_list(rest_cfg, None, None, None);
 
         match response {
             Ok(data) => match data.results {
@@ -196,6 +203,7 @@ impl Environments {
 
     pub fn create_environment(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         env_name: &str,
         description: Option<&str>,
         parent_url: &str,
@@ -205,13 +213,17 @@ impl Environments {
             description: description.map(String::from),
             parent: Some(parent_url.to_string()),
         };
-        let response = environments_create(&mut self.rest_cfg, new_env)?;
+        let response = environments_create(rest_cfg, new_env)?;
         // return the id of the new environment (likely same as the old)
         Ok(Some(response.id))
     }
 
-    pub fn delete_environment(&self, environment_id: String) -> Result<String, EnvironmentError> {
-        let response = environments_destroy(&mut self.rest_cfg, &environment_id);
+    pub fn delete_environment(
+        &self,
+        rest_cfg: &mut OpenApiConfig,
+        environment_id: String,
+    ) -> Result<String, EnvironmentError> {
+        let response = environments_destroy(rest_cfg, &environment_id);
         match response {
             Ok(_) => Ok(environment_id),
             Err(ResponseError(ref content)) => match content.status.as_u16() {
@@ -229,6 +241,7 @@ impl Environments {
 
     pub fn update_environment(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         environment_id: &str,
         environment_name: &str,
         description: Option<&str>,
@@ -242,7 +255,7 @@ impl Environments {
             created_at: None,
             modified_at: None,
         };
-        let response = environments_partial_update(&mut self.rest_cfg, environment_id, Some(env))?;
+        let response = environments_partial_update(rest_cfg, environment_id, Some(env))?;
         Ok(Some(response.id))
     }
 }

--- a/src/environments.rs
+++ b/src/environments.rs
@@ -1,4 +1,4 @@
-use crate::openapi::{extract_details, open_api_config};
+use crate::openapi::{extract_details, open_api_config, OpenApiConfig};
 
 use cloudtruth_restapi::apis::environments_api::*;
 use cloudtruth_restapi::apis::Error;
@@ -8,7 +8,9 @@ use std::collections::HashMap;
 use std::error;
 use std::fmt::{self, Formatter};
 
-pub struct Environments {}
+pub struct Environments<'a> {
+    rest_cfg: &'a mut OpenApiConfig,
+}
 
 #[derive(Debug)]
 pub struct EnvironmentDetails {
@@ -76,13 +78,12 @@ fn bad_request_details(content: &str) -> String {
 }
 
 impl Environments {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new(rest_cfg: &mut OpenApiConfig) -> Self {
+        Self { rest_cfg }
     }
 
     /// Use the environment URL to get the corresponding name.
     pub fn get_name_from_url(&self, url: &str) -> String {
-        let rest_cfg = open_api_config();
         let id = url
             .split('/')
             .filter(|&x| !x.is_empty())
@@ -91,7 +92,7 @@ impl Environments {
         if id.is_empty() {
             "".to_owned()
         } else {
-            let response = environments_retrieve(rest_cfg, id);
+            let response = environments_retrieve(&mut self.rest_cfg, id);
             if let Ok(environment) = response {
                 environment.name
             } else {
@@ -102,8 +103,7 @@ impl Environments {
 
     /// This provides a means to get an entire list of environment URLs to names.
     pub fn get_url_name_map(&self) -> HashMap<String, String> {
-        let rest_cfg = open_api_config();
-        let response = environments_list(&rest_cfg, None, None, None);
+        let response = environments_list(&mut self.rest_cfg, None, None, None);
         let mut result: HashMap<String, String> = HashMap::new();
         if let Ok(list) = response {
             if let Some(environments) = list.results {
@@ -119,8 +119,7 @@ impl Environments {
         &self,
         env_name: &str,
     ) -> Result<Option<EnvironmentDetails>, EnvironmentError> {
-        let rest_cfg = open_api_config();
-        let response = environments_list(&rest_cfg, Some(env_name), None, None);
+        let response = environments_list(&mut self.rest_cfg, Some(env_name), None, None);
 
         match response {
             Ok(data) => match data.results {
@@ -158,8 +157,7 @@ impl Environments {
     }
 
     pub fn get_environment_details(&self) -> Result<Vec<EnvironmentDetails>, EnvironmentError> {
-        let rest_cfg = open_api_config();
-        let response = environments_list(&rest_cfg, None, None, None);
+        let response = environments_list(&mut self.rest_cfg, None, None, None);
 
         match response {
             Ok(data) => match data.results {
@@ -202,20 +200,18 @@ impl Environments {
         description: Option<&str>,
         parent_url: &str,
     ) -> Result<Option<String>, Error<EnvironmentsCreateError>> {
-        let rest_cfg = open_api_config();
         let new_env = EnvironmentCreate {
             name: env_name.to_string(),
             description: description.map(String::from),
             parent: Some(parent_url.to_string()),
         };
-        let response = environments_create(&rest_cfg, new_env)?;
+        let response = environments_create(&mut self.rest_cfg, new_env)?;
         // return the id of the new environment (likely same as the old)
         Ok(Some(response.id))
     }
 
     pub fn delete_environment(&self, environment_id: String) -> Result<String, EnvironmentError> {
-        let rest_cfg = open_api_config();
-        let response = environments_destroy(&rest_cfg, &environment_id);
+        let response = environments_destroy(&mut self.rest_cfg, &environment_id);
         match response {
             Ok(_) => Ok(environment_id),
             Err(ResponseError(ref content)) => match content.status.as_u16() {
@@ -237,7 +233,6 @@ impl Environments {
         environment_name: &str,
         description: Option<&str>,
     ) -> Result<Option<String>, Error<EnvironmentsPartialUpdateError>> {
-        let rest_cfg = open_api_config();
         let env = PatchedEnvironment {
             url: None,
             id: None,
@@ -247,7 +242,7 @@ impl Environments {
             created_at: None,
             modified_at: None,
         };
-        let response = environments_partial_update(&rest_cfg, environment_id, Some(env))?;
+        let response = environments_partial_update(&mut self.rest_cfg, environment_id, Some(env))?;
         Ok(Some(response.id))
     }
 }

--- a/src/integrations.rs
+++ b/src/integrations.rs
@@ -1,4 +1,4 @@
-use crate::openapi::{extract_details, open_api_config};
+use crate::openapi::{extract_details, OpenApiConfig};
 use cloudtruth_restapi::apis::integrations_api::*;
 use cloudtruth_restapi::apis::Error;
 use cloudtruth_restapi::apis::Error::ResponseError;
@@ -151,11 +151,13 @@ impl Integrations {
     }
 
     /// Gets a list of `IntegrationDetails` for all integration types.
-    pub fn get_integration_details(&self) -> Result<Vec<IntegrationDetails>, IntegrationError> {
+    pub fn get_integration_details(
+        &self,
+        rest_cfg: &mut OpenApiConfig,
+    ) -> Result<Vec<IntegrationDetails>, IntegrationError> {
         let mut result: Vec<IntegrationDetails> = Vec::new();
-        let rest_cfg = open_api_config();
 
-        let response = integrations_github_list(&rest_cfg, None, None);
+        let response = integrations_github_list(rest_cfg, None, None);
         if let Ok(paged_results) = response {
             if let Some(list) = paged_results.results {
                 for gh in list {
@@ -176,7 +178,7 @@ impl Integrations {
             return Err(IntegrationError::GitHubListError(response.unwrap_err()));
         }
 
-        let response = integrations_aws_list(&rest_cfg, None, None, None);
+        let response = integrations_aws_list(rest_cfg, None, None, None);
         if let Ok(paged_results) = response {
             if let Some(list) = paged_results.results {
                 for aws in list {
@@ -203,10 +205,10 @@ impl Integrations {
     /// Get the integration node by FQN
     pub fn get_integration_nodes(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         fqn: Option<&str>,
     ) -> Result<Vec<IntegrationNode>, IntegrationError> {
-        let rest_cfg = open_api_config();
-        let response = integrations_explore_list(&rest_cfg, fqn, None);
+        let response = integrations_explore_list(rest_cfg, fqn, None);
         if let Ok(response) = response {
             let mut results: Vec<IntegrationNode> = Vec::new();
             if let Some(list) = response.results {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -55,6 +55,7 @@ fn create_openapi_config(ct_cfg: &CloudTruthConfig) -> OpenApiConfig {
             prefix: Some("Api-Key".to_owned()),
             key: ct_cfg.api_key.clone(),
         }),
+        cookie: None,
     }
 }
 

--- a/src/projects.rs
+++ b/src/projects.rs
@@ -1,4 +1,4 @@
-use crate::openapi::{extract_details, open_api_config};
+use crate::openapi::{extract_details, OpenApiConfig};
 
 use cloudtruth_restapi::apis::projects_api::*;
 use cloudtruth_restapi::apis::Error::{self, ResponseError};
@@ -52,10 +52,10 @@ impl Projects {
     /// Get the details for `proj_name`
     pub fn get_details_by_name(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         proj_name: &str,
     ) -> Result<Option<ProjectDetails>, ProjectError> {
-        let rest_cfg = open_api_config();
-        let response = projects_list(&rest_cfg, Some(proj_name), None);
+        let response = projects_list(rest_cfg, Some(proj_name), None);
 
         match response {
             Ok(data) => match data.results {
@@ -80,8 +80,12 @@ impl Projects {
     }
 
     /// Resolve the `proj_name` to a String
-    pub fn get_id(&self, proj_name: &str) -> Result<Option<String>, ProjectError> {
-        if let Some(details) = self.get_details_by_name(proj_name)? {
+    pub fn get_id(
+        &self,
+        rest_cfg: &mut OpenApiConfig,
+        proj_name: &str,
+    ) -> Result<Option<String>, ProjectError> {
+        if let Some(details) = self.get_details_by_name(rest_cfg, proj_name)? {
             Ok(Some(details.id))
         } else {
             Ok(None)
@@ -89,9 +93,11 @@ impl Projects {
     }
 
     /// Get a complete list of projects for this organization.
-    pub fn get_project_details(&self) -> Result<Vec<ProjectDetails>, ProjectError> {
-        let rest_cfg = open_api_config();
-        let response = projects_list(&rest_cfg, None, None);
+    pub fn get_project_details(
+        &self,
+        rest_cfg: &mut OpenApiConfig,
+    ) -> Result<Vec<ProjectDetails>, ProjectError> {
+        let response = projects_list(rest_cfg, None, None);
 
         match response {
             Ok(data) => match data.results {
@@ -115,15 +121,15 @@ impl Projects {
     /// Create a project with the specified name/description
     pub fn create_project(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         proj_name: &str,
         description: Option<&str>,
     ) -> Result<Option<String>, Error<ProjectsCreateError>> {
-        let rest_cfg = open_api_config();
         let proj = ProjectCreate {
             name: proj_name.to_string(),
             description: description.map(String::from),
         };
-        let response = projects_create(&rest_cfg, proj)?;
+        let response = projects_create(rest_cfg, proj)?;
         // return the project id of the newly minted project
         Ok(Some(response.id))
     }
@@ -131,21 +137,21 @@ impl Projects {
     /// Delete the specified project
     pub fn delete_project(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         project_id: &str,
     ) -> Result<Option<String>, Error<ProjectsDestroyError>> {
-        let rest_cfg = open_api_config();
-        projects_destroy(&rest_cfg, project_id)?;
+        projects_destroy(rest_cfg, project_id)?;
         Ok(Some(project_id.to_string()))
     }
 
     /// Update the specified project
     pub fn update_project(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         project_name: &str,
         project_id: &str,
         description: Option<&str>,
     ) -> Result<Option<String>, Error<ProjectsPartialUpdateError>> {
-        let rest_cfg = open_api_config();
         let proj = PatchedProject {
             url: None,
             id: None,
@@ -154,7 +160,7 @@ impl Projects {
             created_at: None,
             modified_at: None,
         };
-        let response = projects_partial_update(&rest_cfg, project_id, Some(proj))?;
+        let response = projects_partial_update(rest_cfg, project_id, Some(proj))?;
         Ok(Some(response.id))
     }
 }

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -1,4 +1,4 @@
-use crate::openapi::open_api_config;
+use crate::openapi::OpenApiConfig;
 
 use cloudtruth_restapi::apis::projects_api::*;
 use cloudtruth_restapi::apis::Error;
@@ -30,18 +30,18 @@ impl Templates {
 
     pub fn get_body_by_name(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         proj_id: &str,
         env_id: &str,
         template_name: &str,
         show_secrets: bool,
     ) -> Result<Option<String>, Error<ProjectsTemplatesRetrieveError>> {
         // TODO: convert template name to template id outside??
-        let response = self.get_details_by_name(proj_id, template_name);
+        let response = self.get_details_by_name(rest_cfg, proj_id, template_name);
 
         if let Ok(Some(details)) = response {
-            let rest_cfg = open_api_config();
             let response = projects_templates_retrieve(
-                &rest_cfg,
+                rest_cfg,
                 &details.id,
                 proj_id,
                 Some(env_id),
@@ -56,11 +56,11 @@ impl Templates {
 
     pub fn get_details_by_name(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         proj_id: &str,
         template_name: &str,
     ) -> Result<Option<TemplateDetails>, Error<ProjectsTemplatesListError>> {
-        let rest_cfg = open_api_config();
-        let response = projects_templates_list(&rest_cfg, proj_id, Some(template_name), None)?;
+        let response = projects_templates_list(rest_cfg, proj_id, Some(template_name), None)?;
 
         if let Some(templates) = response.results {
             if template_name.is_empty() {
@@ -77,10 +77,10 @@ impl Templates {
 
     pub fn get_template_details(
         &self,
+        rest_cfg: &mut OpenApiConfig,
         proj_id: &str,
     ) -> Result<Vec<TemplateDetails>, Error<ProjectsTemplatesListError>> {
-        let rest_cfg = open_api_config();
-        let response = projects_templates_list(&rest_cfg, proj_id, None, None)?;
+        let response = projects_templates_list(rest_cfg, proj_id, None, None)?;
         let mut list: Vec<TemplateDetails> = Vec::new();
 
         if let Some(templates) = response.results {


### PR DESCRIPTION
Code generation changes:
   * Added cookie to generated `OpenApiConfig` (really `crate::openapi::configuration::Configuration`)
   * Added code to add `cookie` header if it is in the OpenApiConfig
   * Added code to cache the cookie from the `set-cookie` header, if was not already populated

There did not appear to be a good way to make `open_api_config()` return a mutable reference (in part due to lifetime issues), so the `OpenApiConfig` is now part of `main()` and passed into all the places that use it.