### PR TITLE
1.0.10 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 1.0.10 - 2021-10-01
+
+* Added `--as-of` to `templates get` for raw or evaluated template at specified date/time (or tag).
+* Changes to `configuration profile set`:
+  * Fixed issue with reporting wrong action.
+  * Added ability to set a source-profile using `--source`.
+* Improved error handling to provide more understandable information.
+* Updated several help strings.
+
 # 1.0.9 - 2021-09-24
 
 * Enhanced `parameters set` to allow parameter creation without a value for any environment.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.0.9"
+version = "1.0.10"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.0.9"
+version = "1.0.10"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2018"

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.0.9
+cloudtruth 1.0.10
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 


### PR DESCRIPTION
* Added `--as-of` to `templates get` for raw or evaluated template at specified date/time (or tag).
* Changes to `configuration profile set`:
  * Fixed issue with reporting wrong action.
  * Added ability to set a source-profile using `--source`.
* Improved error handling to provide more understandable information.
* Updated several help strings.
