### PR TITLE
Add 'template validate' command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -543,6 +543,10 @@ pub fn build_cli() -> App<'static, 'static> {
                     .arg(rename_option().help("New template name"))
                     .arg(description_option().help("Template description"))
                     .about("Set the CloudTruth template"),
+                SubCommand::with_name("validate")
+                    .visible_aliases(&["valid", "val", "v"])
+                    .arg(name_arg().help("Template name"))
+                    .about("Validate a CloudTruth template"),
             ])
         )
         .subcommand(

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -642,14 +642,15 @@ FLAGS:
     -V, --version    Prints version information
 
 SUBCOMMANDS:
-    delete     Delete the CloudTruth template [aliases: del, d]
-    edit       Edit the specified template [aliases: ed, e]
-    get        Get an evaluated template from CloudTruth
-    help       Prints this message or the help of the given subcommand(s)
-    history    Display template history [aliases: hist, h]
-    list       List CloudTruth templates [aliases: ls, l]
-    preview    Evaluate the provided template without storing [aliases: prev, pre]
-    set        Set the CloudTruth template [aliases: s]
+    delete      Delete the CloudTruth template [aliases: del, d]
+    edit        Edit the specified template [aliases: ed, e]
+    get         Get an evaluated template from CloudTruth
+    help        Prints this message or the help of the given subcommand(s)
+    history     Display template history [aliases: hist, h]
+    list        List CloudTruth templates [aliases: ls, l]
+    preview     Evaluate the provided template without storing [aliases: prev, pre]
+    set         Set the CloudTruth template [aliases: s]
+    validate    Validate a CloudTruth template [aliases: valid, val, v]
 ========================================
 cloudtruth-templates-delete 
 Delete the CloudTruth template
@@ -757,6 +758,19 @@ OPTIONS:
     -b, --body <FILE>           File containing the template
     -d, --desc <description>    Template description
     -r, --rename <rename>       New template name
+
+ARGS:
+    <NAME>    Template name
+========================================
+cloudtruth-templates-validate 
+Validate a CloudTruth template
+
+USAGE:
+    cloudtruth templates validate <NAME>
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
 
 ARGS:
     <NAME>    Template name

--- a/tests/pytest/test_integrations.py
+++ b/tests/pytest/test_integrations.py
@@ -308,6 +308,9 @@ PARAMETER_2 = PARAM2
         result = self.run_cli(cmd_env, proj_cmd + f"template get '{temp_name}'")
         self.assertResultError(result, missing_param2)
 
+        result = self.run_cli(cmd_env, proj_cmd + f"template validate '{temp_name}'")
+        self.assertResultError(result, missing_param2)
+
         # copy current body into a file
         result = self.run_cli(cmd_env, proj_cmd + f"template get '{temp_name}' --raw")
         self.assertResultSuccess(result)

--- a/tests/pytest/test_templates.py
+++ b/tests/pytest/test_templates.py
@@ -45,6 +45,10 @@ class TestTemplates(TestCase):
         self.assertResultSuccess(result)
         self.assertEqual(body, result.out())
 
+        result = self.run_cli(cmd_env, sub_cmd + f"validate {temp_name}")
+        self.assertResultSuccess(result)
+        self.assertIn("Success", result.out())
+
         # update the description
         new_desc = "Updated description"
         result = self.run_cli(cmd_env, sub_cmd + f"set {temp_name} --desc \"{new_desc}\"")


### PR DESCRIPTION
Here's the help:
    validate    Validate a CloudTruth template [aliases: valid, val, v]
```
(Ricks-MacBook-Pro):~/cloudtruth-cli $ target/debug/cloudtruth t v -h
cloudtruth-templates-validate 
Validate a CloudTruth template

USAGE:
    cloudtruth templates validate <NAME>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <NAME>    Template name
(Ricks-MacBook-Pro):~/cloudtruth-cli
```

Here's a sample failure (from the CLI integration tests):
````
/Users/rick/cloudtruth-cli/target/debug/cloudtruth --project proj-int-broken template validate "temp-int-broken"

Error: 
   0: Evaluation failed:
        param2: The external content of `github://rickporter-tuono/hello-world/master/README.md` is not present.

Location:
   /rustc/a178d0322ce20e33eac124758e837cbd80a6f633/library/core/src/result.rs:1675

Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```