### PR TITLE
Fix a couple missed instances of no success checking

### DIFF
--- a/tests/pytest/test_integrations.py
+++ b/tests/pytest/test_integrations.py
@@ -297,9 +297,9 @@ PARAMETER_2 = PARAM2
 
         # export will fail, and should provide details about what failed
         result = self.run_cli(cmd_env, proj_cmd + "param export docker")
+        self.assertResultError(result, "422 Unprocessable Entity")
         # TODO: once `param export` improves feedback, use it
         # self.assertError(result, missing_fqn2)
-        self.assertResultError(result, "422 Unprocessable Entity")
 
         ##########################
         # template checks
@@ -310,10 +310,9 @@ PARAMETER_2 = PARAM2
 
         # copy current body into a file
         result = self.run_cli(cmd_env, proj_cmd + f"template get '{temp_name}' --raw")
-        write_file(filename, result.out())
-
-        # make sure the template has the references
         self.assertResultSuccess(result)
+        # make sure the template has the references
+        write_file(filename, result.out())
         self.assertIn(param1, result.out())
         self.assertIn(param2, result.out())
         self.assertIn(param3, result.out())

--- a/tests/pytest/test_parameters.py
+++ b/tests/pytest/test_parameters.py
@@ -189,8 +189,8 @@ my_param,cRaZy value,default,string,0,static,false,this is just a test descripti
         key1 = "my_param"
         value1 = "super-SENSITIVE-vAluE"
         desc1 = "my secret value"
-        result = self.run_cli(cmd_env,
-                              sub_cmd + f"set {key1} --secret true --value '{value1}' --desc '{desc1}'")
+        create_cmd = sub_cmd + f"set {key1} --secret true --value '{value1}' --desc '{desc1}'"
+        result = self.run_cli(cmd_env, create_cmd)
         self.assertResultSuccess(result)
 
         result = self.run_cli(cmd_env, sub_cmd + "ls -v")
@@ -295,6 +295,7 @@ my_param,super-SENSITIVE-vAluE,default,string,0,static,true,my secret value
         self.assertIn(desc2, result.out())
 
         result = self.run_cli(cmd_env, sub_cmd + f"get {key1}")
+        self.assertResultSuccess(result)
         self.assertIn(value2, result.out())
 
         ########
@@ -1518,6 +1519,7 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
 
         env_cmd += f"--as-of {modified_at}"
         result = self.run_cli(cmd_env, env_cmd)
+        self.assertResultSuccess(result)
         data = eval(result.out())
         for item in data["parameter"]:
             if item.get("Environment") == env_a:
@@ -1801,6 +1803,7 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.assertIn(f"{param1},{value},{env_name},string,0,static,false", result.out())
 
         result = self.run_cli(cmd_env, rules_cmd)
+        self.assertResultSuccess(result)
         self.assertIn("No parameter rules found in project", result.out())
 
         result = self.run_cli(cmd_env, set_cmd + "--no-min-len")
@@ -1971,6 +1974,7 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.assertIn(f"{param1},{value},{env_name},integer,0,static,false", result.out())
 
         result = self.run_cli(cmd_env, rules_cmd)
+        self.assertResultSuccess(result)
         self.assertIn("No parameter rules found in project", result.out())
 
         # TODO: failed create/update with values in place
@@ -1992,9 +1996,11 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.assertIn("min-len rules not valid for integer parameters", result.err())
 
         result = self.run_cli(cmd_env, list_cmd)
+        self.assertResultSuccess(result)
         self.assertIn(f"{param1},-,,integer,0,static,false", result.out())
 
         result = self.run_cli(cmd_env, rules_cmd)
+        self.assertResultSuccess(result)
         self.assertIn("No parameter rules found in project", result.out())
 
         #################
@@ -2058,6 +2064,7 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.assertIn("min-len rules not valid for bool parameters", result.err())
 
         result = self.run_cli(cmd_env, list_cmd)
+        self.assertResultSuccess(result)
         self.assertIn(f"{param1},-,,bool,0,static,false", result.out())
 
         result = self.run_cli(cmd_env, rules_cmd)

--- a/tests/pytest/test_run.py
+++ b/tests/pytest/test_run.py
@@ -110,6 +110,7 @@ class TestRun(TestCase):
         cmd = base_cmd + f"--project {proj_name} run  -i none -- '{printenv} > {filename}' {printenv}"
 
         result = self.run_cli(cmd_env, cmd)
+        # NOTE: don't care whether this paases or fails (may be different on each platform)
         self.assertIn("command contains spaces, and may fail", result.err())
 
         # cleanup

--- a/tests/pytest/test_templates.py
+++ b/tests/pytest/test_templates.py
@@ -51,6 +51,7 @@ class TestTemplates(TestCase):
         self.assertResultSuccess(result)
         self.assertIn(f"Updated template '{temp_name}'", result.out())
         result = self.run_cli(cmd_env, sub_cmd + "ls --values -f csv")
+        self.assertResultSuccess(result)
         self.assertIn(f"{temp_name},{new_desc}", result.out())
 
         # idempotent - do it again

--- a/tests/pytest/test_timing.py
+++ b/tests/pytest/test_timing.py
@@ -80,6 +80,7 @@ class TestTiming(TestCase):
 
         for index in range(num_values):
             result = self.set_param(cmd_env, proj_name, self._param_name(index), "abc123", secret=secret)
+            self.assertResultSuccess(result)
             create_timing = parse_timing(create_timing, result.stdout)
             create_total.append(delta_to_msecs(result.timediff))
 

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -242,8 +242,8 @@ class TestCase(unittest.TestCase):
         return None
 
     def create_project(self, cmd_env, proj_name: str) -> Result:
-        result = self.run_cli(cmd_env,
-                              self._base_cmd + f"proj set '{proj_name}' -d '{AUTO_DESCRIPTION}'")
+        proj_cmd = self._base_cmd + f"proj set '{proj_name}' -d '{AUTO_DESCRIPTION}'"
+        result = self.run_cli(cmd_env, proj_cmd)
         self.assertResultSuccess(result)
         return result
 
@@ -358,4 +358,5 @@ class TestCase(unittest.TestCase):
             cmd += f"--as-of '{time}' "
 
         result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
         self.assertIn(value, result.out())


### PR DESCRIPTION
A couple of the re-ordering/refactoring things were done to support a search for uncheck values:
```
grep -nA 1 "result = " tests/pytest/*.py | grep -v "result = " | grep -v "assertResult"
```