### PR TITLE
1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.0.1 - 2021-07-26
+
+* Pickup latest OpenAPI changes.
+* Add HTTP Cookie header sent from the first response in subsequent requests.
+* Remove generated client docs from repository.
+* Restore GiHub CI testing.
+
 # 1.0.0 - 2021-07-20
 
 * Update to use REST API server (replaces GraphQL).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.0.0"
+version = "1.0.1"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2018"

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.0.0
+cloudtruth 1.0.1
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 


### PR DESCRIPTION
* Pickup latest OpenAPI changes.
* Add HTTP Cookie header sent from the first response in subsequent requests.
* Remove generated client docs from repository.
* Restore GiHub CI testing.
