### PR TITLE
1.0.8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.0.8 - 2021-09-22
+
+* Added `environments tag` command with the following sub-commands:
+  * `list` - display tags for a specific environment.
+  * `set` - create/update environment tag properties.
+  * `delete` - delete environment tag.
+* Added `--show-times` to `list` for `integrations`, `projects`, and `environments`.
+* Changed parameter properties `dynamic` to `external`, and `static` to `internal`.
+* Added Centos-8 RPM support.
+* Improved debugging for failed tests.
+
 # 1.0.7 - 2021-09-10
 
 * Improved `templates` commands:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.0.7"
+version = "1.0.8"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.0.7"
+version = "1.0.8"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2018"

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.0.7
+cloudtruth 1.0.8
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 


### PR DESCRIPTION
* Added `environments tag` command with the following sub-commands:
  * `list` - display tags for a specific environment.
  * `set` - create/update environment tag properties.
  * `delete` - delete environment tag.
* Added `--show-times` to `list` for `integrations`, `projects`, and `environments`.
* Changed parameter properties `dynamic` to `external`, and `static` to `internal`.
* Added Centos-8 RPM support.
* Improved debugging for failed tests.
