### PR TITLE
Cleanup new parameters when fail to add value

### DIFF
--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -145,7 +145,7 @@ impl Parameters {
     /// Deletes the specified parameter by ID
     ///
     /// On success, it returns the deleted parameter ID. On failure, it returns an Error.
-    fn delete_param_by_id(
+    pub fn delete_parameter_by_id(
         &self,
         rest_cfg: &mut OpenApiConfig,
         proj_id: &str,
@@ -170,7 +170,7 @@ impl Parameters {
         let response = self.get_details_by_name(rest_cfg, proj_id, env_id, key_name);
 
         if let Ok(Some(details)) = response {
-            self.delete_param_by_id(rest_cfg, proj_id, details.id.as_str())
+            self.delete_parameter_by_id(rest_cfg, proj_id, details.id.as_str())
         } else {
             Ok(None)
         }

--- a/tests/pytest/test_parameters.py
+++ b/tests/pytest/test_parameters.py
@@ -844,10 +844,7 @@ SECOND_SECRET='sensitive value with spaces'
         # check that nothing was added
         sub_cmd = base_cmd + f" --project {proj_name} parameters "
         result = self.run_cli(cmd_env, sub_cmd + "list --values --secrets -f csv")
-        # TODO: this should be the case -- no parameters, but for now checking invalid value
-        # self.assertTrue(result.out_contains_value(empty_msg))
-        expected = f"{key1},,,static,false"
-        self.assertIn(expected, result.out())
+        self.assertTrue(result.out_contains_value(empty_msg))
 
         # verify `--dynamic` flag causes specialized warning
         sub_cmd = base_cmd + f" --project {proj_name} parameters "


### PR DESCRIPTION
When a new parameter is added and we fail to add the value (e.g. bad FQN), remove the parameter.