### PR TITLE
Performance improvements

### DIFF
--- a/client/src/apis/api_api.rs
+++ b/client/src/apis/api_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -45,7 +46,18 @@ pub fn api_schema_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/client/src/apis/audit_api.rs
+++ b/client/src/apis/audit_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -105,7 +106,18 @@ pub fn audit_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -161,7 +173,18 @@ pub fn audit_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -216,7 +239,18 @@ pub fn audit_summary_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/client/src/apis/configuration.rs
+++ b/client/src/apis/configuration.rs
@@ -19,6 +19,7 @@ pub struct Configuration {
     pub oauth_access_token: Option<String>,
     pub bearer_access_token: Option<String>,
     pub api_key: Option<ApiKey>,
+    pub rest_debug: bool,
     pub cookie: Option<String>,
     // TODO: take an oauth2 token source, similar to the go one
 }
@@ -47,6 +48,7 @@ impl Default for Configuration {
             oauth_access_token: None,
             bearer_access_token: None,
             api_key: None,
+            rest_debug: false,
             cookie: None,
         }
     }

--- a/client/src/apis/environments_api.rs
+++ b/client/src/apis/environments_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -88,7 +89,18 @@ pub fn environments_create(
     local_var_req_builder = local_var_req_builder.json(&environment_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -147,7 +159,18 @@ pub fn environments_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -221,7 +244,18 @@ pub fn environments_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -282,7 +316,18 @@ pub fn environments_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_environment);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -341,7 +386,18 @@ pub fn environments_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -402,7 +458,18 @@ pub fn environments_update(
     local_var_req_builder = local_var_req_builder.json(&environment);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/client/src/apis/integrations_api.rs
+++ b/client/src/apis/integrations_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -127,7 +128,18 @@ pub fn integrations_aws_create(
     local_var_req_builder = local_var_req_builder.json(&aws_integration_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -186,7 +198,18 @@ pub fn integrations_aws_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -260,7 +283,18 @@ pub fn integrations_aws_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -321,7 +355,18 @@ pub fn integrations_aws_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_aws_integration);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -385,7 +430,18 @@ pub fn integrations_aws_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -446,7 +502,18 @@ pub fn integrations_aws_update(
     local_var_req_builder = local_var_req_builder.json(&aws_integration);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -515,7 +582,18 @@ pub fn integrations_explore_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -572,7 +650,18 @@ pub fn integrations_github_create(
     local_var_req_builder = local_var_req_builder.json(&git_hub_integration_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -631,7 +720,18 @@ pub fn integrations_github_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -700,7 +800,18 @@ pub fn integrations_github_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -764,7 +875,18 @@ pub fn integrations_github_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/client/src/apis/invitations_api.rs
+++ b/client/src/apis/invitations_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -110,7 +111,18 @@ pub fn invitations_accept_create(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -167,7 +179,18 @@ pub fn invitations_create(
     local_var_req_builder = local_var_req_builder.json(&invitation_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -226,7 +249,18 @@ pub fn invitations_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -305,7 +339,18 @@ pub fn invitations_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -366,7 +411,18 @@ pub fn invitations_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_invitation);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -426,7 +482,18 @@ pub fn invitations_resend_create(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -485,7 +552,18 @@ pub fn invitations_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -546,7 +624,18 @@ pub fn invitations_update(
     local_var_req_builder = local_var_req_builder.json(&invitation);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/client/src/apis/memberships_api.rs
+++ b/client/src/apis/memberships_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -87,7 +88,18 @@ pub fn memberships_create(
     local_var_req_builder = local_var_req_builder.json(&membership_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -146,7 +158,18 @@ pub fn memberships_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -220,7 +243,18 @@ pub fn memberships_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -281,7 +315,18 @@ pub fn memberships_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_membership);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -340,7 +385,18 @@ pub fn memberships_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -401,7 +457,18 @@ pub fn memberships_update(
     local_var_req_builder = local_var_req_builder.json(&membership);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/client/src/apis/organizations_api.rs
+++ b/client/src/apis/organizations_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -87,7 +88,18 @@ pub fn organizations_create(
     local_var_req_builder = local_var_req_builder.json(&organization_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -146,7 +158,18 @@ pub fn organizations_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -215,7 +238,18 @@ pub fn organizations_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -276,7 +310,18 @@ pub fn organizations_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_organization);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -335,7 +380,18 @@ pub fn organizations_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -396,7 +452,18 @@ pub fn organizations_update(
     local_var_req_builder = local_var_req_builder.json(&organization);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/client/src/apis/projects_api.rs
+++ b/client/src/apis/projects_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -237,7 +238,18 @@ pub fn projects_create(
     local_var_req_builder = local_var_req_builder.json(&project_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -292,7 +304,18 @@ pub fn projects_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -361,7 +384,18 @@ pub fn projects_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -471,7 +505,18 @@ pub fn projects_parameter_export_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -532,7 +577,18 @@ pub fn projects_parameters_create(
     local_var_req_builder = local_var_req_builder.json(&parameter_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -593,7 +649,18 @@ pub fn projects_parameters_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -682,7 +749,18 @@ pub fn projects_parameters_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -745,7 +823,18 @@ pub fn projects_parameters_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_parameter);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -821,7 +910,18 @@ pub fn projects_parameters_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -884,7 +984,18 @@ pub fn projects_parameters_update(
     local_var_req_builder = local_var_req_builder.json(&parameter);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -953,7 +1064,18 @@ pub fn projects_parameters_values_create(
     local_var_req_builder = local_var_req_builder.json(&value_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1017,7 +1139,18 @@ pub fn projects_parameters_values_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1104,7 +1237,18 @@ pub fn projects_parameters_values_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1175,7 +1319,18 @@ pub fn projects_parameters_values_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_value);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1249,7 +1404,18 @@ pub fn projects_parameters_values_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1320,7 +1486,18 @@ pub fn projects_parameters_values_update(
     local_var_req_builder = local_var_req_builder.json(&value);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1377,7 +1554,18 @@ pub fn projects_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_project);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1432,7 +1620,18 @@ pub fn projects_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1504,7 +1703,18 @@ pub fn projects_template_preview_create(
     local_var_req_builder = local_var_req_builder.json(&template_preview);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1565,7 +1775,18 @@ pub fn projects_templates_create(
     local_var_req_builder = local_var_req_builder.json(&template_create);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1626,7 +1847,18 @@ pub fn projects_templates_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1700,7 +1932,18 @@ pub fn projects_templates_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1763,7 +2006,18 @@ pub fn projects_templates_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_template);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1834,7 +2088,18 @@ pub fn projects_templates_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1897,7 +2162,18 @@ pub fn projects_templates_update(
     local_var_req_builder = local_var_req_builder.json(&template);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -1954,7 +2230,18 @@ pub fn projects_update(
     local_var_req_builder = local_var_req_builder.json(&project);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/client/src/apis/serviceaccounts_api.rs
+++ b/client/src/apis/serviceaccounts_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -88,7 +89,18 @@ pub fn serviceaccounts_create(
     local_var_req_builder = local_var_req_builder.json(&service_account_create_request);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -147,7 +159,18 @@ pub fn serviceaccounts_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -211,7 +234,18 @@ pub fn serviceaccounts_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -272,7 +306,18 @@ pub fn serviceaccounts_partial_update(
     local_var_req_builder = local_var_req_builder.json(&patched_service_account);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -331,7 +376,18 @@ pub fn serviceaccounts_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -392,7 +448,18 @@ pub fn serviceaccounts_update(
     local_var_req_builder = local_var_req_builder.json(&service_account);
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/client/src/apis/users_api.rs
+++ b/client/src/apis/users_api.rs
@@ -9,6 +9,7 @@
  */
 
 use reqwest;
+use std::time::Instant;
 
 use super::{configuration, Error};
 use crate::apis::ResponseContent;
@@ -72,7 +73,18 @@ pub fn users_destroy(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -141,7 +153,18 @@ pub fn users_list(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;
@@ -200,7 +223,18 @@ pub fn users_retrieve(
     }
 
     let local_var_req = local_var_req_builder.build()?;
+    let method = local_var_req.method().clone();
+    let start = Instant::now();
     let mut local_var_resp = local_var_client.execute(local_var_req)?;
+    if configuration.rest_debug {
+        let duration = start.elapsed();
+        println!(
+            "URL {} {} elapsed: {:?}",
+            method,
+            &local_var_resp.url(),
+            duration
+        );
+    }
 
     let local_var_status = local_var_resp.status();
     let local_var_content = local_var_resp.text()?;

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,6 +1,9 @@
 use crate::config::profiles::Profile;
-use crate::config::{CT_API_KEY, CT_ENVIRONMENT, CT_PROJECT, CT_REQ_TIMEOUT, CT_SERVER_URL};
+use crate::config::{
+    CT_API_KEY, CT_ENVIRONMENT, CT_PROJECT, CT_REQ_TIMEOUT, CT_REST_DEBUG, CT_SERVER_URL,
+};
 use std::env;
+use std::str::FromStr;
 
 pub struct ConfigEnv {}
 
@@ -12,6 +15,8 @@ impl ConfigEnv {
             environment: ConfigEnv::get_override(CT_ENVIRONMENT),
             project: ConfigEnv::get_override(CT_PROJECT),
             request_timeout: ConfigEnv::get_duration_override(),
+            rest_debug: ConfigEnv::get_override(CT_REST_DEBUG)
+                .map(|s| bool::from_str(&s.to_lowercase()).unwrap()),
             server_url: ConfigEnv::get_override(CT_SERVER_URL),
             source_profile: None,
         }
@@ -49,6 +54,7 @@ mod tests {
         env::remove_var(CT_PROJECT);
         env::remove_var(CT_REQ_TIMEOUT);
         env::remove_var(CT_SERVER_URL);
+        env::remove_var(CT_REST_DEBUG);
     }
 
     #[test]
@@ -72,6 +78,7 @@ mod tests {
         env::set_var(CT_PROJECT, "skunkworks");
         env::set_var(CT_REQ_TIMEOUT, "500");
         env::set_var(CT_SERVER_URL, "http://localhost:7001/graphql");
+        env::set_var(CT_REST_DEBUG, "true");
 
         assert_eq!(
             Profile {
@@ -80,6 +87,7 @@ mod tests {
                 environment: Some("my_environment".to_string()),
                 project: Some("skunkworks".to_string()),
                 request_timeout: Some(500),
+                rest_debug: Some(true),
                 server_url: Some("http://localhost:7001/graphql".to_string()),
                 source_profile: None
             },

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -114,6 +114,7 @@ impl ConfigFile {
             parent: profile.source_profile.clone(),
             server_url: profile.server_url.clone(),
             request_timeout: profile.request_timeout.map(|t| format!("{}", t)),
+            rest_debug: profile.rest_debug,
         }
     }
 

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -8,6 +8,7 @@ pub struct Profile {
     pub environment: Option<String>,
     pub project: Option<String>,
     pub request_timeout: Option<u64>,
+    pub rest_debug: Option<bool>,
     pub server_url: Option<String>,
     pub(crate) source_profile: Option<String>,
 }
@@ -23,6 +24,7 @@ pub struct ProfileDetails {
     pub parent: Option<String>,
     pub server_url: Option<String>,
     pub request_timeout: Option<String>,
+    pub rest_debug: Option<bool>,
 }
 
 impl Default for Profile {
@@ -35,6 +37,7 @@ impl Default for Profile {
             request_timeout: None,
             server_url: None,
             source_profile: None,
+            rest_debug: None,
         }
     }
 }
@@ -54,6 +57,7 @@ impl Profile {
                 .or_else(|| self.environment.clone()),
             project: other.project.clone().or_else(|| self.project.clone()),
             request_timeout: other.request_timeout.or(self.request_timeout),
+            rest_debug: other.rest_debug.or(self.rest_debug),
             server_url: other.server_url.clone().or_else(|| self.server_url.clone()),
             source_profile: self.source_profile.clone(),
         }
@@ -76,6 +80,7 @@ mod tests {
             environment: Some("my_environment".to_string()),
             project: Some("skunkworks".to_string()),
             request_timeout: Some(100),
+            rest_debug: Some(true),
             server_url: Some("http://localhost:7001/graphql".to_string()),
             ..Profile::default()
         };
@@ -91,6 +96,7 @@ mod tests {
             environment: Some("my_environment".to_string()),
             project: Some("skunkworks".to_string()),
             request_timeout: Some(23),
+            rest_debug: Some(false),
             server_url: Some("http://localhost:7001/graphql".to_string()),
             ..Profile::default()
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -626,7 +626,7 @@ fn process_parameters_command(
         let key = subcmd_args.value_of("KEY").unwrap();
         let proj_id = resolved.project_id();
         let env_id = resolved.environment_id();
-        let parameter = parameters.get_details_by_name(rest_cfg, proj_id, env_id, key);
+        let parameter = parameters.get_details_by_name(rest_cfg, proj_id, env_id, key, false);
 
         if let Ok(details) = parameter {
             // Treat parameters without values set as if the value were simply empty, since
@@ -705,7 +705,7 @@ fn process_parameters_command(
             // get the original values, so that is not lost
             let mut updated: ParameterDetails;
             if let Some(original) =
-                parameters.get_details_by_name(rest_cfg, proj_id, env_id, key_name)?
+                parameters.get_details_by_name(rest_cfg, proj_id, env_id, key_name, true)?
             {
                 // only update if there is something to update
                 if description.is_some() || secret.is_some() || rename.is_some() {

--- a/src/openapi.rs
+++ b/src/openapi.rs
@@ -57,6 +57,7 @@ impl From<&CloudTruthConfig> for OpenApiConfig {
                 key: ct_cfg.api_key.clone(),
             }),
             cookie: None,
+            rest_debug: ct_cfg.rest_debug,
         }
     }
 }
@@ -78,6 +79,7 @@ mod tests {
             project: Some("my-proj".to_string()),
             server_url: url.to_string(),
             request_timeout: Some(Duration::new(120, 0)),
+            rest_debug: true,
         };
         let openapi_cfg = OpenApiConfig::from(&ct_cfg);
         // check that the trailing slash removed from the URL
@@ -88,6 +90,7 @@ mod tests {
         assert_eq!(openapi_cfg.api_key.unwrap().key, api_key.to_string());
         assert_eq!(openapi_cfg.user_agent.unwrap(), user_agent_name());
         assert_eq!(openapi_cfg.bearer_access_token, None);
+        assert_eq!(openapi_cfg.rest_debug, true);
         // unfortunately, no means to interrogate the client to find the timeout
     }
 

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -208,7 +208,7 @@ impl Parameters {
         key_name: &str,
     ) -> Result<Option<String>, Error<ProjectsParametersDestroyError>> {
         // The only delete mechanism is by parameter ID, so start by querying the parameter info.
-        let response = self.get_details_by_name(rest_cfg, proj_id, env_id, key_name);
+        let response = self.get_details_by_name(rest_cfg, proj_id, env_id, key_name, true);
 
         if let Ok(Some(details)) = response {
             self.delete_parameter_by_id(rest_cfg, proj_id, details.id.as_str())
@@ -226,7 +226,7 @@ impl Parameters {
         key_name: &str,
     ) -> Result<Option<String>, Error<ProjectsParametersValuesDestroyError>> {
         // The only delete mechanism is by parameter ID, so start by querying the parameter info.
-        let response = self.get_details_by_name(rest_cfg, proj_id, env_id, key_name);
+        let response = self.get_details_by_name(rest_cfg, proj_id, env_id, key_name, true);
 
         if let Ok(Some(details)) = response {
             if details.env_url.contains(env_id) {
@@ -289,12 +289,13 @@ impl Parameters {
         proj_id: &str,
         env_id: &str,
         key_name: &str,
+        mask_secrets: bool,
     ) -> Result<Option<ParameterDetails>, Error<ProjectsParametersListError>> {
         let response = projects_parameters_list(
             rest_cfg,
             proj_id,
             Some(env_id),
-            Some(false), // get secret value when querying a single parameter
+            Some(mask_secrets),
             Some(key_name),
             None,
             PAGE_SIZE,

--- a/tests/pytest/test_environments.py
+++ b/tests/pytest/test_environments.py
@@ -90,7 +90,9 @@ class TestEnvironments(TestCase):
 
         # make sure we get the same parameter list
         after = self.run_cli(cmd_env, param_cmd)
-        self.assertEqual(before, after)
+        self.assertEqual(before.return_value, after.return_value)
+        self.assertEqual(before.out(), after.out())
+        self.assertEqual(before.err(), after.err())
 
         # cleanup
         self.delete_project(cmd_env, proj_name)

--- a/tests/pytest/test_timing.py
+++ b/tests/pytest/test_timing.py
@@ -1,0 +1,133 @@
+import os
+
+from collections import OrderedDict
+from typing import List
+
+from testcase import TestCase
+from testcase import CT_REST_DEBUG
+
+
+# some environment variables for test control (without file modification)
+CT_PERSIST = "CLOUDTRUTH_TEST_PERSIST"
+CT_PARAM_COUNT = "CLOUDTRUTH_TEST_PARAMETER_COUNT"
+
+
+ENV_RESOLVE = "env-resolve"
+PROJ_RESOLVE = "proj-resolve"
+DEFAULT_PARAM_COUNT = 20
+
+
+def parse_time(value: str) -> int:
+    """
+    Parses the string into a integer representing the number of milliseconds.
+    """
+    if value.endswith("ms"):
+        return int(float(value.replace("ms", "")))
+    return int(float(value.replace("s", "")) * 1000)
+
+
+def parse_timing(timing_info: List[List[int]], lines: List[str]) -> List[List[int]]:
+    url_count = 0
+    for line in lines:
+        if not line.startswith("URL"):
+            continue
+
+        elapsed = line.split("elapsed: ")[-1]
+        curr_list = timing_info[url_count]
+        curr_list.append(parse_time(elapsed))
+        timing_info[url_count] = curr_list
+        url_count += 1
+
+    return timing_info
+
+
+def print_timing_info(test_name: str, timing_info: OrderedDict) -> None:
+    print("\n" + '=' * 40 + f"  {test_name} " + '=' * 40)
+    print("Times in milliseconds")
+    for operation, times in timing_info.items():
+        pretty = ", ".join([str(x) for x in times])
+        print(f"{operation}  ==>  [{pretty}]")
+
+
+class TestTiming(TestCase):
+    def setUp(self) -> None:
+        self.leave_up = CT_PERSIST in os.environ
+        self.param_count = int(os.environ.get(CT_PARAM_COUNT) or DEFAULT_PARAM_COUNT)
+        self.param_prefix = "param"
+        super().setUp()
+
+    def _param_name(self, index: int) -> str:
+        return f"{self.param_prefix}{index}"
+
+    def _parameter_create_timing(self, proj_name: str, num_values: int, secret: bool) -> OrderedDict:
+        base_cmd = self.get_cli_base_cmd()
+        get_cmd = base_cmd + f"--project '{proj_name}' param get "
+        cmd_env = self.get_cmd_env()
+        cmd_env[CT_REST_DEBUG] = "true"
+        create_timing = [[], [], [], [], [], ]
+        get_timing = [[], [], [], []]
+
+        for index in range(num_values):
+            result = self.set_param(cmd_env, proj_name, self._param_name(index), "abc123", secret=secret)
+            self.assertEqual(result.return_value, 0)
+            create_timing = parse_timing(create_timing, result.stdout)
+
+            result = self.run_cli(cmd_env, get_cmd + f"'{self._param_name(index)}'")
+            self.assertEqual(result.return_value, 0)
+            get_timing = parse_timing(get_timing, result.stdout)
+
+        rval = OrderedDict()
+        rval["create-" + ENV_RESOLVE] = create_timing[0]
+        rval["create-" + PROJ_RESOLVE] = create_timing[1]
+        rval["create-param-set"] = create_timing[2]
+        rval["create-param-set"] = create_timing[3]
+        rval["create-value-set"] = create_timing[4]
+
+        rval["get-" + ENV_RESOLVE] = get_timing[0]
+        rval["get-" + PROJ_RESOLVE] = get_timing[1]
+        rval["get-param-resolve"] = get_timing[2]
+        rval["get-param-retrieve"] = get_timing[3]
+        return rval
+
+    def _parameter_retrieve_timing(self, proj_name: str, num_values: int) -> OrderedDict:
+        base_cmd = self.get_cli_base_cmd()
+        get_cmd = base_cmd + f"--project '{proj_name}' param get "
+        cmd_env = self.get_cmd_env()
+        cmd_env[CT_REST_DEBUG] = "true"
+
+        timing_info = [[], [], [], []]
+        for index in range(num_values):
+            result = self.run_cli(cmd_env, get_cmd + f"'{self._param_name(index)}'")
+            self.assertEqual(result.return_value, 0)
+            timing_info = parse_timing(timing_info, result.stdout)
+
+        rval = OrderedDict()
+        rval[ENV_RESOLVE] = timing_info[0]
+        rval[PROJ_RESOLVE] = timing_info[1]
+        rval["param-resolve"] = timing_info[2]
+        rval["param-retrieve"] = timing_info[3]
+        return rval
+
+    def test_timing_secrets(self) -> None:
+        cmd_env = self.get_cmd_env()
+        proj_name = self.make_name("test-timing-secrets")
+        self.create_project(cmd_env, proj_name)
+
+        timing = self._parameter_create_timing(proj_name, self.param_count, True)
+        print_timing_info("timing-secrets", timing)
+
+        # cleanup
+        if not self.leave_up:
+            self.delete_project(cmd_env, proj_name)
+
+    def test_timing_params(self) -> None:
+        cmd_env = self.get_cmd_env()
+        proj_name = self.make_name("test-timing-params")
+        self.create_project(cmd_env, proj_name)
+
+        timing = self._parameter_create_timing(proj_name, self.param_count, False)
+        print_timing_info("timing-parameters", timing)
+
+        # cleanup
+        if not self.leave_up:
+            self.delete_project(cmd_env, proj_name)

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -15,6 +15,7 @@ CT_PROFILE = "CLOUDTRUTH_PROFILE"
 CT_PROJ = "CLOUDTRUTH_PROJECT"
 CT_URL = "CLOUDTRUTH_SERVER_URL"
 CT_TIMEOUT = "CLOUDTRUTH_REQUEST_TIMEOUT"
+CT_REST_DEBUG = "CLOUDTRUTH_REST_DEBUG"
 
 DEFAULT_SERVER_URL = "https://api.cloudtruth.io"
 DEFAULT_ENV_NAME = "default"
@@ -230,26 +231,30 @@ class TestCase(unittest.TestCase):
                 }
         return None
 
-    def create_project(self, cmd_env, proj_name: str) -> None:
+    def create_project(self, cmd_env, proj_name: str) -> Result:
         result = self.run_cli(cmd_env,
                               self._base_cmd + f"proj set '{proj_name}' -d '{AUTO_DESCRIPTION}'")
         self.assertEqual(result.return_value, 0)
+        return result
 
-    def delete_project(self, cmd_env, proj_name: str) -> None:
+    def delete_project(self, cmd_env, proj_name: str) -> Result:
         result = self.run_cli(cmd_env, self._base_cmd + f"proj delete '{proj_name}' --confirm")
         self.assertEqual(result.return_value, 0)
+        return result
 
-    def create_environment(self, cmd_env, env_name: str, parent: Optional[str] = None) -> None:
+    def create_environment(self, cmd_env, env_name: str, parent: Optional[str] = None) -> Result:
         cmd = self._base_cmd + f"env set '{env_name}' "
         if parent:
             cmd += f"-p '{parent}' "
         cmd += f"-d '{AUTO_DESCRIPTION}'"
         result = self.run_cli(cmd_env, cmd)
         self.assertEqual(result.return_value, 0)
+        return result
 
-    def delete_environment(self, cmd_env, env_name: str) -> None:
+    def delete_environment(self, cmd_env, env_name: str) -> Result:
         result = self.run_cli(cmd_env, self._base_cmd + f"env del '{env_name}' --confirm")
         self.assertEqual(result.return_value, 0)
+        return result
 
     def set_param(
             self,
@@ -260,7 +265,7 @@ class TestCase(unittest.TestCase):
             secret: Optional[bool] = None,
             env: Optional[str] = None,
             desc: Optional[str] = None,
-    ) -> None:
+    ) -> Result:
         cmd = self._base_cmd + f"--project '{proj}' "
         if env:
             cmd += f"--env '{env}' "
@@ -271,6 +276,7 @@ class TestCase(unittest.TestCase):
             cmd += f"--desc '{desc}' "
         result = self.run_cli(cmd_env, cmd)
         self.assertEqual(result.return_value, 0)
+        return result
 
     def unset_param(
         self,
@@ -278,21 +284,23 @@ class TestCase(unittest.TestCase):
         proj: str,
         name: str,
         env: Optional[str] = None,
-    ):
+    ) -> Result:
         cmd = self._base_cmd + f"--project '{proj}' "
         if env:
             cmd += f"--env '{env}' "
         cmd += f"param unset '{name}' "
         result = self.run_cli(cmd_env, cmd)
         self.assertEqual(result.return_value, 0)
+        return result
 
-    def delete_param(self, cmd_env, proj: str, name: str, env: Optional[str] = None) -> None:
+    def delete_param(self, cmd_env, proj: str, name: str, env: Optional[str] = None) -> Result:
         cmd = self._base_cmd + f"--project '{proj}' "
         if env:
             cmd += f"--env '{env}' "
         cmd += f"param delete '{name}'"
         result = self.run_cli(cmd_env, cmd)
         self.assertEqual(result.return_value, 0)
+        return result
 
     def verify_param(
             self,

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -4,6 +4,7 @@ import shlex
 import subprocess
 import unittest
 from copy import deepcopy
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import List, Optional, Dict
 
@@ -68,6 +69,7 @@ class Result:
     return_value: int = 0,
     stdout: List = dataclasses.field(default_factory=list),
     stderr: List = dataclasses.field(default_factory=list),
+    timediff: timedelta = timedelta(0)
 
     @staticmethod
     def _first_line_contains(stream: List[str], value: str) -> Optional[str]:
@@ -198,13 +200,16 @@ class TestCase(unittest.TestCase):
                 if proj_name:
                     self._projects.add(proj_name)
 
+        start = datetime.now()
         process = subprocess.run(
             cmd, env=env, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
+        delta = datetime.now() - start
         result = Result(
             return_value=process.returncode,
             stdout=process.stdout.decode("us-ascii", errors="ignore").replace("\r", "").split("\n"),
             stderr=process.stderr.decode("us-ascii", errors="ignore").replace("\r", "").split("\n"),
+            timediff=delta,
         )
 
         if self.log_output:


### PR DESCRIPTION
1. When getting a single Parameter, mask_secrets unless the value is needed.
2. Add configurable REST_DEBUG to see URLs and timing info
3. Use a 2-step 'get_details_by_name()' -- get the id, then get the value by id (workaround for server issue)