### PR TITLE
1.0.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.0.9 - 2021-09-24
+
+* Enhanced `parameters set` to allow parameter creation without a value for any environment.
+* Added `template validate` to check if an existing template still works.
+* Fixed `parameters environment --as-of` issue when using a tag name.
+* Added `configuration profile` commands to avoid need to modify configuration file with editor.
+  * Move `configuration list` functionality into `configuration profile list`.
+* Improved handling for many error responses to provide more understandable information.
+
 # 1.0.8 - 2021-09-22
 
 * Added `environments tag` command with the following sub-commands:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.0.8"
+version = "1.0.9"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.0.8"
+version = "1.0.9"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2018"

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.0.8
+cloudtruth 1.0.9
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 


### PR DESCRIPTION
* Enhanced `parameters set` to allow parameter creation without a value for any environment.
* Added `template validate` to check if an existing template still works.
* Fixed `parameters environment --as-of` issue when using a tag name.
* Added `configuration profile` commands to avoid need to modify configuration file with editor.
  * Move `configuration list` functionality into `configuration profile list`.
* Improved handling for many error responses to provide more understandable information.
