### PR TITLE
Allow for evaluated parameters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ env:
   CLOUDTRUTH_TEST_PARAMETERS_FQN: github://rickporter-tuono/cloudtruth_test/my-branch/short.yaml
   CLOUDTRUTH_TEST_PARAMETERS_JMES: speicla.POrk_Egg_Foo_Young
 
+  CLOUDTRUTH_TEST_TEMPLATE_FQN: github://rickporter-tuono/cloudtruth_test/main/ci_test_template.txt
+  CLOUDTRUTH_TEST_TEMPLATE_PARAM1: my-param-name
+
 jobs:
   lint:
     name: Lint

--- a/client/src/apis/projects_api.rs
+++ b/client/src/apis/projects_api.rs
@@ -751,6 +751,7 @@ pub fn projects_parameters_list(
     project_pk: &str,
     as_of: Option<String>,
     environment: Option<&str>,
+    evaluate: Option<bool>,
     mask_secrets: Option<bool>,
     name: Option<&str>,
     page: Option<i32>,
@@ -777,6 +778,10 @@ pub fn projects_parameters_list(
     if let Some(ref local_var_str) = environment {
         local_var_req_builder =
             local_var_req_builder.query(&[("environment", &local_var_str.to_string())]);
+    }
+    if let Some(ref local_var_str) = evaluate {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("evaluate", &local_var_str.to_string())]);
     }
     if let Some(ref local_var_str) = mask_secrets {
         local_var_req_builder =
@@ -941,6 +946,7 @@ pub fn projects_parameters_retrieve(
     project_pk: &str,
     as_of: Option<String>,
     environment: Option<&str>,
+    evaluate: Option<bool>,
     mask_secrets: Option<bool>,
     partial_success: Option<bool>,
     tag: Option<&str>,
@@ -965,6 +971,10 @@ pub fn projects_parameters_retrieve(
     if let Some(ref local_var_str) = environment {
         local_var_req_builder =
             local_var_req_builder.query(&[("environment", &local_var_str.to_string())]);
+    }
+    if let Some(ref local_var_str) = evaluate {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("evaluate", &local_var_str.to_string())]);
     }
     if let Some(ref local_var_str) = mask_secrets {
         local_var_req_builder =
@@ -1876,6 +1886,7 @@ pub fn projects_parameters_values_list(
     project_pk: &str,
     as_of: Option<String>,
     environment: Option<&str>,
+    evaluate: Option<bool>,
     mask_secrets: Option<bool>,
     page: Option<i32>,
     page_size: Option<i32>,
@@ -1901,6 +1912,10 @@ pub fn projects_parameters_values_list(
     if let Some(ref local_var_str) = environment {
         local_var_req_builder =
             local_var_req_builder.query(&[("environment", &local_var_str.to_string())]);
+    }
+    if let Some(ref local_var_str) = evaluate {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("evaluate", &local_var_str.to_string())]);
     }
     if let Some(ref local_var_str) = mask_secrets {
         local_var_req_builder =
@@ -2066,6 +2081,7 @@ pub fn projects_parameters_values_retrieve(
     parameter_pk: &str,
     project_pk: &str,
     as_of: Option<String>,
+    evaluate: Option<bool>,
     mask_secrets: Option<bool>,
     partial_success: Option<bool>,
     tag: Option<&str>,
@@ -2086,6 +2102,10 @@ pub fn projects_parameters_values_retrieve(
     if let Some(ref local_var_str) = as_of {
         local_var_req_builder =
             local_var_req_builder.query(&[("as_of", &local_var_str.to_string())]);
+    }
+    if let Some(ref local_var_str) = evaluate {
+        local_var_req_builder =
+            local_var_req_builder.query(&[("evaluate", &local_var_str.to_string())]);
     }
     if let Some(ref local_var_str) = mask_secrets {
         local_var_req_builder =

--- a/client/src/models/patched_value.rs
+++ b/client/src/models/patched_value.rs
@@ -50,6 +50,9 @@ pub struct PatchedValue {
     /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `external` and parameters that are not `secret`, the system will use the content in `internal_value` to satisfy the request.  For values that are not `external` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `external`, the system will retrieve the content from the integration on-demand.  You can control the error handling behavior of the server through the `partial_success` query parameter.  If the content from the integration is `secret` and the parameter is not, an error will occur.  If an `external_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
     #[serde(rename = "value", skip_serializing_if = "Option::is_none")]
     pub value: Option<String>,
+    /// If true, the `value` field has undergone template evaluation.
+    #[serde(rename = "evaluated", skip_serializing_if = "Option::is_none")]
+    pub evaluated: Option<bool>,
     /// Indicates the value content is a secret.  Normally this is `true` when the parameter is a secret, however it is possible for a parameter to be a secret with a external value that is not a secret.  It is not possible to convert a parameter from a secret to a non-secret if any of the values are external and a secret.  Clients can check this condition by leveraging this field.
     #[serde(rename = "secret", skip_serializing_if = "Option::is_none")]
     pub secret: Option<bool>,
@@ -88,6 +91,7 @@ impl PatchedValue {
             internal_value: None,
             interpolated: None,
             value: None,
+            evaluated: None,
             secret: None,
             referenced_parameters: None,
             referenced_templates: None,

--- a/client/src/models/value.rs
+++ b/client/src/models/value.rs
@@ -50,6 +50,9 @@ pub struct Value {
     /// This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:  For values that are not `external` and parameters that are not `secret`, the system will use the content in `internal_value` to satisfy the request.  For values that are not `external` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.  For values that are `external`, the system will retrieve the content from the integration on-demand.  You can control the error handling behavior of the server through the `partial_success` query parameter.  If the content from the integration is `secret` and the parameter is not, an error will occur.  If an `external_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.  If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.  Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
     #[serde(rename = "value")]
     pub value: Option<String>,
+    /// If true, the `value` field has undergone template evaluation.
+    #[serde(rename = "evaluated")]
+    pub evaluated: bool,
     /// Indicates the value content is a secret.  Normally this is `true` when the parameter is a secret, however it is possible for a parameter to be a secret with a external value that is not a secret.  It is not possible to convert a parameter from a secret to a non-secret if any of the values are external and a secret.  Clients can check this condition by leveraging this field.
     #[serde(rename = "secret")]
     pub secret: Option<bool>,
@@ -76,6 +79,7 @@ impl Value {
         parameter: String,
         external_error: Option<String>,
         value: Option<String>,
+        evaluated: bool,
         secret: Option<bool>,
         referenced_parameters: Vec<String>,
         referenced_templates: Vec<String>,
@@ -96,6 +100,7 @@ impl Value {
             internal_value: None,
             interpolated: None,
             value,
+            evaluated,
             secret,
             referenced_parameters,
             referenced_templates,

--- a/openapi.yml
+++ b/openapi.yml
@@ -1952,6 +1952,14 @@ paths:
         description: Name or id (uuid) of the environment to get parameter values
           for.  Cannot be used with `values`.
       - in: query
+        name: evaluate
+        schema:
+          type: boolean
+          default: true
+        description: |-
+          If `true`, runs template evaluation on this parameter's values.  If `false`, returns the value's template.
+          No effect on values that are not interpolated.
+      - in: query
         name: mask_secrets
         schema:
           type: boolean
@@ -2337,6 +2345,14 @@ paths:
           value of a parameter in an environment for which is is not explicitly set.
           To see _effective_ values use the Parameters API (see the `values` field).
       - in: query
+        name: evaluate
+        schema:
+          type: boolean
+          default: true
+        description: |-
+          If `true`, runs template evaluation on this parameter.  If `false`, returns the value's template.
+          No effect on values that are not interpolated.
+      - in: query
         name: mask_secrets
         schema:
           type: boolean
@@ -2466,6 +2482,14 @@ paths:
           format: date-time
         description: Specify a point in time to retrieve configuration from. Cannot
           be specified with `tag`.
+      - in: query
+        name: evaluate
+        schema:
+          type: boolean
+          default: true
+        description: |-
+          If `true`, runs template evaluation on this parameter.  If `false`, returns the value's template.
+          No effect on values that are not interpolated.
       - in: path
         name: id
         schema:
@@ -2690,6 +2714,14 @@ paths:
           type: string
         description: Name or id (uuid) of the environment to get parameter values
           for.  Cannot be used with `values`.
+      - in: query
+        name: evaluate
+        schema:
+          type: boolean
+          default: true
+        description: |-
+          If `true`, runs template evaluation on this parameter's values.  If `false`, returns the value's template.
+          No effect on values that are not interpolated.
       - in: path
         name: id
         schema:
@@ -5323,7 +5355,9 @@ components:
           format: date-time
           description: The point in time this tag represents.
         usage:
-          $ref: '#/components/schemas/TagReadUsage'
+          allOf:
+          - $ref: '#/components/schemas/TagReadUsage'
+          readOnly: true
     PatchedTemplate:
       type: object
       description: A parameter template in a given project, optionally instantiated
@@ -5486,6 +5520,10 @@ components:
             If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.
 
             Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
+        evaluated:
+          type: boolean
+          readOnly: true
+          description: If true, the `value` field has undergone template evaluation.
         secret:
           type: boolean
           nullable: true
@@ -5697,7 +5735,9 @@ components:
           format: date-time
           description: The point in time this tag represents.
         usage:
-          $ref: '#/components/schemas/TagReadUsage'
+          allOf:
+          - $ref: '#/components/schemas/TagReadUsage'
+          readOnly: true
       required:
       - id
       - name
@@ -6090,6 +6130,10 @@ components:
             If you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.
 
             Clients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable.
+        evaluated:
+          type: boolean
+          readOnly: true
+          description: If true, the `value` field has undergone template evaluation.
         secret:
           type: boolean
           nullable: true
@@ -6127,6 +6171,7 @@ components:
       - earliest_tag
       - environment
       - environment_name
+      - evaluated
       - external_error
       - id
       - modified_at

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,6 +28,8 @@ pub const LIST_SUBCMD: &str = "list";
 pub const SET_SUBCMD: &str = "set";
 pub const TAG_SUBCMD: &str = "tag";
 
+const TRUE_FALSE_VALUES: &[&str] = &["true", "false"];
+
 const DELETE_ALIASES: &[&str] = &["del", "d"];
 const DIFF_ALIASES: &[&str] = &["difference", "differ", "diff", "di"];
 const EDIT_ALIASES: &[&str] = &["ed", "e"];
@@ -39,6 +41,14 @@ pub fn binary_name() -> String {
     option_env!("CARGO_PKG_NAME")
         .unwrap_or("cloudtruth")
         .to_string()
+}
+
+pub fn true_false_option(input: Option<&str>) -> Option<bool> {
+    match input {
+        Some("true") => Some(true),
+        Some("false") => Some(false),
+        _ => None,
+    }
 }
 
 fn table_format_options() -> Arg<'static, 'static> {
@@ -394,6 +404,9 @@ pub fn build_cli() -> App<'static, 'static> {
                         .arg(Arg::with_name("rules")
                             .long("rules")
                             .help("Display the parameter rules."))
+                        .arg(Arg::with_name("evaluated")
+                            .long("evaluated")
+                            .help("Display the evaluated values"))
                         .arg(values_flag().help("Display parameter information/values"))
                         .arg(param_as_of_arg())
                         .arg(show_times_arg())
@@ -428,8 +441,16 @@ pub fn build_cli() -> App<'static, 'static> {
                         .arg(Arg::with_name("secret")
                             .long("secret")
                             .takes_value(true)
-                            .possible_values(&["true", "false"])
+                            .possible_values(TRUE_FALSE_VALUES)
                             .help("Flags whether this is a secret parameter"))
+                        .arg(Arg::with_name("evaluate")
+                            .long("evaluate")
+                            .short("e")
+                            .alias("eval")
+                            .takes_value(true)
+                            .possible_values(TRUE_FALSE_VALUES)
+                            .help("Flags whether this value gets evaluated")
+                        )
                         .arg(Arg::with_name("param-type")
                             .short("t")
                             .long("type")
@@ -498,6 +519,8 @@ pub fn build_cli() -> App<'static, 'static> {
                                 "environment",
                                 "fqn",
                                 "jmes-path",
+                                "raw",
+                                "rule-count",
                                 "secret",
                                 "created-at",
                                 "modified-at",

--- a/src/database/parameter_details.rs
+++ b/src/database/parameter_details.rs
@@ -116,6 +116,7 @@ fn default_param_value() -> &'static Value {
         secret: None,
         internal_value: None,
         interpolated: None,
+        evaluated: false,
         referenced_parameters: vec![],
         referenced_templates: vec![],
         value: Some(DEFAULT_VALUE.to_owned()),

--- a/src/database/parameter_details.rs
+++ b/src/database/parameter_details.rs
@@ -23,6 +23,8 @@ pub struct ParameterDetails {
     pub external: bool,
     pub fqn: String,
     pub jmes_path: String,
+    pub evaluated: bool,
+    pub raw_value: String, // the unevaluated value
     pub created_at: String,
     pub modified_at: String,
 
@@ -43,6 +45,19 @@ impl ParameterDetails {
             "secret" => format!("{}", self.secret),
             "created-at" => self.created_at.clone(),
             "modified-at" => self.modified_at.clone(),
+            "rule-count" => self.rules.len().to_string(),
+            "raw" => self.raw_value.clone(),
+            "scope" => {
+                let mut scope = String::from(if self.external {
+                    "external"
+                } else {
+                    "internal"
+                });
+                if self.evaluated {
+                    scope.push_str("-evaluated");
+                }
+                scope
+            }
             _ => format!("Unhandled property name '{}'", property_name),
         }
     }
@@ -61,6 +76,8 @@ impl ParameterDetails {
         self.external = env_value.external.unwrap_or(false);
         self.fqn = env_value.external_fqn.clone().unwrap_or_default();
         self.jmes_path = env_value.external_filter.clone().unwrap_or_default();
+        self.evaluated = env_value.interpolated.unwrap_or(false);
+        self.raw_value = env_value.internal_value.clone().unwrap_or_default();
         self.created_at = env_value.created_at.clone();
         self.modified_at = env_value.modified_at.clone();
         self.error = env_value.external_error.clone().unwrap_or_default();
@@ -95,6 +112,8 @@ impl Default for ParameterDetails {
             external: false,
             fqn: "".to_string(),
             jmes_path: "".to_string(),
+            evaluated: false,
+            raw_value: "".to_string(),
             created_at: "".to_string(),
             modified_at: "".to_string(),
             error: "".to_string(),
@@ -154,6 +173,8 @@ impl From<&Parameter> for ParameterDetails {
             external: env_value.external.unwrap_or(false),
             fqn: env_value.external_fqn.clone().unwrap_or_default(),
             jmes_path: env_value.external_filter.clone().unwrap_or_default(),
+            evaluated: env_value.interpolated.unwrap_or(false),
+            raw_value: env_value.internal_value.clone().unwrap_or_default(),
             created_at: env_value.created_at.clone(),
             modified_at: env_value.modified_at.clone(),
 

--- a/src/database/parameter_error.rs
+++ b/src/database/parameter_error.rs
@@ -9,6 +9,7 @@ pub enum ParameterError {
     RuleError(String, String),
     UnhandledError(String),
     ResponseError(String),
+    EvaluationError(String),
 }
 
 impl fmt::Display for ParameterError {
@@ -28,6 +29,9 @@ impl fmt::Display for ParameterError {
             }
             ParameterError::ResponseError(msg) => {
                 write!(f, "{}", msg)
+            }
+            ParameterError::EvaluationError(msg) => {
+                write!(f, "Evaluation error: {}", msg)
             }
         }
     }

--- a/src/database/parameters.rs
+++ b/src/database/parameters.rs
@@ -164,7 +164,8 @@ impl Parameters {
             proj_id,
             as_of_arg,
             env_arg,
-            Some(true), // no need to fetch secrets
+            Some(false), // no need to evaluate references to get id
+            Some(true),  // no need to fetch secrets
             Some(key_name),
             None,
             PAGE_SIZE,
@@ -212,6 +213,7 @@ impl Parameters {
             proj_id,
             as_of,
             Some(env_id),
+            Some(true), // for now, always evaluate interpolated parameters
             Some(mask_secrets),
             Some(key_name),
             None,
@@ -290,11 +292,13 @@ impl Parameters {
         let has_values = include_values || tag.is_some();
         let env_arg = if has_values { Some(env_id) } else { None };
         let value_arg = if has_values { None } else { VALUES_FALSE };
+        let eval_arg = Some(include_values);
         let response = projects_parameters_list(
             rest_cfg,
             proj_id,
             as_of,
             env_arg,
+            eval_arg,
             Some(mask_secrets),
             None,
             None,
@@ -350,11 +354,13 @@ impl Parameters {
         mask_secrets: bool,
         as_of: Option<String>,
     ) -> Result<ParameterDetailMap, ParameterError> {
+        let eval_arg = VALUES_TRUE;
         let response = projects_parameters_list(
             rest_cfg,
             proj_id,
             as_of,
             None, // cannot give an environment, or it will only get for that environment
+            eval_arg,
             Some(mask_secrets),
             Some(param_name),
             None,
@@ -524,6 +530,7 @@ impl Parameters {
             external_error: None,
             earliest_tag: None,
             interpolated: None,
+            evaluated: None,
             referenced_parameters: None,
             referenced_templates: None,
         };

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -419,7 +419,8 @@ OPTIONS:
     -f, --format <format>             Display difference format [default: table]  [possible values: table, csv, json,
                                       yaml]
     -p, --property <properties>...    List of the properties to compare. [default: value]  [possible values: value,
-                                      type, environment, fqn, jmes-path, secret, created-at, modified-at]
+                                      type, environment, fqn, jmes-path, raw, rule-count, secret, created-at, modified-
+                                      at]
 ========================================
 cloudtruth-parameters-environment 
 Shows the environments with parameter overrides
@@ -488,6 +489,7 @@ USAGE:
     cloudtruth parameters list [FLAGS] [OPTIONS]
 
 FLAGS:
+        --evaluated     Display the evaluated values
         --external      Display the external values and FQN/JMES path.
     -h, --help          Prints help information
         --rules         Display the parameter rules.
@@ -518,19 +520,20 @@ FLAGS:
     -V, --version       Prints version information
 
 OPTIONS:
-    -f, --fqn <FQN>             Fully Qualified Name (FQN) reference for external parameter.
-    -j, --jmes <JMES>           JMES path within FQN for external parameter
-        --max <MAX>             Set parameter rule maximum value
-        --max-len <MAX-LEN>     Set parameter rule maximum length value
-        --min <MIN>             Set parameter rule minimum value
-        --min-len <MIN-LEN>     Set parameter rule minimum length value
-        --regex <REGEX>         Set parameter rule regex value
-    -d, --desc <description>    Parameter description
-    -i, --input <input-file>    Read the static value from the local input file
-    -t, --type <param-type>     The parameter type [possible values: bool, string, integer]
-    -r, --rename <rename>       New parameter name
-        --secret <secret>       Flags whether this is a secret parameter [possible values: true, false]
-    -v, --value <value>         Static parameter value
+    -f, --fqn <FQN>              Fully Qualified Name (FQN) reference for external parameter.
+    -j, --jmes <JMES>            JMES path within FQN for external parameter
+        --max <MAX>              Set parameter rule maximum value
+        --max-len <MAX-LEN>      Set parameter rule maximum length value
+        --min <MIN>              Set parameter rule minimum value
+        --min-len <MIN-LEN>      Set parameter rule minimum length value
+        --regex <REGEX>          Set parameter rule regex value
+    -d, --desc <description>     Parameter description
+    -e, --evaluate <evaluate>    Flags whether this value gets evaluated [possible values: true, false]
+    -i, --input <input-file>     Read the static value from the local input file
+    -t, --type <param-type>      The parameter type [possible values: bool, string, integer]
+    -r, --rename <rename>        New parameter name
+        --secret <secret>        Flags whether this is a secret parameter [possible values: true, false]
+    -v, --value <value>          Static parameter value
 
 ARGS:
     <KEY>    Name of parameter to set

--- a/tests/pytest/test_parameters.py
+++ b/tests/pytest/test_parameters.py
@@ -1,8 +1,13 @@
 import datetime
 
 from typing import Tuple, Dict
-from testcase import TestCase, DEFAULT_ENV_NAME, REDACTED, DEFAULT_PARAM_VALUE
-from testcase import PROP_CREATED, PROP_MODIFIED, PROP_VALUE
+from testcase import TestCase
+from testcase import DEFAULT_ENV_NAME
+from testcase import DEFAULT_PARAM_VALUE
+from testcase import PROP_CREATED
+from testcase import PROP_MODIFIED
+from testcase import PROP_VALUE
+from testcase import REDACTED
 
 
 class TestParameters(TestCase):
@@ -166,6 +171,15 @@ my_param,cRaZy value,default,string,0,internal,false,this is just a test descrip
         result = self.run_cli(cmd_env, sub_cmd + "list --values -f csv")
         self.assertResultSuccess(result)
         self.assertIn(f"{key1},{DEFAULT_PARAM_VALUE},,string,0,internal,false", result.out())
+
+        # make sure we error out on conflicting args
+        mutually_exclusive = "are mutually exclusive"
+        result = self.run_cli(cmd_env, sub_cmd + "list --rules --external")
+        self.assertResultWarning(result, mutually_exclusive)
+        result = self.run_cli(cmd_env, sub_cmd + "list --rules --evaluated")
+        self.assertResultWarning(result, mutually_exclusive)
+        result = self.run_cli(cmd_env, sub_cmd + "list --external --evaluated")
+        self.assertResultWarning(result, mutually_exclusive)
 
         # delete the project
         self.delete_project(cmd_env, proj_name)
@@ -1585,6 +1599,166 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.delete_environment(cmd_env, env_b)
         self.delete_project(cmd_env, proj_name)
 
+    def test_parameter_evaluated(self):
+        base_cmd = self.get_cli_base_cmd()
+        cmd_env = self.get_cmd_env()
+
+        # add a new project, and a couple environments
+        proj_name = self.make_name("test-evaluated")
+        self.create_project(cmd_env, proj_name)
+        env_name_a = self.make_name("test-eval-a")
+        self.create_environment(cmd_env, env_name_a)
+        env_name_b = self.make_name("test-eval-b")
+        self.create_environment(cmd_env, env_name_b)
+
+        # create an internal parameter
+        param1 = "param1"
+        value1a = "first value"
+        value1b = "other value"
+        self.set_param(cmd_env, proj_name, param1, value1a, env=env_name_a)
+        self.set_param(cmd_env, proj_name, param1, value1b, env=env_name_b)
+
+        # verify `--evaluated` flag causes specialized warning
+        sub_cmd = base_cmd + f" --project {proj_name} parameters "
+        empty_msg = f"No evaluated parameters found in project {proj_name}"
+        result = self.run_cli(cmd_env, sub_cmd + "list --evaluated")
+        self.assertResultSuccess(result)
+        self.assertIn(empty_msg, result.out())
+
+        result = self.run_cli(cmd_env, sub_cmd + "list --evaluated -v -s --show-times")
+        self.assertResultSuccess(result)
+        self.assertIn(empty_msg, result.out())
+
+        # create another parameter -- keep one value evaluated and the other not (even though
+        # nothing to evaluate) to prove it is a value property
+        param2 = "param2"
+        value2a = "my-value"
+        value2b = "your-value"
+        self.set_param(cmd_env, proj_name, param2, value2a, env=env_name_a, evaluate=True)
+        self.set_param(cmd_env, proj_name, param2, value2b, env=env_name_b, evaluate=False)
+
+        csv_unevaluated = "string,0,internal,false,"
+        csv_evaluated = "string,0,internal-evaluated,false"
+        result = self.list_params(cmd_env, proj_name, env=env_name_a, fmt="csv")
+        self.assertIn(f"{param1},{value1a},{env_name_a},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param2},{value2a},{env_name_a},{csv_evaluated}", result.out())
+
+        result = self.list_params(cmd_env, proj_name, env=env_name_b, fmt="csv")
+        self.assertIn(f"{param1},{value1b},{env_name_b},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param2},{value2b},{env_name_b},{csv_unevaluated}", result.out())
+
+        ####################
+        # add a "real" evaluated parameter
+        param3 = "param3"
+        value3a = f"{{{{ {param1} }}}}"
+        value3b = f"{{{{ {param2} }}}}"
+        self.set_param(cmd_env, proj_name, param3, value3a, env=env_name_a, evaluate=True)
+        self.set_param(cmd_env, proj_name, param3, value3b, env=env_name_b, evaluate=True)
+
+        # in env-a, the value points at param1
+        result = self.run_cli(cmd_env, base_cmd + f"--project '{proj_name}' --env '{env_name_a}' param get '{param3}'")
+        self.assertResultSuccess(result)
+        self.assertIn(value1a, result.out())
+
+        result = self.list_params(cmd_env, proj_name, env=env_name_a, fmt="csv")
+        self.assertIn(f"{param1},{value1a},{env_name_a},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param2},{value2a},{env_name_a},{csv_evaluated}", result.out())
+        self.assertIn(f"{param3},{value1a},{env_name_a},{csv_evaluated}", result.out())
+
+        result = self.list_params(cmd_env, proj_name, env=env_name_b, fmt="csv")
+        self.assertIn(f"{param1},{value1b},{env_name_b},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param2},{value2b},{env_name_b},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param3},{value2b},{env_name_b},{csv_evaluated}", result.out())
+
+        ##################
+        # recursion: param4={{param3}} => value1a
+        param4 = "param4"
+        value4a = f"{{{{ {param3} }}}}"
+        self.set_param(cmd_env, proj_name, param4, value=value4a, env=env_name_a, evaluate=True)
+
+        result = self.list_params(cmd_env, proj_name, env=env_name_a, show_values=True, show_evaluated=True, fmt="csv")
+        self.assertResultSuccess(result)
+        # TODO: the value (2nd property) should be evaluated, not an unevaluated reference
+        self.assertIn(f"{param4},{value3a},{value4a}", result.out())
+        # self.assertIn(f"{param4},{value1a},{value4a}", result.out())
+
+        # remove the extra parameter to avoid references (TODO: can we remove this?)
+        self.delete_param(cmd_env, proj_name, param4)
+
+        ##################
+        # invalid parameter value -- see that value does not get updated
+        bad_param = "cloudtruth.parameters.unknown"
+        param_a_cmd = base_cmd + f"--project '{proj_name}' --env '{env_name_a}' param "
+        missing_cmd = param_a_cmd + f"set '{param3}' --value '{{{{ {bad_param} }}}}'"
+        result = self.run_cli(cmd_env, missing_cmd)
+        self.assertResultError(result, "Evaluation error")
+        self.assertIn("reference automatic parameter that does not exist", result.err())
+        self.assertIn(bad_param, result.err())
+
+        result = self.list_params(cmd_env, proj_name, env=env_name_a, fmt="csv")
+        self.assertResultSuccess(result)
+        self.assertIn(f"{param3},{value1a},{env_name_a},{csv_evaluated}", result.out())
+
+        ####################
+        # set param3 to not evaluate in one environment, but verify it evaluates in the other
+        self.set_param(cmd_env, proj_name, param3, env=env_name_a, evaluate=False)
+
+        result = self.list_params(cmd_env, proj_name, env=env_name_a, fmt="csv")
+        self.assertIn(f"{param1},{value1a},{env_name_a},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param2},{value2a},{env_name_a},{csv_evaluated}", result.out())
+        self.assertIn(f"{param3},{value3a},{env_name_a},{csv_unevaluated}", result.out())
+
+        result = self.list_params(cmd_env, proj_name, env=env_name_b, fmt="csv")
+        self.assertIn(f"{param1},{value1b},{env_name_b},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param2},{value2b},{env_name_b},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param3},{value2b},{env_name_b},{csv_evaluated}", result.out())
+
+        detail_cmd = f"param get '{param3}' --details"
+        get_cmd = base_cmd + f"--project '{proj_name}' --env '{env_name_a}' " + detail_cmd
+        result = self.run_cli(cmd_env, get_cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(f"Name: {param3}", result.out())
+        self.assertIn(f"Value: {{{{ {param1} }}}}", result.out())
+        self.assertIn(f"Source: {env_name_a}", result.out())
+        self.assertIn("Evaluated: false", result.out())
+
+        get_cmd = base_cmd + f"--project '{proj_name}' --env '{env_name_b}' " + detail_cmd
+        result = self.run_cli(cmd_env, get_cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(f"Name: {param3}", result.out())
+        self.assertIn(f"Value: {value2b}", result.out())
+        self.assertIn(f"Source: {env_name_b}", result.out())
+        self.assertIn("Evaluated: true", result.out())
+        self.assertIn(f"Raw: {{{{ {param2} }}}}", result.out())
+
+        ####################
+        # set param3 no longer evaluated
+        self.set_param(cmd_env, proj_name, param3, env=env_name_b, evaluate=False)
+
+        result = self.list_params(cmd_env, proj_name, env=env_name_a, fmt="csv")
+        self.assertIn(f"{param1},{value1a},{env_name_a},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param2},{value2a},{env_name_a},{csv_evaluated}", result.out())
+        self.assertIn(f"{param3},{value3a},{env_name_a},{csv_unevaluated}", result.out())
+
+        result = self.list_params(cmd_env, proj_name, env=env_name_b, fmt="csv")
+        self.assertIn(f"{param1},{value1b},{env_name_b},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param2},{value2b},{env_name_b},{csv_unevaluated}", result.out())
+        self.assertIn(f"{param3},{{{{ {param2} }}}},{env_name_b},{csv_unevaluated}", result.out())
+
+        ##################
+        # use one of the "pre-defined" values
+        value3c = "{{ cloudtruth.environment }}"
+        self.set_param(cmd_env, proj_name, param3, value=value3c, env=env_name_a, evaluate=True)
+        result = self.list_params(cmd_env, proj_name, env=env_name_a, show_evaluated=True, fmt="csv")
+        self.assertResultSuccess(result)
+        self.assertIn(f"{param2},{value2a},{value2a}", result.out())
+        self.assertIn(f"{param3},{env_name_a},{value3c}", result.out())
+
+        # cleanup
+        self.delete_project(cmd_env, proj_name)
+        self.delete_environment(cmd_env, env_name_a)
+        self.delete_environment(cmd_env, env_name_b)
+
     def test_parameter_types_basic(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
@@ -1700,7 +1874,7 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.create_environment(cmd_env, env_name)
         param_cmd = base_cmd + f"--project {proj_name} --env {env_name} param "
         list_cmd = param_cmd + "ls -v -f csv"
-        rules_cmd = param_cmd + "ls --rules -f csv"
+        rules_cmd = param_cmd + "ls --rules -v -f csv"
         rule_err_msg = "Rule violation"
         create_err_msg = "Rule create error"
 
@@ -1735,6 +1909,10 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.assertIn(f"{param1},string,regex,{regex}", result.out())
 
         result = self.run_cli(cmd_env, param_cmd + "list --rules")
+        self.assertResultSuccess(result)
+        self.assertEqual(result.out(), f"{param1}\n")
+
+        result = self.run_cli(cmd_env, param_cmd + "list --rules -v")
         self.assertResultSuccess(result)
         self.assertEqual(result.out(), """\
 +--------+------------+-----------+------------+
@@ -1903,7 +2081,7 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.create_environment(cmd_env, env_name)
         param_cmd = base_cmd + f"--project {proj_name} --env {env_name} param "
         list_cmd = param_cmd + "ls -v -f csv"
-        rules_cmd = param_cmd + "ls --rules -f csv"
+        rules_cmd = param_cmd + "ls --rules -vf csv"
         rule_err_msg = "Rule violation"
         create_err_msg = "Rule create error"
 
@@ -1938,6 +2116,10 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.assertIn(f"{param1},integer,min,{min_value}", result.out())
 
         result = self.run_cli(cmd_env, param_cmd + "list --rules")
+        self.assertResultSuccess(result)
+        self.assertEqual(result.out(), f"{param1}\n")
+
+        result = self.run_cli(cmd_env, param_cmd + "list --rules -v")
         self.assertResultSuccess(result)
         self.assertEqual(result.out(), """\
 +--------+------------+-----------+------------+
@@ -2072,7 +2254,7 @@ Parameter,{env_a} ({modified_a}),{env_b} ({modified_b})
         self.create_environment(cmd_env, env_name)
         param_cmd = base_cmd + f"--project {proj_name} --env {env_name} param "
         list_cmd = param_cmd + "ls -v -f csv"
-        rules_cmd = param_cmd + "ls --rules -f csv"
+        rules_cmd = param_cmd + "ls --rules -f csv -v"
         create_err_msg = "Rule create error"
 
         # create a basic parameter without a value, so the rule cannot be violated

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -39,7 +39,10 @@ DEFAULT_PARAM_VALUE = "-"
 # properties
 PROP_CREATED = "Created At"
 PROP_MODIFIED = "Modified At"
+PROP_NAME = "Name"
+PROP_TYPE = "Type"
 PROP_VALUE = "Value"
+PROP_RAW = "Raw"
 
 
 def get_cli_base_cmd() -> str:
@@ -166,7 +169,7 @@ class TestCase(unittest.TestCase):
         """
         This is a convenience method to check the return code, and error output.
         """
-        # check the error message is emtpty first, since it gives the most info about a failure
+        # check the error message is empty first, since it gives the most info about a failure
         self.assertEqual(result.err(), "")
         self.assertEqual(result.return_value, 0)
 
@@ -294,22 +297,33 @@ class TestCase(unittest.TestCase):
             cmd_env,
             proj: str,
             name: str,
-            value: str,
+            value: Optional[str] = None,
             secret: Optional[bool] = None,
             env: Optional[str] = None,
             desc: Optional[str] = None,
-            param_type: Optional[str] = None
+            param_type: Optional[str] = None,
+            fqn: Optional[str] = None,
+            jmes: Optional[str] = None,
+            evaluate: Optional[bool] = None,
     ) -> Result:
         cmd = self._base_cmd + f"--project '{proj}' "
         if env:
             cmd += f"--env '{env}' "
-        cmd += f"param set '{name}' --value '{value}' "
+        cmd += f"param set '{name}' "
+        if value:
+            cmd += f"--value '{value}' "
         if secret is not None:
             cmd += f"--secret '{str(secret).lower()}' "
         if desc:
             cmd += f"--desc '{desc}' "
         if param_type:
             cmd += f"--type '{param_type}' "
+        if fqn:
+            cmd += f"--fqn '{fqn}' "
+        if jmes:
+            cmd += f"--jmes '{jmes}' "
+        if evaluate is not None:
+            cmd += f"--evaluate '{str(evaluate).lower()}' "
         result = self.run_cli(cmd_env, cmd)
         self.assertResultSuccess(result)
         return result
@@ -383,3 +397,42 @@ class TestCase(unittest.TestCase):
         result = self.run_cli(cmd_env, cmd)
         self.assertResultSuccess(result)
         self.assertIn(value, result.out())
+
+    def list_params(
+            self,
+            cmd_env,
+            proj: str,
+            env: Optional[str] = None,
+            show_values: bool = True,
+            secrets: bool = False,
+            fmt: Optional[str] = None,
+            as_of: Optional[str] = None,
+            show_times: bool = False,
+            show_rules: bool = False,
+            show_external: bool = False,
+            show_evaluated: bool = False,
+    ) -> Result:
+        cmd = self._base_cmd + f"--project '{proj}' "
+        if env:
+            cmd += f"--env '{env}' "
+        cmd += "param ls "
+        if fmt:
+            cmd += f"-f {fmt} "
+        if as_of:
+            cmd += f"--as-of '{as_of}' "
+        if secrets:
+            cmd += "-s "
+        if show_values:
+            cmd += "-v "
+        if show_times:
+            cmd += "--show-times "
+        if show_rules:
+            cmd += "--rules "
+        if show_external:
+            cmd += "--external "
+        if show_evaluated:
+            cmd += "--evaluated "
+
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        return result


### PR DESCRIPTION
Adds `parameter set --evaluate` flag to toggle whether a parameter is evaluated.
Adds `parameter list --evaulated` to show the both the evaluated and unevaluated values.