### PR TITLE
Add 'environment tree' command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -156,6 +156,10 @@ pub fn build_cli() -> App<'static, 'static> {
                             .long("parent")
                             .takes_value(true)
                             .help("Environment's parent name (only used for create)")),
+                    SubCommand::with_name("tree")
+                        .visible_aliases(&["tr", "t"])
+                        .about("Show a tree representation of the environments")
+                        .arg(name_arg().help("Show this environment with children").required(false).default_value("default")),
                 ])
         )
         .subcommand(

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -110,6 +110,7 @@ SUBCOMMANDS:
     help      Prints this message or the help of the given subcommand(s)
     list      List CloudTruth environments [aliases: ls, l]
     set       Create/update a CloudTruth environment
+    tree      Show a tree representation of the environments [aliases: tr, t]
 ========================================
 cloudtruth-environments-delete 
 Delete specified CloudTruth environment
@@ -157,6 +158,19 @@ OPTIONS:
 
 ARGS:
     <NAME>    Environment name
+========================================
+cloudtruth-environments-tree 
+Show a tree representation of the environments
+
+USAGE:
+    cloudtruth environments tree [NAME]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+ARGS:
+    <NAME>    Show this environment with children [default: default]
 ============================================================
 cloudtruth-integrations 
 Work with CloudTruth integrations


### PR DESCRIPTION
Examples:

```
(Ricks-MacBook-Pro):~/cloudtruth-cli $ target/debug/cloudtruth env tree -h
cloudtruth-environments-tree 
Show a tree representation of the environments

USAGE:
    cloudtruth environments tree [NAME]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <NAME>    Show this environment with children [default: default]
(Ricks-MacBook-Pro):~/cloudtruth-cli $ target/debug/cloudtruth env tree 
default
  development
  production
  staging
    foo
      bar
(Ricks-MacBook-Pro):~/cloudtruth-cli $ target/debug/cloudtruth env tree foo
foo
  bar
(Ricks-MacBook-Pro):~/cloudtruth-cli $
```