### PR TITLE
1.0.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 1.0.13 - 2021-11-05
+
+* Added several `integrations` commands:
+  * Added `refresh` to trigger update of an integration connection status.
+  * Added `get` to get detailed information about an integration.
+  * Added `pushes <set|delete|list|get|sync|tasks>` commands to manage push actions.
+* Added `schema` command to get the latest schema from the server, or local CLI version.
+* Added `--user`, `--before`, and `--after` filters to `audit-logs list`.
+* Fixed issue with `templates history --as-of` using tags.
+* Show values for items when a `--format <table|csv|json|yaml>` is specified.
+
 # 1.0.12 - 2021-10-26
 
 * Added parent project support:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.0.12"
+version = "1.0.13"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.0.12"
+version = "1.0.13"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2018"

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.0.12
+cloudtruth 1.0.13
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 


### PR DESCRIPTION
* Added several `integrations` commands:
  * Added `refresh` to trigger update of an integration connection status.
  * Added `get` to get detailed information about an integration.
  * Added `pushes <set|delete|list|get|sync|tasks>` commands to manage push actions.
* Added `schema` command to get the latest schema from the server, or local CLI version.
* Added `--user`, `--before`, and `--after` filters to `audit-logs list`.
* Fixed issue with `templates history --as-of` using tags.
* Show values for items when a `--format <table|csv|json|yaml>` is specified.
