### PR TITLE
1.0.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.0.3 - 2021-08-06
+
+* Added `parameters difference` command to compare parameters between two different environments.
+* Performance improvements:
+  * Reduce the number of instances where secrets are retrieved.
+  * Get parameter details using retrieve (by identifier), instead of a filtered list.
+  * Added REST profiling prints when `CLOUDTRUTH_REST_DEBUG` is true.
+* Improved feedback for errors retrieving dynamic parameters.
+* Use standard cookie handling.
+
 # 1.0.2 - 2021-07-30
 
 * Improved aliases (e.g. `list` now accepts `ls` or `l`).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,7 +295,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.0.2"
+version = "1.0.3"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2018"

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.0.2
+cloudtruth 1.0.3
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 


### PR DESCRIPTION
* Added `parameters difference` command to compare parameters between two different environments.
* Performance improvements:
  * Reduce the number of instances where secrets are retrieved.
  * Get parameter details using retrieve (by identifier), instead of a filtered list.
  * Added REST profiling prints when `CLOUDTRUTH_REST_DEBUG` is true.
* Improved feedback for errors retrieving dynamic parameters.
* Use standard cookie handling.
