### PR TITLE
1.0.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 1.0.6 - 2021-09-07
+
+* Updated `parameters set` with type and rule arguments:
+  * Added `--type <string|integer|bool>` for parameter type.
+  * Added `--max`, `--min`, `--max-len`, `--min-len`, `--regex` to set the rules, and a `no` 
+    version of each (e.g. `--no-min-len`) to delete the rules.
+* Updated `parameters list` with type and rule information:
+  * Added "Param Type" and "Rules" (count) to the `--values` output.
+  * Added `--rules` view of existing rules.
+
 # 1.0.5 - 2021-08-30
 
 * Allow retrieving unevaluated template text using `template get --raw`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.0.5"
+version = "1.0.6"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2018"

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.0.5
+cloudtruth 1.0.6
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 


### PR DESCRIPTION
* Updated `parameters set` with type and rule arguments:
  * Added `--type <string|integer|bool>` for parameter type.
  * Added `--max`, `--min`, `--max-len`, `--min-len`, `--regex` to set the rules, and a `no` 
    version of each (e.g. `--no-min-len`) to delete the rules.
* Updated `parameters list` with type and rule information:
  * Added "Param Type" and "Rules" (count) to the `--values` output.
  * Added `--rules` view of existing rules.
