### PR TITLE
1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.1.0 - 2021-11-12
+
+* BREAKING CHANGE:
+  * Moved `integrations pushes` commands to `actions pushes`.
+    * Made integration-name optional (using `--integration|-i <name>`) for most `pushes` commands.
+* Internal changes to improve testing.
+
 # 1.0.13 - 2021-11-05
 
 * Added several `integrations` commands:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.0.13"
+version = "1.1.0"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.0.13"
+version = "1.1.0"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2018"

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.0.13
+cloudtruth 1.1.0
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 


### PR DESCRIPTION
* BREAKING CHANGE:
  * Moved `integrations pushes` commands to `actions pushes`.
    * Made integration-name optional (using `--integration|-i <name>`) for most `pushes` commands.
* Internal changes to improve testing.
