### PR TITLE
Update to latest OpenApi spec

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -1,6 +1,6 @@
 # Rust API client for cloudtruth-restapi
 
-CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
 
 ## Overview
 

--- a/client/src/apis/api_api.rs
+++ b/client/src/apis/api_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com
@@ -43,18 +43,6 @@ pub fn api_schema_retrieve(
         local_var_req_builder =
             local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
     }
-
-    if let Some(ref local_var_token) = configuration.bearer_access_token {
-        local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
-    };
-    if let Some(ref local_var_apikey) = configuration.api_key {
-        let local_var_key = local_var_apikey.key.clone();
-        let local_var_value = match local_var_apikey.prefix {
-            Some(ref local_var_prefix) => format!("{} {}", local_var_prefix, local_var_key),
-            None => local_var_key,
-        };
-        local_var_req_builder = local_var_req_builder.header("Authorization", local_var_value);
-    };
 
     let local_var_req = local_var_req_builder.build()?;
     let mut local_var_resp = local_var_client.execute(local_var_req)?;

--- a/client/src/apis/audit_api.rs
+++ b/client/src/apis/audit_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/apis/configuration.rs
+++ b/client/src/apis/configuration.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/apis/environments_api.rs
+++ b/client/src/apis/environments_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/apis/integrations_api.rs
+++ b/client/src/apis/integrations_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/apis/invitations_api.rs
+++ b/client/src/apis/invitations_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/apis/memberships_api.rs
+++ b/client/src/apis/memberships_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/apis/organizations_api.rs
+++ b/client/src/apis/organizations_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/apis/projects_api.rs
+++ b/client/src/apis/projects_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/apis/serviceaccounts_api.rs
+++ b/client/src/apis/serviceaccounts_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/apis/users_api.rs
+++ b/client/src/apis/users_api.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/audit_trail.rs
+++ b/client/src/models/audit_trail.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/audit_trail_summary.rs
+++ b/client/src/models/audit_trail_summary.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/aws_enabled_regions_enum.rs
+++ b/client/src/models/aws_enabled_regions_enum.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/aws_enabled_services_enum.rs
+++ b/client/src/models/aws_enabled_services_enum.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/aws_integration.rs
+++ b/client/src/models/aws_integration.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/aws_integration_create.rs
+++ b/client/src/models/aws_integration_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/environment.rs
+++ b/client/src/models/environment.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/environment_create.rs
+++ b/client/src/models/environment_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/git_hub_integration.rs
+++ b/client/src/models/git_hub_integration.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/git_hub_integration_create.rs
+++ b/client/src/models/git_hub_integration_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/integration_explorer.rs
+++ b/client/src/models/integration_explorer.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/invitation.rs
+++ b/client/src/models/invitation.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/invitation_create.rs
+++ b/client/src/models/invitation_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/membership.rs
+++ b/client/src/models/membership.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/membership_create.rs
+++ b/client/src/models/membership_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/node_type_enum.rs
+++ b/client/src/models/node_type_enum.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/object_type_enum.rs
+++ b/client/src/models/object_type_enum.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/organization.rs
+++ b/client/src/models/organization.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/organization_create.rs
+++ b/client/src/models/organization_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_audit_trail_list.rs
+++ b/client/src/models/paginated_audit_trail_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_aws_integration_list.rs
+++ b/client/src/models/paginated_aws_integration_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_environment_list.rs
+++ b/client/src/models/paginated_environment_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_git_hub_integration_list.rs
+++ b/client/src/models/paginated_git_hub_integration_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_integration_explorer_list.rs
+++ b/client/src/models/paginated_integration_explorer_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_invitation_list.rs
+++ b/client/src/models/paginated_invitation_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_membership_list.rs
+++ b/client/src/models/paginated_membership_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_organization_list.rs
+++ b/client/src/models/paginated_organization_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_parameter_list.rs
+++ b/client/src/models/paginated_parameter_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_project_list.rs
+++ b/client/src/models/paginated_project_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_service_account_list.rs
+++ b/client/src/models/paginated_service_account_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_template_list.rs
+++ b/client/src/models/paginated_template_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_user_list.rs
+++ b/client/src/models/paginated_user_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/paginated_value_list.rs
+++ b/client/src/models/paginated_value_list.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/parameter.rs
+++ b/client/src/models/parameter.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com
@@ -28,9 +28,6 @@ pub struct Parameter {
     pub secret: Option<bool>,
     #[serde(rename = "templates")]
     pub templates: Vec<String>,
-    /// If `true` then at least one of the values is dynamic.
-    #[serde(rename = "uses_dynamic_values")]
-    pub uses_dynamic_values: bool,
     ///              Each parameter has an effective value in every environment based on             environment inheritance and which environments have had a value set.              Environments inherit from a single parent to form a tree, as a result             a single parameter may have different values present for each environment.             When a value is not explicitly set in an environment, the parent environment             is consulted to see if it has a value defined, and so on.              The dictionary of values has an environment url as the key, and the optional             Value record that it resolves to.  If the Value.environment matches the key,             then it is an explicit value set for that environment.  If they differ, the             value was obtained from a parent environment (directly or indirectly).  If the             value is None then no value has ever been set in any environment for this             parameter.              key: Environment url             value: optional Value record         
     #[serde(rename = "values")]
     pub values: ::std::collections::HashMap<String, crate::models::Value>,
@@ -47,7 +44,6 @@ impl Parameter {
         id: String,
         name: String,
         templates: Vec<String>,
-        uses_dynamic_values: bool,
         values: ::std::collections::HashMap<String, crate::models::Value>,
         created_at: String,
         modified_at: String,
@@ -59,7 +55,6 @@ impl Parameter {
             description: None,
             secret: None,
             templates,
-            uses_dynamic_values,
             values,
             created_at,
             modified_at,

--- a/client/src/models/parameter_create.rs
+++ b/client/src/models/parameter_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/parameter_export.rs
+++ b/client/src/models/parameter_export.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/patched_aws_integration.rs
+++ b/client/src/models/patched_aws_integration.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/patched_environment.rs
+++ b/client/src/models/patched_environment.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/patched_invitation.rs
+++ b/client/src/models/patched_invitation.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/patched_membership.rs
+++ b/client/src/models/patched_membership.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/patched_organization.rs
+++ b/client/src/models/patched_organization.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/patched_parameter.rs
+++ b/client/src/models/patched_parameter.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com
@@ -28,12 +28,6 @@ pub struct PatchedParameter {
     pub secret: Option<bool>,
     #[serde(rename = "templates", skip_serializing_if = "Option::is_none")]
     pub templates: Option<Vec<String>>,
-    /// If `true` then at least one of the values is dynamic.
-    #[serde(
-        rename = "uses_dynamic_values",
-        skip_serializing_if = "Option::is_none"
-    )]
-    pub uses_dynamic_values: Option<bool>,
     ///              Each parameter has an effective value in every environment based on             environment inheritance and which environments have had a value set.              Environments inherit from a single parent to form a tree, as a result             a single parameter may have different values present for each environment.             When a value is not explicitly set in an environment, the parent environment             is consulted to see if it has a value defined, and so on.              The dictionary of values has an environment url as the key, and the optional             Value record that it resolves to.  If the Value.environment matches the key,             then it is an explicit value set for that environment.  If they differ, the             value was obtained from a parent environment (directly or indirectly).  If the             value is None then no value has ever been set in any environment for this             parameter.              key: Environment url             value: optional Value record         
     #[serde(rename = "values", skip_serializing_if = "Option::is_none")]
     pub values: Option<::std::collections::HashMap<String, crate::models::Value>>,
@@ -53,7 +47,6 @@ impl PatchedParameter {
             description: None,
             secret: None,
             templates: None,
-            uses_dynamic_values: None,
             values: None,
             created_at: None,
             modified_at: None,

--- a/client/src/models/patched_project.rs
+++ b/client/src/models/patched_project.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/patched_service_account.rs
+++ b/client/src/models/patched_service_account.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/patched_template.rs
+++ b/client/src/models/patched_template.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/patched_value.rs
+++ b/client/src/models/patched_value.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com
@@ -35,9 +35,12 @@ pub struct PatchedValue {
     /// This is the content to use when resolving the Value for a static non-secret.
     #[serde(rename = "static_value", skip_serializing_if = "Option::is_none")]
     pub static_value: Option<String>,
-    /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `dynamic` and parameters that are not `secret`, the system will use the content in `static_value` to satisfy the request.  For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, or if the parameter is `secret` and the content from the integration is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
+    /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `dynamic` and parameters that are not `secret`, the system will use the content in `static_value` to satisfy the request.  For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
     #[serde(rename = "value", skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
+    /// Indicates the value content is a secret.  Normally this is `true` when the parameter is a secret, however it is possible for a parameter to be a secret with a dynamic value that is not a secret.  It is not possible to convert a parameter from a secret to a non-secret if any of the values are dynamic and a secret.  Clients can check this condition by leveraging this field.
+    #[serde(rename = "secret", skip_serializing_if = "Option::is_none")]
+    pub secret: Option<bool>,
     #[serde(rename = "created_at", skip_serializing_if = "Option::is_none")]
     pub created_at: Option<String>,
     #[serde(rename = "modified_at", skip_serializing_if = "Option::is_none")]
@@ -57,6 +60,7 @@ impl PatchedValue {
             dynamic_filter: None,
             static_value: None,
             value: None,
+            secret: None,
             created_at: None,
             modified_at: None,
         }

--- a/client/src/models/project.rs
+++ b/client/src/models/project.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/project_create.rs
+++ b/client/src/models/project_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/role_enum.rs
+++ b/client/src/models/role_enum.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/service_account.rs
+++ b/client/src/models/service_account.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/service_account_create_request.rs
+++ b/client/src/models/service_account_create_request.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/service_account_create_response.rs
+++ b/client/src/models/service_account_create_response.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/template.rs
+++ b/client/src/models/template.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/template_create.rs
+++ b/client/src/models/template_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/template_preview.rs
+++ b/client/src/models/template_preview.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/user.rs
+++ b/client/src/models/user.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/client/src/models/value.rs
+++ b/client/src/models/value.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com
@@ -35,9 +35,12 @@ pub struct Value {
     /// This is the content to use when resolving the Value for a static non-secret.
     #[serde(rename = "static_value", skip_serializing_if = "Option::is_none")]
     pub static_value: Option<String>,
-    /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `dynamic` and parameters that are not `secret`, the system will use the content in `static_value` to satisfy the request.  For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, or if the parameter is `secret` and the content from the integration is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
+    /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `dynamic` and parameters that are not `secret`, the system will use the content in `static_value` to satisfy the request.  For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
     #[serde(rename = "value")]
     pub value: Option<String>,
+    /// Indicates the value content is a secret.  Normally this is `true` when the parameter is a secret, however it is possible for a parameter to be a secret with a dynamic value that is not a secret.  It is not possible to convert a parameter from a secret to a non-secret if any of the values are dynamic and a secret.  Clients can check this condition by leveraging this field.
+    #[serde(rename = "secret")]
+    pub secret: Option<bool>,
     #[serde(rename = "created_at")]
     pub created_at: String,
     #[serde(rename = "modified_at")]
@@ -52,6 +55,7 @@ impl Value {
         environment: String,
         parameter: String,
         value: Option<String>,
+        secret: Option<bool>,
         created_at: String,
         modified_at: String,
     ) -> Value {
@@ -65,6 +69,7 @@ impl Value {
             dynamic_filter: None,
             static_value: None,
             value,
+            secret,
             created_at,
             modified_at,
         }

--- a/client/src/models/value_create.rs
+++ b/client/src/models/value_create.rs
@@ -1,7 +1,7 @@
 /*
  * CloudTruth Management API
  *
- * CloudTruth centralizes your parameters and secrets making them easier to manage and use.
+ * CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.
  *
  * The version of the OpenAPI document: 1.0.0
  * Contact: support@cloudtruth.com

--- a/openapi.yml
+++ b/openapi.yml
@@ -2,8 +2,8 @@ openapi: 3.0.3
 info:
   title: CloudTruth Management API
   version: ''
-  description: CloudTruth centralizes your parameters and secrets making them easier
-    to manage and use.
+  description: CloudTruth centralizes your configuration parameters and secrets making
+    them easier to manage and use as a team.
   contact:
     name: CloudTruth Support
     email: support@cloudtruth.com
@@ -128,8 +128,6 @@ paths:
       tags:
       - api
       security:
-      - JWTAuth: []
-      - ApiKeyAuth: []
       - {}
       responses:
         '200':
@@ -3633,10 +3631,6 @@ components:
             type: string
             format: uri
           readOnly: true
-        uses_dynamic_values:
-          type: boolean
-          readOnly: true
-          description: If `true` then at least one of the values is dynamic.
         values:
           type: object
           additionalProperties:
@@ -3675,7 +3669,6 @@ components:
       - name
       - templates
       - url
-      - uses_dynamic_values
       - values
     ParameterCreate:
       type: object
@@ -3975,10 +3968,6 @@ components:
             type: string
             format: uri
           readOnly: true
-        uses_dynamic_values:
-          type: boolean
-          readOnly: true
-          description: If `true` then at least one of the values is dynamic.
         values:
           type: object
           additionalProperties:
@@ -4175,11 +4164,21 @@ components:
 
             For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.
 
-            For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, or if the parameter is `secret` and the content from the integration is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.
+            For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.
 
             If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.
 
             Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
+        secret:
+          type: boolean
+          nullable: true
+          readOnly: true
+          description: Indicates the value content is a secret.  Normally this is
+            `true` when the parameter is a secret, however it is possible for a parameter
+            to be a secret with a dynamic value that is not a secret.  It is not possible
+            to convert a parameter from a secret to a non-secret if any of the values
+            are dynamic and a secret.  Clients can check this condition by leveraging
+            this field.
         created_at:
           type: string
           format: date-time
@@ -4522,11 +4521,21 @@ components:
 
             For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.
 
-            For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, or if the parameter is `secret` and the content from the integration is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.
+            For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.
 
             If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.
 
             Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
+        secret:
+          type: boolean
+          nullable: true
+          readOnly: true
+          description: Indicates the value content is a secret.  Normally this is
+            `true` when the parameter is a secret, however it is possible for a parameter
+            to be a secret with a dynamic value that is not a secret.  It is not possible
+            to convert a parameter from a secret to a non-secret if any of the values
+            are dynamic and a secret.  Clients can check this condition by leveraging
+            this field.
         created_at:
           type: string
           format: date-time
@@ -4541,6 +4550,7 @@ components:
       - id
       - modified_at
       - parameter
+      - secret
       - url
       - value
     ValueCreate:
@@ -4609,3 +4619,5 @@ components:
         \ the JWT, place your JWT in the Authorization header as 'Bearer JWT', where\n\
         JWT is your JWT.  For example:\n\n    Authorization: Bearer eyJhbGciOiJIkuydfy.eyJzdWIiOiIxMjM....\n\
         \        "
+externalDocs:
+  url: https://docs.cloudtruth.com/

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -44,6 +44,7 @@ fn default_param_value() -> &'static Value {
         dynamic: None,
         dynamic_fqn: None,
         dynamic_filter: None,
+        secret: None,
         static_value: None,
         value: Some("—".to_owned()),
         created_at: "".to_owned(),
@@ -62,7 +63,7 @@ impl From<&Parameter> for ParameterDetails {
         ParameterDetails {
             id: api_param.id.clone(),
             key: api_param.name.clone(),
-            secret: api_param.secret.unwrap_or(false),
+            secret: api_param.secret.unwrap_or(false) || env_value.secret.unwrap_or(false),
             description: api_param.description.clone().unwrap_or_default(),
 
             val_id: env_value.id.clone(),
@@ -373,7 +374,6 @@ impl Parameters {
             description: description.map(String::from),
             secret,
             templates: None,
-            uses_dynamic_values: None,
             values: None,
             created_at: None,
             modified_at: None,
@@ -437,6 +437,7 @@ impl Parameters {
             id: None,
             environment: None,
             parameter: None,
+            secret: None,
             dynamic: Some(dynamic),
             dynamic_fqn: fqn.map(String::from),
             dynamic_filter: jmes_path.map(String::from),


### PR DESCRIPTION
Picks up the following OpenAPI spec changes:
1. Updates API description
2. Removes authentication from API retrieval
3. Removes the 'uses_dynamic_values' property from the Parameter schema
4. Adds/adjusts the Value secret