### PR TITLE
Adjustments for dynamic error handling changes

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -35,14 +35,14 @@ Class | Method | HTTP request | Description
 *EnvironmentsApi* | [**environments_retrieve**](docs/EnvironmentsApi.md#environments_retrieve) | **get** /api/v1/environments/{id}/ | 
 *EnvironmentsApi* | [**environments_update**](docs/EnvironmentsApi.md#environments_update) | **put** /api/v1/environments/{id}/ | 
 *IntegrationsApi* | [**integrations_aws_create**](docs/IntegrationsApi.md#integrations_aws_create) | **post** /api/v1/integrations/aws/ | Establishes an AWS Integration.
-*IntegrationsApi* | [**integrations_aws_destroy**](docs/IntegrationsApi.md#integrations_aws_destroy) | **delete** /api/v1/integrations/aws/{id}/ | 
+*IntegrationsApi* | [**integrations_aws_destroy**](docs/IntegrationsApi.md#integrations_aws_destroy) | **delete** /api/v1/integrations/aws/{id}/ | Delete an AWS integration.
 *IntegrationsApi* | [**integrations_aws_list**](docs/IntegrationsApi.md#integrations_aws_list) | **get** /api/v1/integrations/aws/ | 
 *IntegrationsApi* | [**integrations_aws_partial_update**](docs/IntegrationsApi.md#integrations_aws_partial_update) | **patch** /api/v1/integrations/aws/{id}/ | 
 *IntegrationsApi* | [**integrations_aws_retrieve**](docs/IntegrationsApi.md#integrations_aws_retrieve) | **get** /api/v1/integrations/aws/{id}/ | Get details of an AWS Integration.
 *IntegrationsApi* | [**integrations_aws_update**](docs/IntegrationsApi.md#integrations_aws_update) | **put** /api/v1/integrations/aws/{id}/ | 
 *IntegrationsApi* | [**integrations_explore_list**](docs/IntegrationsApi.md#integrations_explore_list) | **get** /api/v1/integrations/explore/ | Retrieve third-party integration data for the specified FQN.
 *IntegrationsApi* | [**integrations_github_create**](docs/IntegrationsApi.md#integrations_github_create) | **post** /api/v1/integrations/github/ | Establishes a GitHub Integration.
-*IntegrationsApi* | [**integrations_github_destroy**](docs/IntegrationsApi.md#integrations_github_destroy) | **delete** /api/v1/integrations/github/{id}/ | 
+*IntegrationsApi* | [**integrations_github_destroy**](docs/IntegrationsApi.md#integrations_github_destroy) | **delete** /api/v1/integrations/github/{id}/ | Delete a GitHub integration.
 *IntegrationsApi* | [**integrations_github_list**](docs/IntegrationsApi.md#integrations_github_list) | **get** /api/v1/integrations/github/ | 
 *IntegrationsApi* | [**integrations_github_retrieve**](docs/IntegrationsApi.md#integrations_github_retrieve) | **get** /api/v1/integrations/github/{id}/ | Get details of a GitHub Integration.
 *InvitationsApi* | [**invitations_accept_create**](docs/InvitationsApi.md#invitations_accept_create) | **post** /api/v1/invitations/{id}/accept/ | Accept an invitation.

--- a/client/src/apis/integrations_api.rs
+++ b/client/src/apis/integrations_api.rs
@@ -25,6 +25,7 @@ pub enum IntegrationsAwsCreateError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum IntegrationsAwsDestroyError {
+    Status409(),
     UnknownValue(serde_json::Value),
 }
 
@@ -78,6 +79,7 @@ pub enum IntegrationsGithubCreateError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum IntegrationsGithubDestroyError {
+    Status409(),
     UnknownValue(serde_json::Value),
 }
 
@@ -157,6 +159,7 @@ pub fn integrations_aws_create(
 pub fn integrations_aws_destroy(
     configuration: &configuration::Configuration,
     id: &str,
+    in_use: Option<&str>,
 ) -> Result<(), Error<IntegrationsAwsDestroyError>> {
     let local_var_client = &configuration.client;
 
@@ -167,6 +170,10 @@ pub fn integrations_aws_destroy(
     );
     let mut local_var_req_builder = local_var_client.delete(local_var_uri_str.as_str());
 
+    if let Some(ref local_var_str) = in_use {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("in_use", &local_var_str.to_string())]);
+    }
     if let Some(ref local_var_user_agent) = configuration.user_agent {
         local_var_req_builder =
             local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
@@ -616,6 +623,7 @@ pub fn integrations_github_create(
 pub fn integrations_github_destroy(
     configuration: &configuration::Configuration,
     id: &str,
+    in_use: Option<&str>,
 ) -> Result<(), Error<IntegrationsGithubDestroyError>> {
     let local_var_client = &configuration.client;
 
@@ -626,6 +634,10 @@ pub fn integrations_github_destroy(
     );
     let mut local_var_req_builder = local_var_client.delete(local_var_uri_str.as_str());
 
+    if let Some(ref local_var_str) = in_use {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("in_use", &local_var_str.to_string())]);
+    }
     if let Some(ref local_var_user_agent) = configuration.user_agent {
         local_var_req_builder =
             local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());

--- a/client/src/apis/projects_api.rs
+++ b/client/src/apis/projects_api.rs
@@ -638,6 +638,7 @@ pub fn projects_parameters_list(
     name: Option<&str>,
     page: Option<i32>,
     page_size: Option<i32>,
+    partial_success: Option<bool>,
     wrap: Option<bool>,
 ) -> Result<crate::models::PaginatedParameterList, Error<ProjectsParametersListError>> {
     let local_var_client = &configuration.client;
@@ -668,6 +669,10 @@ pub fn projects_parameters_list(
     if let Some(ref local_var_str) = page_size {
         local_var_req_builder =
             local_var_req_builder.query(&[("page_size", &local_var_str.to_string())]);
+    }
+    if let Some(ref local_var_str) = partial_success {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("partial_success", &local_var_str.to_string())]);
     }
     if let Some(ref local_var_str) = wrap {
         local_var_req_builder =
@@ -792,6 +797,7 @@ pub fn projects_parameters_retrieve(
     project_pk: &str,
     environment: Option<&str>,
     mask_secrets: Option<bool>,
+    partial_success: Option<bool>,
     wrap: Option<bool>,
 ) -> Result<crate::models::Parameter, Error<ProjectsParametersRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -811,6 +817,10 @@ pub fn projects_parameters_retrieve(
     if let Some(ref local_var_str) = mask_secrets {
         local_var_req_builder =
             local_var_req_builder.query(&[("mask_secrets", &local_var_str.to_string())]);
+    }
+    if let Some(ref local_var_str) = partial_success {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("partial_success", &local_var_str.to_string())]);
     }
     if let Some(ref local_var_str) = wrap {
         local_var_req_builder =
@@ -1075,6 +1085,7 @@ pub fn projects_parameters_values_list(
     mask_secrets: Option<bool>,
     page: Option<i32>,
     page_size: Option<i32>,
+    partial_success: Option<bool>,
     wrap: Option<bool>,
 ) -> Result<crate::models::PaginatedValueList, Error<ProjectsParametersValuesListError>> {
     let local_var_client = &configuration.client;
@@ -1102,6 +1113,10 @@ pub fn projects_parameters_values_list(
     if let Some(ref local_var_str) = page_size {
         local_var_req_builder =
             local_var_req_builder.query(&[("page_size", &local_var_str.to_string())]);
+    }
+    if let Some(ref local_var_str) = partial_success {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("partial_success", &local_var_str.to_string())]);
     }
     if let Some(ref local_var_str) = wrap {
         local_var_req_builder =
@@ -1235,6 +1250,7 @@ pub fn projects_parameters_values_retrieve(
     parameter_pk: &str,
     project_pk: &str,
     mask_secrets: Option<bool>,
+    partial_success: Option<bool>,
     wrap: Option<bool>,
 ) -> Result<crate::models::Value, Error<ProjectsParametersValuesRetrieveError>> {
     let local_var_client = &configuration.client;
@@ -1251,6 +1267,10 @@ pub fn projects_parameters_values_retrieve(
     if let Some(ref local_var_str) = mask_secrets {
         local_var_req_builder =
             local_var_req_builder.query(&[("mask_secrets", &local_var_str.to_string())]);
+    }
+    if let Some(ref local_var_str) = partial_success {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("partial_success", &local_var_str.to_string())]);
     }
     if let Some(ref local_var_str) = wrap {
         local_var_req_builder =

--- a/client/src/models/patched_value.rs
+++ b/client/src/models/patched_value.rs
@@ -32,10 +32,13 @@ pub struct PatchedValue {
     /// If `dynamic`, the content returned by the integration can be reduced by applying a JMESpath expression.  This is valid as long as the content is structured and of a supported format.  We support JMESpath expressions on `json`, `yaml`, and `dotenv` content.
     #[serde(rename = "dynamic_filter", skip_serializing_if = "Option::is_none")]
     pub dynamic_filter: Option<String>,
+    /// If the value is dynamic, and an error occurs retrieving it, the reason for the retrieval error will be placed into this field.  The query parameter `partial_success` can be used to control whether this condition causes an HTTP error response or not.
+    #[serde(rename = "dynamic_error", skip_serializing_if = "Option::is_none")]
+    pub dynamic_error: Option<String>,
     /// This is the content to use when resolving the Value for a static non-secret.
     #[serde(rename = "static_value", skip_serializing_if = "Option::is_none")]
     pub static_value: Option<String>,
-    /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `dynamic` and parameters that are not `secret`, the system will use the content in `static_value` to satisfy the request.  For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
+    /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `dynamic` and parameters that are not `secret`, the system will use the content in `static_value` to satisfy the request.  For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  You can control the error handling behavior of the server through the `partial_success` query parameter.  If the content from the integration is `secret` and the parameter is not, an error will occur.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
     #[serde(rename = "value", skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
     /// Indicates the value content is a secret.  Normally this is `true` when the parameter is a secret, however it is possible for a parameter to be a secret with a dynamic value that is not a secret.  It is not possible to convert a parameter from a secret to a non-secret if any of the values are dynamic and a secret.  Clients can check this condition by leveraging this field.
@@ -58,6 +61,7 @@ impl PatchedValue {
             dynamic: None,
             dynamic_fqn: None,
             dynamic_filter: None,
+            dynamic_error: None,
             static_value: None,
             value: None,
             secret: None,

--- a/client/src/models/value.rs
+++ b/client/src/models/value.rs
@@ -32,10 +32,13 @@ pub struct Value {
     /// If `dynamic`, the content returned by the integration can be reduced by applying a JMESpath expression.  This is valid as long as the content is structured and of a supported format.  We support JMESpath expressions on `json`, `yaml`, and `dotenv` content.
     #[serde(rename = "dynamic_filter", skip_serializing_if = "Option::is_none")]
     pub dynamic_filter: Option<String>,
+    /// If the value is dynamic, and an error occurs retrieving it, the reason for the retrieval error will be placed into this field.  The query parameter `partial_success` can be used to control whether this condition causes an HTTP error response or not.
+    #[serde(rename = "dynamic_error")]
+    pub dynamic_error: Option<String>,
     /// This is the content to use when resolving the Value for a static non-secret.
     #[serde(rename = "static_value", skip_serializing_if = "Option::is_none")]
     pub static_value: Option<String>,
-    /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `dynamic` and parameters that are not `secret`, the system will use the content in `static_value` to satisfy the request.  For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
+    /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `dynamic` and parameters that are not `secret`, the system will use the content in `static_value` to satisfy the request.  For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  You can control the error handling behavior of the server through the `partial_success` query parameter.  If the content from the integration is `secret` and the parameter is not, an error will occur.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
     #[serde(rename = "value")]
     pub value: Option<String>,
     /// Indicates the value content is a secret.  Normally this is `true` when the parameter is a secret, however it is possible for a parameter to be a secret with a dynamic value that is not a secret.  It is not possible to convert a parameter from a secret to a non-secret if any of the values are dynamic and a secret.  Clients can check this condition by leveraging this field.
@@ -54,6 +57,7 @@ impl Value {
         id: String,
         environment: String,
         parameter: String,
+        dynamic_error: Option<String>,
         value: Option<String>,
         secret: Option<bool>,
         created_at: String,
@@ -67,6 +71,7 @@ impl Value {
             dynamic: None,
             dynamic_fqn: None,
             dynamic_filter: None,
+            dynamic_error,
             static_value: None,
             value,
             secret,

--- a/openapi.yml
+++ b/openapi.yml
@@ -605,6 +605,7 @@ paths:
     delete:
       operationId: integrations_aws_destroy
       description: ''
+      summary: Delete an AWS integration.
       parameters:
       - in: path
         name: id
@@ -613,6 +614,20 @@ paths:
           format: uuid
           description: The unique identifier for the integration.
         required: true
+      - in: query
+        name: in_use
+        schema:
+          type: string
+          enum:
+          - fail
+          - leave
+          - remove
+        description: |-
+          (Optional) Desired behavior if the integration has in-use values.
+
+          - `fail` will return HTTP error 409 if there are any values using the integration.
+          - `leave` (default) will leave values in place and future queries may fail; you can control future value query behavior with the `lookup_error` query parameter on those requests.
+          - `remove` will remove the all values using the integration when the integration is removed.
       tags:
       - integrations
       security:
@@ -620,7 +635,10 @@ paths:
       - ApiKeyAuth: []
       responses:
         '204':
-          description: No response body
+          description: Integration removed.
+        '409':
+          description: The integration is used by one (or more) Value(s) and cannot
+            be removed.
   /api/v1/integrations/explore/:
     get:
       operationId: integrations_explore_list
@@ -775,6 +793,7 @@ paths:
     delete:
       operationId: integrations_github_destroy
       description: ''
+      summary: Delete a GitHub integration.
       parameters:
       - in: path
         name: id
@@ -783,6 +802,20 @@ paths:
           format: uuid
           description: The unique identifier for the integration.
         required: true
+      - in: query
+        name: in_use
+        schema:
+          type: string
+          enum:
+          - fail
+          - leave
+          - remove
+        description: |-
+          (Optional) Desired behavior if the integration has in-use values.
+
+          - `fail` will return HTTP error 409 if there are any values using the integration.
+          - `leave` (default) will leave values in place and future queries may fail; you can control future value query behavior with the `lookup_error` query parameter on those requests.
+          - `remove` will remove the all values using the integration when the integration is removed.
       tags:
       - integrations
       security:
@@ -790,7 +823,10 @@ paths:
       - ApiKeyAuth: []
       responses:
         '204':
-          description: No response body
+          description: Integration removed.
+        '409':
+          description: The integration is used by one (or more) Value(s) and cannot
+            be removed.
   /api/v1/invitations/:
     get:
       operationId: invitations_list
@@ -1703,6 +1739,16 @@ paths:
         description: Number of results to return per page.
         schema:
           type: integer
+      - in: query
+        name: partial_success
+        schema:
+          type: boolean
+          default: false
+        description: |-
+          Determine if the response is allowed to include a partial success.
+
+          A partial success can occur if one or more dynamic values cannot be retrieved, for example when an in-use integration is removed using the `leave` option, leaving the values untouched. When `true`, any error that occurs during dynamic value retrieval will be placed into a field named `dynamic_error` in the affected Value, and the `value` field will be empty.  When `false`, any such error will cause the entire request to fail.
+          Partial success allows clients to tolerate invalid dynamic values better.
       - in: path
         name: project_pk
         schema:
@@ -1804,6 +1850,16 @@ paths:
           format: uuid
         description: The parameter id.
         required: true
+      - in: query
+        name: partial_success
+        schema:
+          type: boolean
+          default: false
+        description: |-
+          Determine if the response is allowed to include a partial success.
+
+          A partial success can occur if one or more dynamic values cannot be retrieved, for example when an in-use integration is removed using the `leave` option, leaving the values untouched. When `true`, any error that occurs during dynamic value retrieval will be placed into a field named `dynamic_error` in the affected Value, and the `value` field will be empty.  When `false`, any such error will cause the entire request to fail.
+          Partial success allows clients to tolerate invalid dynamic values better.
       - in: path
         name: project_pk
         schema:
@@ -1905,6 +1961,16 @@ paths:
           format: uuid
         description: The parameter id.
         required: true
+      - in: query
+        name: partial_success
+        schema:
+          type: boolean
+          default: false
+        description: |-
+          Determine if the response is allowed to include a partial success.
+
+          A partial success can occur if one or more dynamic values cannot be retrieved, for example when an in-use integration is removed using the `leave` option, leaving the values untouched. When `true`, any error that occurs during dynamic value retrieval will be placed into a field named `dynamic_error` in the affected Value, and the `value` field will be empty.  When `false`, any such error will cause the entire request to fail.
+          Partial success allows clients to tolerate invalid dynamic values better.
       - in: path
         name: project_pk
         schema:
@@ -2098,6 +2164,16 @@ paths:
         schema:
           type: boolean
         description: If true, masks all secrets (defaults to false).
+      - in: query
+        name: partial_success
+        schema:
+          type: boolean
+          default: false
+        description: |-
+          Determine if the response is allowed to include a partial success.
+
+          A partial success can occur if one or more dynamic values cannot be retrieved, for example when an in-use integration is removed using the `leave` option, leaving the values untouched. When `true`, any error that occurs during dynamic value retrieval will be placed into a field named `dynamic_error` in the affected Value, and the `value` field will be empty.  When `false`, any such error will cause the entire request to fail.
+          Partial success allows clients to tolerate invalid dynamic values better.
       - in: path
         name: project_pk
         schema:
@@ -4237,6 +4313,14 @@ components:
             content is structured and of a supported format.  We support JMESpath
             expressions on `json`, `yaml`, and `dotenv` content.
           maxLength: 1024
+        dynamic_error:
+          type: string
+          nullable: true
+          readOnly: true
+          description: If the value is dynamic, and an error occurs retrieving it,
+            the reason for the retrieval error will be placed into this field.  The
+            query parameter `partial_success` can be used to control whether this
+            condition causes an HTTP error response or not.
         static_value:
           type: string
           nullable: true
@@ -4254,7 +4338,9 @@ components:
 
             For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.
 
-            For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.
+            For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  You can control the error handling behavior of the server through the `partial_success` query parameter.
+
+            If the content from the integration is `secret` and the parameter is not, an error will occur.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.
 
             If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.
 
@@ -4594,6 +4680,14 @@ components:
             content is structured and of a supported format.  We support JMESpath
             expressions on `json`, `yaml`, and `dotenv` content.
           maxLength: 1024
+        dynamic_error:
+          type: string
+          nullable: true
+          readOnly: true
+          description: If the value is dynamic, and an error occurs retrieving it,
+            the reason for the retrieval error will be placed into this field.  The
+            query parameter `partial_success` can be used to control whether this
+            condition causes an HTTP error response or not.
         static_value:
           type: string
           nullable: true
@@ -4611,7 +4705,9 @@ components:
 
             For values that are not `dynamic` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.
 
-            For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  If the content from the integration is `secret` and the parameter is not, an error response will be given.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.
+            For values that are `dynamic`, the system will retrieve the content from the integration on-demand.  You can control the error handling behavior of the server through the `partial_success` query parameter.
+
+            If the content from the integration is `secret` and the parameter is not, an error will occur.  If a `dynamic_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.
 
             If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.
 
@@ -4636,6 +4732,7 @@ components:
           readOnly: true
       required:
       - created_at
+      - dynamic_error
       - environment
       - id
       - modified_at

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -33,6 +33,9 @@ pub struct ParameterDetails {
     pub dynamic: bool,
     pub fqn: String,
     pub jmes_path: String,
+
+    // captures errors when fetching dynamic parameters
+    pub error: String,
 }
 
 impl ParameterDetails {
@@ -68,6 +71,7 @@ impl Default for ParameterDetails {
             dynamic: false,
             fqn: "".to_string(),
             jmes_path: "".to_string(),
+            error: "".to_string(),
         }
     }
 }
@@ -90,6 +94,7 @@ fn default_param_value() -> &'static Value {
         value: Some(DEFAULT_VALUE.to_owned()),
         created_at: "".to_owned(),
         modified_at: "".to_owned(),
+        dynamic_error: None,
     })
 }
 
@@ -114,6 +119,8 @@ impl From<&Parameter> for ParameterDetails {
             dynamic: env_value.dynamic.unwrap_or(false),
             fqn: env_value.dynamic_fqn.clone().unwrap_or_default(),
             jmes_path: env_value.dynamic_filter.clone().unwrap_or_default(),
+
+            error: env_value.dynamic_error.clone().unwrap_or_default(),
         }
     }
 }
@@ -293,7 +300,8 @@ impl Parameters {
             Some(key_name),
             None,
             PAGE_SIZE,
-            None,
+            Some(true),
+            WRAP_SECRETS,
         );
         if let Ok(data) = response {
             if let Some(parameters) = data.results {
@@ -333,7 +341,8 @@ impl Parameters {
                 proj_id,
                 Some(env_id),
                 Some(mask_secrets),
-                None,
+                Some(true),
+                WRAP_SECRETS,
             )?;
             Ok(Some(ParameterDetails::from(&response)))
         } else {
@@ -360,6 +369,7 @@ impl Parameters {
             Some(key_name),
             None,
             PAGE_SIZE,
+            Some(true),
             WRAP_SECRETS,
         )?;
         if let Some(parameters) = response.results {
@@ -446,6 +456,7 @@ impl Parameters {
             None,
             None,
             PAGE_SIZE,
+            Some(true),
             WRAP_SECRETS,
         )?;
         if let Some(parameters) = response.results {
@@ -592,6 +603,7 @@ impl Parameters {
             value: None,
             created_at: None,
             modified_at: None,
+            dynamic_error: None,
         };
         let response = projects_parameters_values_partial_update(
             rest_cfg,

--- a/src/parameters.rs
+++ b/src/parameters.rs
@@ -76,8 +76,13 @@ impl Default for ParameterDetails {
     }
 }
 
+pub struct ParameterValueEntry {
+    pub value: String,
+    pub error: String,
+}
+
 pub type ParameterDetailMap = HashMap<String, ParameterDetails>;
-pub type ParameterValueMap = HashMap<String, String>;
+pub type ParameterValueMap = HashMap<String, ParameterValueEntry>;
 
 /// Gets the singleton default `Value`
 fn default_param_value() -> &'static Value {
@@ -399,7 +404,11 @@ impl Parameters {
         let mut env_vars = ParameterValueMap::new();
 
         for param in parameters {
-            env_vars.insert(param.key, param.value);
+            let entry = ParameterValueEntry {
+                value: param.value,
+                error: param.error,
+            };
+            env_vars.insert(param.key, entry);
         }
         Ok(env_vars)
     }

--- a/src/subprocess.rs
+++ b/src/subprocess.rs
@@ -91,11 +91,15 @@ pub struct SubProcess {
 }
 
 impl SubProcess {
-    pub fn new(ct_vars: EnvSettings) -> Self {
+    pub fn new() -> Self {
         Self {
-            ct_vars,
+            ct_vars: Default::default(),
             env_vars: Default::default(),
         }
+    }
+
+    pub fn set_cloudtruth_environment(&mut self, ct_vars: EnvSettings) {
+        self.ct_vars = ct_vars;
     }
 
     fn current_env(&self) -> EnvSettings {


### PR DESCRIPTION
Here's an example (without the benefit of color) of a parameter list when there's a broken integration:

```
(Ricks-MacBook-Pro):~/cloudtruth-cli $ target/debug/cloudtruth param ls -v
+--------------+-------+---------+---------+--------+-------------+
| Name         | Value | Source  | Type    | Secret | Description |
+--------------+-------+---------+---------+--------+-------------+
| my_dyn_param |       | default | dynamic | false  |             |
+--------------+-------+---------+---------+--------+-------------+
Errors resolving parameters:
   my_dyn_param: No integration available for `github://rickporter-tuono/cloudtruth_test/main/short.yaml`.

(Ricks-MacBook-Pro):~/cloudtruth-cli $ 
```