### PR TITLE
Add '--raw' option to 'template get'

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -318,6 +318,10 @@ pub fn build_cli() -> App<'static, 'static> {
                     .arg(name_arg().help("Template name")),
                 SubCommand::with_name(GET_SUBCMD)
                     .about("Get an evaluated template from CloudTruth")
+                    .arg(Arg::with_name("raw")
+                        .short("r")
+                        .long("raw")
+                        .help("Get the raw, unevaluated template text"))
                     .arg(secrets_display_flag().help("Display secret values in evaluation"))
                     .arg(name_arg().help("Template name")),
                 SubCommand::with_name(LIST_SUBCMD)

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -518,6 +518,7 @@ USAGE:
 
 FLAGS:
     -h, --help       Prints help information
+    -r, --raw        Get the raw, unevaluated template text
     -s, --secrets    Display secret values in evaluation
     -V, --version    Prints version information
 

--- a/tests/pytest/test_templates.py
+++ b/tests/pytest/test_templates.py
@@ -85,6 +85,10 @@ class TestTemplates(TestCase):
         result = self.run_cli(cmd_env, sub_cmd + f"get {temp_name}")
         self.assertEqual(body, result.out())
 
+        # nothing variable, but quick test of API
+        result = self.run_cli(cmd_env, sub_cmd + f"get {temp_name} --raw")
+        self.assertEqual(body, result.out())
+
         # nothing to update
         result = self.run_cli(cmd_env, sub_cmd + f"set {temp_name}")
         self.assertEqual(result.return_value, 0)
@@ -168,6 +172,11 @@ ANOTHER_PARAM=PARAM2
         self.assertEqual(result.return_value, 0)
         self.assertIn(eval_a, result.out())
 
+        # see that we get back the unresolved/unevaluated body
+        result = self.run_cli(cmd_env, sub_cmd + f"get -r {temp_name}")
+        self.assertEqual(result.return_value, 0)
+        self.assertIn(body, result.out())
+
         # check preview, too
         result = self.run_cli(cmd_env, sub_cmd + f"preview {filename}")
         self.assertEqual(result.return_value, 0)
@@ -188,6 +197,11 @@ ANOTHER_PARAM=PARAM2
         result = self.run_cli(cmd_env, sub_cmd + f"get {temp_name}")
         self.assertEqual(result.return_value, 0)
         self.assertIn(eval_b, result.out())
+
+        # see that we get back the unresolved/unevaluated body
+        result = self.run_cli(cmd_env, sub_cmd + f"get {temp_name} -r")
+        self.assertEqual(result.return_value, 0)
+        self.assertIn(body, result.out())
 
         # check preview, too
         result = self.run_cli(cmd_env, sub_cmd + f"preview {filename}")


### PR DESCRIPTION
Sample output:
```
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ target/debug/cloudtruth template get my_temp 
# dummy template
param1 = foo
param2 = some value
# this is a secret
param3 = *****
# another comment
p2 = some value
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ target/debug/cloudtruth template get my_temp -r
# dummy template
param1 = {{ param1 }}
param2 = {{ param2 }}
# this is a secret
param3 = {{ secret1 }}
# another comment
p2 = {{ param2 }}
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ target/debug/cloudtruth template get --raw my_temp
# dummy template
param1 = {{ param1 }}
param2 = {{ param2 }}
# this is a secret
param3 = {{ secret1 }}
# another comment
p2 = {{ param2 }}
(Ricks-MacBook-Pro):~/cloudtruth-cli2 $ 
```