### PR TITLE
Use filtered parameter list to get individual parameters

### DIFF
--- a/src/database/parameters.rs
+++ b/src/database/parameters.rs
@@ -338,33 +338,6 @@ impl Parameters {
         env_id: &str,
         key_name: &str,
         mask_secrets: bool,
-    ) -> Result<Option<ParameterDetails>, Error<ProjectsParametersRetrieveError>> {
-        if let Some(id) = self.get_id(rest_cfg, proj_id, env_id, key_name) {
-            let response = projects_parameters_retrieve(
-                rest_cfg,
-                &id,
-                proj_id,
-                Some(env_id),
-                Some(mask_secrets),
-                Some(true),
-                WRAP_SECRETS,
-            )?;
-            Ok(Some(ParameterDetails::from(&response)))
-        } else {
-            Ok(None)
-        }
-    }
-
-    /// This is the original `get_details_by_name()` where the parameter/value are resolved in one
-    /// query. However, this currently causes performance issues that are being worked on.
-    #[allow(dead_code)]
-    pub fn _get_details_by_name(
-        &self,
-        rest_cfg: &OpenApiConfig,
-        proj_id: &str,
-        env_id: &str,
-        key_name: &str,
-        mask_secrets: bool,
     ) -> Result<Option<ParameterDetails>, Error<ProjectsParametersListError>> {
         let response = projects_parameters_list(
             rest_cfg,

--- a/tests/pytest/test_timing.py
+++ b/tests/pytest/test_timing.py
@@ -73,7 +73,7 @@ class TestTiming(TestCase):
         cmd_env[CT_REST_DEBUG] = "true"
         create_timing = [[], [], [], [], [], ]
         create_total = []
-        get_timing = [[], [], [], [], ]
+        get_timing = [[], [], [], ]
         get_total = []
         list_timing = [[], [], [], [], ]
         list_total = []
@@ -103,8 +103,7 @@ class TestTiming(TestCase):
 
         rval["get-" + ENV_RESOLVE] = get_timing[0]
         rval["get-" + PROJ_RESOLVE] = get_timing[1]
-        rval["get-param-resolve"] = get_timing[2]
-        rval["get-param-retrieve"] = get_timing[3]
+        rval["get-param-retrieve"] = get_timing[2]
         rval["get-total"] = get_total
 
         rval["list-" + ENV_RESOLVE] = list_timing[0]


### PR DESCRIPTION
Removes a server workaround. Back to resolving the parameter by a filtered list with secrets resolved -- one fewer step than workaround.