### PR TITLE
1.0.7 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.0.7 - 2021-09-10
+
+* Improved `templates` commands:
+  * Added `history` command.
+  * Better error feedback when `get` or `preview` fail due to external parameters.
+  * Added `--as-of` argument to `preview`.
+  * Added `--show-times` flag to `list`.
+* Added `--as-of` argument to `parameter export`.
+* Support additional date formats in `--as-of` arguments (e.g. `mm/dd/YYYY`, `mm-dd-YYYY`). 
+* Improved integration tests to use environment variables.
+
 # 1.0.6 - 2021-09-07
 
 * Updated `parameters set` with type and rule arguments:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.0.6"
+version = "1.0.7"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2018"

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.0.6
+cloudtruth 1.0.7
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 


### PR DESCRIPTION
* Improved `templates` commands:
  * Added `history` command.
  * Better error feedback when `get` or `preview` fail due to external parameters.
  * Added `--as-of` argument to `preview`.
  * Added `--show-times` flag to `list`.
* Added `--as-of` argument to `parameter export`.
* Support additional date formats in `--as-of` arguments (e.g. `mm/dd/YYYY`, `mm-dd-YYYY`). 
* Improved integration tests to use environment variables.