### PR TITLE
Several schema command improvements

### DIFF
--- a/client/src/apis/api_api.rs
+++ b/client/src/apis/api_api.rs
@@ -12,7 +12,7 @@ use reqwest;
 use std::time::Instant;
 
 use super::{configuration, Error};
-use crate::apis::{handle_serde_error, ResponseContent};
+use crate::apis::ResponseContent;
 
 /// struct for typed errors of method `api_schema_retrieve`
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,7 +26,7 @@ pub fn api_schema_retrieve(
     configuration: &configuration::Configuration,
     format: Option<&str>,
     lang: Option<&str>,
-) -> Result<::std::collections::HashMap<String, serde_json::Value>, Error<ApiSchemaRetrieveError>> {
+) -> Result<String, Error<ApiSchemaRetrieveError>> {
     let local_var_client = &configuration.client;
 
     let local_var_uri_str = format!("{}/api/schema/", configuration.base_path);
@@ -64,8 +64,7 @@ pub fn api_schema_retrieve(
     let local_var_content = local_var_resp.text()?;
 
     if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
-        serde_json::from_str(&local_var_content)
-            .map_err(|e| handle_serde_error(e, &method, local_var_resp.url(), &local_var_content))
+        Ok(local_var_content)
     } else {
         let local_var_entity: Option<ApiSchemaRetrieveError> =
             serde_json::from_str(&local_var_content).ok();

--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,11854 @@
+{
+    "openapi": "3.0.3",
+    "info": {
+        "title": "CloudTruth Management API",
+        "version": "",
+        "description": "CloudTruth centralizes your configuration parameters and secrets making them easier to manage and use as a team.",
+        "contact": {
+            "name": "CloudTruth Support",
+            "email": "support@cloudtruth.com"
+        }
+    },
+    "paths": {
+        "/api/schema/": {
+            "get": {
+                "operationId": "api_schema_retrieve",
+                "description": "OpenApi3 schema for this API. Format can be selected via content negotiation.\n\n- YAML: application/vnd.oai.openapi\n- JSON: application/vnd.oai.openapi+json",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "format",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "json",
+                                "yaml"
+                            ]
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "lang",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "af",
+                                "ar",
+                                "ar-dz",
+                                "ast",
+                                "az",
+                                "be",
+                                "bg",
+                                "bn",
+                                "br",
+                                "bs",
+                                "ca",
+                                "cs",
+                                "cy",
+                                "da",
+                                "de",
+                                "dsb",
+                                "el",
+                                "en",
+                                "en-au",
+                                "en-gb",
+                                "eo",
+                                "es",
+                                "es-ar",
+                                "es-co",
+                                "es-mx",
+                                "es-ni",
+                                "es-ve",
+                                "et",
+                                "eu",
+                                "fa",
+                                "fi",
+                                "fr",
+                                "fy",
+                                "ga",
+                                "gd",
+                                "gl",
+                                "he",
+                                "hi",
+                                "hr",
+                                "hsb",
+                                "hu",
+                                "hy",
+                                "ia",
+                                "id",
+                                "ig",
+                                "io",
+                                "is",
+                                "it",
+                                "ja",
+                                "ka",
+                                "kab",
+                                "kk",
+                                "km",
+                                "kn",
+                                "ko",
+                                "ky",
+                                "lb",
+                                "lt",
+                                "lv",
+                                "mk",
+                                "ml",
+                                "mn",
+                                "mr",
+                                "my",
+                                "nb",
+                                "ne",
+                                "nl",
+                                "nn",
+                                "os",
+                                "pa",
+                                "pl",
+                                "pt",
+                                "pt-br",
+                                "ro",
+                                "ru",
+                                "sk",
+                                "sl",
+                                "sq",
+                                "sr",
+                                "sr-latn",
+                                "sv",
+                                "sw",
+                                "ta",
+                                "te",
+                                "tg",
+                                "th",
+                                "tk",
+                                "tr",
+                                "tt",
+                                "udm",
+                                "uk",
+                                "ur",
+                                "uz",
+                                "vi",
+                                "zh-hans",
+                                "zh-hant"
+                            ]
+                        }
+                    }
+                ],
+                "tags": [
+                    "api"
+                ],
+                "security": [
+                    {}
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/vnd.oai.openapi": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                }
+                            },
+                            "application/yaml": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                }
+                            },
+                            "application/vnd.oai.openapi+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                }
+                            },
+                            "application/json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": {}
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/audit/": {
+            "get": {
+                "operationId": "audit_list",
+                "description": "A searchable log of all the actions taken by users and service accounts within the organization.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "action",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "create",
+                                "delete",
+                                "pull",
+                                "push",
+                                "update"
+                            ]
+                        },
+                        "description": "The action that was taken."
+                    },
+                    {
+                        "in": "query",
+                        "name": "earliest",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "latest",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "object_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "object_type",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "user_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "audit"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAuditTrailList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/audit/{id}/": {
+            "get": {
+                "operationId": "audit_retrieve",
+                "description": "Retrieve one record from the audit log.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the audit record."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "audit"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuditTrail"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/audit/summary/": {
+            "get": {
+                "operationId": "audit_summary_retrieve",
+                "description": "Summary information about the organization's audit trail.",
+                "tags": [
+                    "audit"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuditTrailSummary"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/environments/": {
+            "get": {
+                "operationId": "environments_list",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "description__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "parent__name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "parent__name__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedEnvironmentList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "environments_create",
+                "tags": [
+                    "environments"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EnvironmentCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EnvironmentCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/EnvironmentCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Environment"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/environments/{environment_pk}/pushes/": {
+            "get": {
+                "operationId": "environments_pushes_list",
+                "description": "The complete history of push operations that this environment was involved in.",
+                "summary": "List push operations.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "environment_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAwsPushTaskStepList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/environments/{environment_pk}/tags/": {
+            "get": {
+                "operationId": "environments_tags_list",
+                "description": "Tags allow you to name stable points in time for your configuration.\n\nAny query API that accepts an `as_of` option will also accept a `tag`\noption however they are mutually exclusive.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "description__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "environment_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "timestamp",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "timestamp__gte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "timestamp__lte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedTagList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "environments_tags_create",
+                "description": "Tags allow you to name stable points in time for your configuration.\n\nAny query API that accepts an `as_of` option will also accept a `tag`\noption however they are mutually exclusive.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "environment_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TagCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TagCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TagCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Tag"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/environments/{environment_pk}/tags/{id}/": {
+            "get": {
+                "operationId": "environments_tags_retrieve",
+                "description": "Tags allow you to name stable points in time for your configuration.\n\nAny query API that accepts an `as_of` option will also accept a `tag`\noption however they are mutually exclusive.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "environment_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the tag."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Tag"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "environments_tags_update",
+                "description": "Tags allow you to name stable points in time for your configuration.\n\nAny query API that accepts an `as_of` option will also accept a `tag`\noption however they are mutually exclusive.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "environment_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the tag."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TagUpdate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TagUpdate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TagUpdate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TagUpdate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "environments_tags_partial_update",
+                "description": "Tags allow you to name stable points in time for your configuration.\n\nAny query API that accepts an `as_of` option will also accept a `tag`\noption however they are mutually exclusive.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "environment_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the tag."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedTagUpdate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedTagUpdate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedTagUpdate"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TagUpdate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "environments_tags_destroy",
+                "description": "Tags allow you to name stable points in time for your configuration.\n\nAny query API that accepts an `as_of` option will also accept a `tag`\noption however they are mutually exclusive.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "environment_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the tag."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/environments/{id}/": {
+            "get": {
+                "operationId": "environments_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the environment."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Environment"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "environments_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the environment."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Environment"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Environment"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Environment"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Environment"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "environments_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the environment."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedEnvironment"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedEnvironment"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedEnvironment"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Environment"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "environments_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the environment."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "environments"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Environment destroyed."
+                    },
+                    "409": {
+                        "description": "The environment has children and cannot be removed."
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/": {
+            "get": {
+                "operationId": "integrations_aws_list",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "aws_account_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "aws_role_name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAwsIntegrationList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "integrations_aws_create",
+                "description": "### Description ###\n\nEstablishes an AWS Integration for your CloudTruth organization.\n\n### Pre-Conditions ###\n\n- An AWS Integration for the account and role cannot already exist.\n### Post-Conditions ###\n\n- You must establish an IAM role and trust relationship based on the Role Name and the External ID.",
+                "summary": "Establishes an AWS Integration.",
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsIntegrationCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsIntegrationCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsIntegrationCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsIntegration"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pulls/": {
+            "get": {
+                "operationId": "integrations_aws_pulls_list",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "description__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAwsPullList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "integrations_aws_pulls_create",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPull"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPull"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPull"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPull"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pulls/{awspull_pk}/tasks/": {
+            "get": {
+                "operationId": "integrations_aws_pulls_tasks_list",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspull_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at__gte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at__lte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "state",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "failure",
+                                "queued",
+                                "running",
+                                "skipped",
+                                "success"
+                            ]
+                        },
+                        "description": "The current state of this task."
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAwsPushTaskList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pulls/{awspull_pk}/tasks/{awspulltask_pk}/steps/": {
+            "get": {
+                "operationId": "integrations_aws_pulls_tasks_steps_list",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspull_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspulltask_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fqn",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at__gte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at__lte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "operation",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "create",
+                                "delete",
+                                "read",
+                                "update"
+                            ]
+                        },
+                        "description": "The operation performed, if any.\n\nWhen the operation is an update, there may be additional details in the success_detail field to describe the change.\n\nWhen the project is filled in but the environment and parameterare not, the operation is on the project.  When the environmentis filled in but the project and parameter are not, the operationis on the environment.  When the project and parameter are filledin but the environment is not, the operation is on the parameter.When all three are filled in, the operation is on the value ofthe parameter of the project in the specified environment."
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "success",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "venue_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "venue_id__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "venue_name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "venue_name__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAwsPushTaskStepList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pulls/{awspull_pk}/tasks/{awspulltask_pk}/steps/{id}/": {
+            "get": {
+                "operationId": "integrations_aws_pulls_tasks_steps_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspull_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspulltask_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for a task step."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPushTaskStep"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pulls/{awspull_pk}/tasks/{id}/": {
+            "get": {
+                "operationId": "integrations_aws_pulls_tasks_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspull_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier for the push action task."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPushTask"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pulls/{id}/": {
+            "get": {
+                "operationId": "integrations_aws_pulls_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPull"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "integrations_aws_pulls_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPull"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPull"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPull"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPull"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "integrations_aws_pulls_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAwsPull"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAwsPull"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAwsPull"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPull"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "integrations_aws_pulls_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pulls/{id}/sync/": {
+            "post": {
+                "operationId": "integrations_aws_pulls_sync_create",
+                "description": "Enqueue a pull synchronization task.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPull"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPull"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPull"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Synchronization task enqueued."
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pushes/": {
+            "get": {
+                "operationId": "integrations_aws_pushes_list",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "description__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAwsPushList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "integrations_aws_pushes_create",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPush"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPush"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPush"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPush"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pushes/{awspush_pk}/tasks/": {
+            "get": {
+                "operationId": "integrations_aws_pushes_tasks_list",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspush_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at__gte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at__lte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "state",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "failure",
+                                "queued",
+                                "running",
+                                "skipped",
+                                "success"
+                            ]
+                        },
+                        "description": "The current state of this task."
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAwsPushTaskList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pushes/{awspush_pk}/tasks/{awspushtask_pk}/steps/": {
+            "get": {
+                "operationId": "integrations_aws_pushes_tasks_steps_list",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspush_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspushtask_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "fqn",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at__gte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "modified_at__lte",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "operation",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "create",
+                                "delete",
+                                "read",
+                                "update"
+                            ]
+                        },
+                        "description": "The operation performed, if any.\n\nWhen the operation is an update, there may be additional details in the success_detail field to describe the change.\n\nWhen the project is filled in but the environment and parameterare not, the operation is on the project.  When the environmentis filled in but the project and parameter are not, the operationis on the environment.  When the project and parameter are filledin but the environment is not, the operation is on the parameter.When all three are filled in, the operation is on the value ofthe parameter of the project in the specified environment."
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "success",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "venue_id",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "venue_id__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "venue_name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "venue_name__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAwsPushTaskStepList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pushes/{awspush_pk}/tasks/{awspushtask_pk}/steps/{id}/": {
+            "get": {
+                "operationId": "integrations_aws_pushes_tasks_steps_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspush_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspushtask_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for a task step."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPushTaskStep"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pushes/{awspush_pk}/tasks/{id}/": {
+            "get": {
+                "operationId": "integrations_aws_pushes_tasks_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "awspush_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier for the push action task."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPushTask"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pushes/{id}/": {
+            "get": {
+                "operationId": "integrations_aws_pushes_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPush"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "integrations_aws_pushes_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPushUpdate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPushUpdate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPushUpdate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPushUpdate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "integrations_aws_pushes_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAwsPushUpdate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAwsPushUpdate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAwsPushUpdate"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsPushUpdate"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "integrations_aws_pushes_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{awsintegration_pk}/pushes/{id}/sync/": {
+            "post": {
+                "operationId": "integrations_aws_pushes_sync_create",
+                "description": "Enqueue a push synchronization task.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "awsintegration_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "Unique identifier for the action."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPush"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPush"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsPush"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "202": {
+                        "description": "Synchronization task enqueued."
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/aws/{id}/": {
+            "get": {
+                "operationId": "integrations_aws_retrieve",
+                "summary": "Get details of an AWS Integration.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier for the integration."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "refresh_status",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Trigger a refresh of the integration status before returning the details."
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsIntegration"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "integrations_aws_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier for the integration."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsIntegration"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsIntegration"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/AwsIntegration"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsIntegration"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "integrations_aws_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier for the integration."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAwsIntegration"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAwsIntegration"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedAwsIntegration"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AwsIntegration"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "integrations_aws_destroy",
+                "summary": "Delete an AWS integration.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier for the integration."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "in_use",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "fail",
+                                "leave",
+                                "remove"
+                            ]
+                        },
+                        "description": "(Optional) Desired behavior if the integration has in-use values.\n\n- `fail` will return HTTP error 409 if there are any values using the integration.\n- `leave` (default) will leave values in place and future queries may fail; you can control future value query behavior with the `lookup_error` query parameter on those requests.\n- `remove` will remove the all values using the integration when the integration is removed."
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Integration removed."
+                    },
+                    "409": {
+                        "description": "The integration is used by one (or more) Value(s) and cannot be removed."
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/explore/": {
+            "get": {
+                "operationId": "integrations_explore_list",
+                "description": "### Description ###\n\nQueries a third-party integration to retrieve the data specified by the FQN.\n\nYou can start exploring by not specifying an 'fqn', which will return a list of FQNs for the existing third-party integrations. Third-party integrations can be configured via the Integrations section of the web application.\n",
+                "summary": "Retrieve third-party integration data for the specified FQN.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "fqn",
+                        "schema": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "FQN (URL-like) for third-party integration."
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {}
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedIntegrationExplorerList"
+                                }
+                            }
+                        },
+                        "description": "The content at the FQN."
+                    },
+                    "400": {
+                        "description": "Invalid FQN requested."
+                    },
+                    "403": {
+                        "description": "Unable to contact the third-party integration."
+                    },
+                    "415": {
+                        "description": "Unsupported content type (usually this means it is binary)."
+                    },
+                    "507": {
+                        "description": "Content exceeds internal size limit of 1MB."
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/github/": {
+            "get": {
+                "operationId": "integrations_github_list",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "gh_organization_slug",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedGitHubIntegrationList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "integrations_github_create",
+                "description": "### Description ###\n\nEstablishes a GitHub Integration in your CloudTruth organization.\n\n### Pre-Conditions ###\n\n- The user must be an Administrator or Owner of your organization.\n- A GitHub Integration with the `installation_id` cannot \nalready exist in this organization.\n- The user must first install the CloudTruth GitHub Application in \ntheir GitHub organization and obtain the `installation_id` of the \napplication in order to create the integration.\n\n### Initiating the GitHub Application Installation ###\n\n- Go to `https://github.com/apps/GITHUB_APP_NAME/installations/new?state=<bearer_token>`\n- On successful installation the browser will return to \n`https://APP_URL/app_setup/github` (configured in ctops/bin/github*) \nand provide the `installation_id` in the URI.\n- POST to this api to verify and establish the integration.",
+                "summary": "Establishes a GitHub Integration.",
+                "tags": [
+                    "integrations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GitHubIntegrationCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GitHubIntegrationCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/GitHubIntegrationCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GitHubIntegration"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/integrations/github/{id}/": {
+            "get": {
+                "operationId": "integrations_github_retrieve",
+                "summary": "Get details of a GitHub Integration.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier for the integration."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "refresh_status",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Refresh the integration status before returning the details."
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/GitHubIntegration"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "integrations_github_destroy",
+                "summary": "Delete a GitHub integration.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier for the integration."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "in_use",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "fail",
+                                "leave",
+                                "remove"
+                            ]
+                        },
+                        "description": "(Optional) Desired behavior if the integration has in-use values.\n\n- `fail` will return HTTP error 409 if there are any values using the integration.\n- `leave` (default) will leave values in place and future queries may fail; you can control future value query behavior with the `lookup_error` query parameter on those requests.\n- `remove` will remove the all values using the integration when the integration is removed."
+                    }
+                ],
+                "tags": [
+                    "integrations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Integration removed."
+                    },
+                    "409": {
+                        "description": "The integration is used by one (or more) Value(s) and cannot be removed."
+                    }
+                }
+            }
+        },
+        "/api/v1/invitations/": {
+            "get": {
+                "operationId": "invitations_list",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "email",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "role",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "ADMIN",
+                                "CONTRIB",
+                                "OWNER",
+                                "VIEWER"
+                            ]
+                        },
+                        "description": "The role that the user will have in the organization, should the user accept."
+                    },
+                    {
+                        "in": "query",
+                        "name": "state",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "accepted",
+                                "bounced",
+                                "pending",
+                                "sent"
+                            ]
+                        },
+                        "description": "The current state of the invitation."
+                    }
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedInvitationList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "invitations_create",
+                "description": "Extend an invitation for someone else to join your organization.",
+                "summary": "Create an invitation.",
+                "tags": [
+                    "invitations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/InvitationCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/InvitationCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/InvitationCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Invitation"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "403": {
+                        "description": "Permission denied.  Is the invitation role more permissive than your own?"
+                    },
+                    "404": {
+                        "description": "Bad Request.  Is there already an invitation for that email?"
+                    }
+                }
+            }
+        },
+        "/api/v1/invitations/{id}/": {
+            "get": {
+                "operationId": "invitations_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier of an invitation."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Invitation"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "invitations_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier of an invitation."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Invitation"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Invitation"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Invitation"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Invitation"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "invitations_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier of an invitation."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedInvitation"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedInvitation"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedInvitation"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Invitation"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "invitations_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "The unique identifier of an invitation."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/invitations/{id}/accept/": {
+            "post": {
+                "operationId": "invitations_accept_create",
+                "description": "Accept an invitation to join an organization.\n\nThe email address used to log in and accept the invitation must match\nthe email address specified by the inviting user when creating the invitation.\n\nOn success the client receives the invitation record as it was updated.\nThe client should then regenerate the JWT with the organization scope and\nproceed to the default landing page.",
+                "summary": "Accept an invitation.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The invitation ID.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    },
+                    {}
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Invitation"
+                                }
+                            }
+                        },
+                        "description": "The invitation was accepted.  The client should obtain an organization scope token and proceed to the landing page."
+                    },
+                    "403": {
+                        "description": "Permission denied.  The accepting user's email may not match the invitation?"
+                    },
+                    "404": {
+                        "description": "Bad Request.  The invitation does not exist or has already been accepted?"
+                    }
+                }
+            }
+        },
+        "/api/v1/invitations/{id}/resend/": {
+            "post": {
+                "operationId": "invitations_resend_create",
+                "description": "Re-send an invitation to the recipient.",
+                "summary": "Resend an invitation.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The invitation ID.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "invitations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Invitation"
+                                }
+                            }
+                        },
+                        "description": "The invitation state was reset to `pending`, which causes it to get sent again.  The most recent state is returned.  Clients should check the state."
+                    },
+                    "404": {
+                        "description": "Bad Request.  Was the invitation already accepted?"
+                    }
+                }
+            }
+        },
+        "/api/v1/memberships/": {
+            "get": {
+                "operationId": "memberships_list",
+                "parameters": [
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "role",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "ADMIN",
+                                "CONTRIB",
+                                "OWNER",
+                                "VIEWER"
+                            ]
+                        },
+                        "description": "The role that the user has in the organization."
+                    },
+                    {
+                        "in": "query",
+                        "name": "user",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "The unique identifier of a user."
+                    }
+                ],
+                "tags": [
+                    "memberships"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedMembershipList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "memberships_create",
+                "tags": [
+                    "memberships"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MembershipCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MembershipCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/MembershipCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Membership"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/memberships/{id}/": {
+            "get": {
+                "operationId": "memberships_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the membership."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "memberships"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Membership"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "memberships_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the membership."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "memberships"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Membership"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Membership"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Membership"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Membership"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "memberships_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the membership."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "memberships"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMembership"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMembership"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedMembership"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Membership"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "memberships_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the membership."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "memberships"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/organizations/": {
+            "get": {
+                "operationId": "organizations_list",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedOrganizationList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "organizations_create",
+                "tags": [
+                    "organizations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OrganizationCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OrganizationCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/OrganizationCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Organization"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/organizations/{id}/": {
+            "get": {
+                "operationId": "organizations_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "description": "A unique identifier for the organization."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Organization"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "organizations_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "description": "A unique identifier for the organization."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Organization"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Organization"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Organization"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Organization"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "organizations_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "description": "A unique identifier for the organization."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedOrganization"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedOrganization"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedOrganization"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Organization"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "organizations_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "description": "A unique identifier for the organization."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "organizations"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/": {
+            "get": {
+                "operationId": "projects_list",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "description__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "name__icontains",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedProjectList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "projects_create",
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Project"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{id}/": {
+            "get": {
+                "operationId": "projects_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the project."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Project"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "projects_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the project."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Project"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Project"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Project"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Project"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "projects_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the project."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedProject"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedProject"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedProject"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Project"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "projects_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the project."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Project destroyed."
+                    },
+                    "409": {
+                        "description": "The project has dependents and cannot be removed."
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameter-export/": {
+            "get": {
+                "operationId": "projects_parameter_export_list",
+                "description": "Exports all parameters in this project in the requested format.\n\nParameter names and values will be coerced to the proper format (e.g. for a\ndotenv export, my_parameter will be capitalized to MY_PARAMETER and its value\nwill be in a quoted string).  Note that capitalization is the only name coercion\nthat will be performed on parameter names, names that are invalid for a given\nformat will be omitted.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "contains",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Only include parameters with names that contain the provided string."
+                    },
+                    {
+                        "in": "query",
+                        "name": "endswith",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Only include parameters with names that end with the provided string."
+                    },
+                    {
+                        "in": "query",
+                        "name": "environment",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Name or id of the environment to use to retrieve parameter values."
+                    },
+                    {
+                        "in": "query",
+                        "name": "explicit_export",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Explicitly marks parameters with export, e.g. `export FOO=bar`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "mask_secrets",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Masks all secrets in the template with `*****`."
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "output",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Format to output: One of 'docker', 'dotenv', 'shell'."
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "startswith",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Only include parameters with names that start with the provided string."
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "wrap",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Indicates all secrets are wrapped. For more information on secret wrapping, see the documentation."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ParameterExport"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameters/": {
+            "get": {
+                "operationId": "projects_parameters_list",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "environment",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Name or id (uuid) of the environment to get parameter values for.  Cannot be used with `values`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If `true`, runs template evaluation on this parameter's values.  If `false`, returns the value's template.\nNo effect on values that are not interpolated."
+                    },
+                    {
+                        "in": "query",
+                        "name": "mask_secrets",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "If true, masks all secrets."
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "partial_success",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Determine if the response is allowed to include a partial success.\n\nA partial success can occur if one or more external values cannot be retrieved, for example when an in-use integration is removed using the `leave` option, leaving the values untouched. When `true`, any error that occurs during external value retrieval will be placed into a field named `external_error` in the affected Value, and the `value` field will be empty.  When `false`, any such error will cause the entire request to fail.\nPartial success allows clients to tolerate invalid external values better."
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "secret",
+                        "schema": {
+                            "type": "boolean"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "values",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If false, values are not returned: the `values` array will have no entries. This speeds up retrieval if value content is not needed.  Cannot be used with `environment`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "wrap",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "If true, wraps all secrets - see documentation for more details."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedParameterList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "projects_parameters_create",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ParameterCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ParameterCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ParameterCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Parameter"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameters/{parameter_pk}/pushes/": {
+            "get": {
+                "operationId": "projects_parameters_pushes_list",
+                "description": "The complete history of push operations that this parameter was involved in.",
+                "summary": "List push operations.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedAwsPushTaskStepList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameters/{parameter_pk}/rules/": {
+            "get": {
+                "operationId": "projects_parameters_rules_list",
+                "parameters": [
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "type",
+                        "schema": {
+                            "type": "string",
+                            "enum": [
+                                "max",
+                                "max_len",
+                                "min",
+                                "min_len",
+                                "regex"
+                            ]
+                        }
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedParameterRuleList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "projects_parameters_rules_create",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ParameterRuleCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ParameterRuleCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ParameterRuleCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ParameterRule"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameters/{parameter_pk}/rules/{id}/": {
+            "get": {
+                "operationId": "projects_parameters_rules_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this parameter rule.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ParameterRule"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "projects_parameters_rules_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this parameter rule.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ParameterRule"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ParameterRule"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ParameterRule"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ParameterRule"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "projects_parameters_rules_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this parameter rule.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedParameterRule"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedParameterRule"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedParameterRule"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ParameterRule"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "projects_parameters_rules_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "A UUID string identifying this parameter rule.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameters/{parameter_pk}/values/": {
+            "get": {
+                "operationId": "projects_parameters_values_list",
+                "description": "\n        Retrieve previously set values of a parameter in one or all environments.\n        To see all the _effective_ values for a parameter across every environment,\n        use the Parameters API (see the `values` field).\n    ",
+                "summary": "Retrieve values.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "environment",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Name or id of the environment to limit the result to. If this is not specified then the result will contain a value for any environment in which it is set. You cannot use this option to retrieve the _effective_ value of a parameter in an environment for which is is not explicitly set. To see _effective_ values use the Parameters API (see the `values` field)."
+                    },
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If `true`, runs template evaluation on this parameter.  If `false`, returns the value's template.\nNo effect on values that are not interpolated."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "A comma-separated list of field names to exclude from the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "include",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "A comma-separated list of field names to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "mask_secrets",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Mask secret values in responses with `*****`."
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "partial_success",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Determine if the response is allowed to include a partial success.\n\nA partial success can occur if one or more external values cannot be retrieved, for example when an in-use integration is removed using the `leave` option, leaving the values untouched. When `true`, any error that occurs during external value retrieval will be placed into a field named `external_error` in the affected Value, and the `value` field will be empty.  When `false`, any such error will cause the entire request to fail.\nPartial success allows clients to tolerate invalid external values better."
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "wrap",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "For writes, indicates `internal_value` is wrapped; for reads, indicates `value` is wrapped. For more information on secret wrapping, see the documentation. "
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedValueList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "projects_parameters_values_create",
+                "description": "Set the value of a parameter in an environment.",
+                "summary": "Set a value.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If `true`, runs template evaluation on this parameter.  If `false`, returns the value's template.\nNo effect on values that are not interpolated."
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "wrap",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Indicates the `internal_value` is a wrapped secret. For more information on secret wrapping, see the documentation. "
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ValueCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ValueCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ValueCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Value"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameters/{parameter_pk}/values/{id}/": {
+            "get": {
+                "operationId": "projects_parameters_values_retrieve",
+                "description": "Retrieve the value of a parameter in an environment.",
+                "summary": "Retrieve a value.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If `true`, runs template evaluation on this parameter.  If `false`, returns the value's template.\nNo effect on values that are not interpolated."
+                    },
+                    {
+                        "in": "query",
+                        "name": "exclude",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "A comma-separated list of field names to exclude from the response."
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the value."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "include",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "A comma-separated list of field names to include in the response."
+                    },
+                    {
+                        "in": "query",
+                        "name": "mask_secrets",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Mask secret values in responses with `*****`."
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "partial_success",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Determine if the response is allowed to include a partial success.\n\nA partial success can occur if one or more external values cannot be retrieved, for example when an in-use integration is removed using the `leave` option, leaving the values untouched. When `true`, any error that occurs during external value retrieval will be placed into a field named `external_error` in the affected Value, and the `value` field will be empty.  When `false`, any such error will cause the entire request to fail.\nPartial success allows clients to tolerate invalid external values better."
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "wrap",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "For writes, indicates `internal_value` is wrapped; for reads, indicates `value` is wrapped. For more information on secret wrapping, see the documentation. "
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Value"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "projects_parameters_values_update",
+                "description": "Update the value of a parameter in an environment.",
+                "summary": "Update a value.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If `true`, runs template evaluation on this parameter.  If `false`, returns the value's template.\nNo effect on values that are not interpolated."
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the value."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "wrap",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Indicates the `internal_value` is a wrapped secret. For more information on secret wrapping, see the documentation. "
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Value"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Value"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Value"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Value"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "projects_parameters_values_partial_update",
+                "description": "Update the value of a parameter in an environment.",
+                "summary": "Update a value.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If `true`, runs template evaluation on this parameter.  If `false`, returns the value's template.\nNo effect on values that are not interpolated."
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the value."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "wrap",
+                        "schema": {
+                            "type": "boolean"
+                        },
+                        "description": "Indicates the `internal_value` is a wrapped secret. For more information on secret wrapping, see the documentation. "
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedValue"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedValue"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedValue"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Value"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "projects_parameters_values_destroy",
+                "description": "Destroy the value of a parameter in an environment.",
+                "summary": "Destroy a value.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If `true`, runs template evaluation on this parameter.  If `false`, returns the value's template.\nNo effect on values that are not interpolated."
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the value."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "parameter_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The parameter id.",
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "description": "The project id.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameters/{id}/": {
+            "get": {
+                "operationId": "projects_parameters_retrieve",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "environment",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Name or id (uuid) of the environment to get parameter values for.  Cannot be used with `values`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If `true`, runs template evaluation on this parameter's values.  If `false`, returns the value's template.\nNo effect on values that are not interpolated."
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "mask_secrets",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "If true, masks all secrets."
+                    },
+                    {
+                        "in": "query",
+                        "name": "partial_success",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Determine if the response is allowed to include a partial success.\n\nA partial success can occur if one or more external values cannot be retrieved, for example when an in-use integration is removed using the `leave` option, leaving the values untouched. When `true`, any error that occurs during external value retrieval will be placed into a field named `external_error` in the affected Value, and the `value` field will be empty.  When `false`, any such error will cause the entire request to fail.\nPartial success allows clients to tolerate invalid external values better."
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "values",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If false, values are not returned: the `values` array will have no entries. This speeds up retrieval if value content is not needed.  Cannot be used with `environment`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "wrap",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "If true, wraps all secrets - see documentation for more details."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Parameter"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "projects_parameters_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Parameter"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Parameter"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Parameter"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Parameter"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "description": "While checking pre-conditions, an external value was encountered that could not be resolved."
+                    },
+                    "404": {
+                        "description": "The given project id could not be found, or while checking pre-conditions, an external value was encountered that could not be resolved."
+                    },
+                    "415": {
+                        "description": "While checking pre-conditions, an external value was encountered that has an invalid content type."
+                    },
+                    "422": {
+                        "description": "A pre-condition to modifying the `secret` setting of the parameter failed, for example setting `secret: false` and having an external value that resolves to a value that is a secret.  In this case it would be unsafe to allow the `secret` setting to change."
+                    },
+                    "507": {
+                        "description": "While checking pre-conditions, an external value was encountered that was too large to process."
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "projects_parameters_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedParameter"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedParameter"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedParameter"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Parameter"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "400": {
+                        "description": "While checking pre-conditions, an external value was encountered that could not be resolved."
+                    },
+                    "404": {
+                        "description": "The given project id could not be found, or while checking pre-conditions, an external value was encountered that could not be resolved."
+                    },
+                    "415": {
+                        "description": "While checking pre-conditions, an external value was encountered that has an invalid content type."
+                    },
+                    "422": {
+                        "description": "A pre-condition to modifying the `secret` setting of the parameter failed, for example setting `secret: false` and having an external value that resolves to a value that is a secret.  In this case it would be unsafe to allow the `secret` setting to change."
+                    },
+                    "507": {
+                        "description": "While checking pre-conditions, an external value was encountered that was too large to process."
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "projects_parameters_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameters/{id}/timeline/": {
+            "get": {
+                "operationId": "projects_parameters_timeline_retrieve",
+                "description": "Summary information about how a parameter has changed over time.\n\nThe time range of historical information available depends on your subscription.\nAny changes to the parameter itself, including rules and values, is included.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ParameterTimeline"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/parameters/timelines/": {
+            "get": {
+                "operationId": "projects_parameters_timelines_retrieve",
+                "description": "Information about how the parameters of a project have changed over time.\n\nThe time range of historical information available depends on your subscription.\nAny changes to the project's parameters, including rules and values, is included.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ParameterTimeline"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/template-preview/": {
+            "post": {
+                "operationId": "projects_template_preview_create",
+                "description": "Endpoint for previewing a template.  Post the template content in the request body.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "environment",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Name or id of the environment to use to instantiate this template. If not specified then the default environment is used."
+                    },
+                    {
+                        "in": "query",
+                        "name": "mask_secrets",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Masks all secrets in the template with `*****`."
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TemplatePreview"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TemplatePreview"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TemplatePreview"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TemplatePreview"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TemplateLookupError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/templates/": {
+            "get": {
+                "operationId": "projects_templates_list",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "environment",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Name or id of the environment to use to evaluate this template. If not specified then the original content is returned in the body."
+                    },
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "If `true`, evaluates the template's body.  If `false`, returns the unevaluated template body.\n"
+                    },
+                    {
+                        "in": "query",
+                        "name": "mask_secrets",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Masks all secrets in the template with `*****`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedTemplateList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TemplateLookupError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "projects_templates_create",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TemplateCreate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TemplateCreate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/TemplateCreate"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Template"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TemplateLookupError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/templates/{id}/": {
+            "get": {
+                "operationId": "projects_templates_retrieve",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "environment",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Name or id of the environment to use to evaluate this template. If not specified then the original content is returned in the body."
+                    },
+                    {
+                        "in": "query",
+                        "name": "evaluate",
+                        "schema": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "description": "If `true`, evaluates the template's body.  If `false`, returns the unevaluated template body.\n"
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "mask_secrets",
+                        "schema": {
+                            "type": "boolean",
+                            "default": false
+                        },
+                        "description": "Masks all secrets in the template with `*****`."
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Template"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TemplateLookupError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "projects_templates_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Template"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Template"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/Template"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Template"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TemplateLookupError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "projects_templates_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedTemplate"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedTemplate"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedTemplate"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Template"
+                                }
+                            }
+                        },
+                        "description": ""
+                    },
+                    "422": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TemplateLookupError"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "projects_templates_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Template destroyed."
+                    },
+                    "409": {
+                        "description": "The template is referenced by another template or value and cannot be removed."
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/templates/{id}/timeline/": {
+            "get": {
+                "operationId": "projects_templates_timeline_retrieve",
+                "description": "Information about how a template has changed over time.\n\nThe time range of historical information available depends on your subscription.\nAny changes to the template itself is included.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "environment",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Name or id of the environment to use to evaluate this template. If not specified then the original content is returned in the body."
+                    },
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid",
+                            "description": "A unique identifier for the parameter."
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TemplateTimeline"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{project_pk}/templates/timelines/": {
+            "get": {
+                "operationId": "projects_templates_timelines_retrieve",
+                "description": "Information about how the templates of a project have changed over time.\n\nThe time range of historical information available depends on your subscription.\nAny changes to the project's templates is included.",
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "as_of",
+                        "schema": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "description": "Specify a point in time to retrieve configuration from. Cannot be specified with `tag`."
+                    },
+                    {
+                        "in": "query",
+                        "name": "environment",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Name or id of the environment to use to evaluate this template. If not specified then the original content is returned in the body."
+                    },
+                    {
+                        "in": "path",
+                        "name": "project_pk",
+                        "schema": {
+                            "type": "string",
+                            "format": "uuid"
+                        },
+                        "required": true
+                    },
+                    {
+                        "in": "query",
+                        "name": "tag",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "Specify a tag to retrieve configuration from.  Cannot be specified with `as_of`."
+                    }
+                ],
+                "tags": [
+                    "projects"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/TemplateTimeline"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/serviceaccounts/": {
+            "get": {
+                "operationId": "serviceaccounts_list",
+                "parameters": [
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    }
+                ],
+                "tags": [
+                    "serviceaccounts"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedServiceAccountList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "post": {
+                "operationId": "serviceaccounts_create",
+                "description": "\n            Creates a new ServiceAccount.  A ServiceAccount is a user record intended\n            for machine use (such as a build system).  It does not have a username/password\n            but is instead accessed using an API key.\n\n            On creation, the API key will be returned.  This key will only be shown once,\n            is not stored on any CloudTruth system, and should be treated as a secret.  Should\n            the key be lost, you will need to delete and recreate the ServiceAccount in order\n            to generate a new API key.\n            ",
+                "summary": "Create a ServiceAccount user.",
+                "tags": [
+                    "serviceaccounts"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ServiceAccountCreateRequest"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ServiceAccountCreateRequest"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ServiceAccountCreateRequest"
+                            }
+                        }
+                    },
+                    "required": true
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ServiceAccountCreateResponse"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/serviceaccounts/{id}/": {
+            "get": {
+                "operationId": "serviceaccounts_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "A unique value identifying this service account.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "serviceaccounts"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ServiceAccount"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "put": {
+                "operationId": "serviceaccounts_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "A unique value identifying this service account.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "serviceaccounts"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ServiceAccount"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ServiceAccount"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ServiceAccount"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ServiceAccount"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "patch": {
+                "operationId": "serviceaccounts_partial_update",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "A unique value identifying this service account.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "serviceaccounts"
+                ],
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedServiceAccount"
+                            }
+                        },
+                        "application/x-www-form-urlencoded": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedServiceAccount"
+                            }
+                        },
+                        "multipart/form-data": {
+                            "schema": {
+                                "$ref": "#/components/schemas/PatchedServiceAccount"
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ServiceAccount"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "serviceaccounts_destroy",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string"
+                        },
+                        "description": "A unique value identifying this service account.",
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "serviceaccounts"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No response body"
+                    }
+                }
+            }
+        },
+        "/api/v1/users/": {
+            "get": {
+                "operationId": "users_list",
+                "parameters": [
+                    {
+                        "name": "ordering",
+                        "required": false,
+                        "in": "query",
+                        "description": "Which field to use when ordering the results.",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "page",
+                        "required": false,
+                        "in": "query",
+                        "description": "A page number within the paginated result set.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "name": "page_size",
+                        "required": false,
+                        "in": "query",
+                        "description": "Number of results to return per page.",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "type",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "tags": [
+                    "users"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/PaginatedUserList"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            }
+        },
+        "/api/v1/users/{id}/": {
+            "get": {
+                "operationId": "users_retrieve",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "description": "The unique identifier of a user."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "users"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        },
+                        "description": ""
+                    }
+                }
+            },
+            "delete": {
+                "operationId": "users_destroy",
+                "description": "### Description ###\n\nDelete the specified user.  This removes all access the User may have to any Organization.\n\n### Pre-Conditions ###\n\n- The user cannot be the only owner of any Organization.\n- The bearer token must belong to the user being deleted.\n- All of the memberships related to the User will be deleted, so all the membership deletion pre-conditions must also be met.\n",
+                "summary": "Delete the specified user.",
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "id",
+                        "schema": {
+                            "type": "string",
+                            "description": "The unique identifier of a user."
+                        },
+                        "required": true
+                    }
+                ],
+                "tags": [
+                    "users"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "User deleted. The client should behave as if the user logged out."
+                    },
+                    "400": {
+                        "description": "Bad Request\n\n- Is the user the only owner of any organization?\n- Were all required fields provided?"
+                    },
+                    "403": {
+                        "description": "Forbidden\n\n- Did the Bearer token belong to the User being deleted?"
+                    }
+                }
+            }
+        },
+        "/api/v1/users/current/": {
+            "get": {
+                "operationId": "users_current_retrieve",
+                "description": "Get user information about the current user.",
+                "summary": "Current user information",
+                "tags": [
+                    "users"
+                ],
+                "security": [
+                    {
+                        "JWTAuth": []
+                    },
+                    {
+                        "ApiKeyAuth": []
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/User"
+                                }
+                            }
+                        },
+                        "description": "User information"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "AuditTrail": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the audit record."
+                    },
+                    "action": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The action that was taken."
+                    },
+                    "object_id": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The id of the object associated with the action."
+                    },
+                    "object_name": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The name of the object associated with the action, if applicable."
+                    },
+                    "object_type": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ObjectTypeEnum"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The type of object associated with the action."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "The timestamp of the activity that was audited."
+                    },
+                    "user": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "Details of the user associated with this change."
+                    }
+                },
+                "required": [
+                    "action",
+                    "id",
+                    "object_id",
+                    "object_name",
+                    "object_type",
+                    "timestamp",
+                    "url",
+                    "user"
+                ]
+            },
+            "AuditTrailSummary": {
+                "type": "object",
+                "properties": {
+                    "earliest": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true,
+                        "readOnly": true,
+                        "description": "The earliest audit record timestamp available."
+                    },
+                    "max_days": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "The maximum number of days the system will save auditing records, based on your subscription."
+                    },
+                    "max_records": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "The maximum number of auditing records the system will save based on your subscription."
+                    },
+                    "total": {
+                        "type": "integer",
+                        "readOnly": true,
+                        "description": "The total number of audit records available."
+                    }
+                },
+                "required": [
+                    "earliest",
+                    "max_days",
+                    "max_records",
+                    "total"
+                ]
+            },
+            "AwsIntegration": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "The unique identifier for the integration."
+                    },
+                    "name": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description for the integration."
+                    },
+                    "status": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/StatusEnum"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The status of the integration connection with the third-party provider as of the `status_last_checked_at` field.  The status is updated automatically by the server when the integration is modified."
+                    },
+                    "status_detail": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "If an error occurs, more details will be available in this field."
+                    },
+                    "status_last_checked_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "The last time the status was evaluated."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "fqn": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "type": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The type of integration."
+                    },
+                    "writable": {
+                        "type": "boolean",
+                        "description": "Allow actions to write to the integration."
+                    },
+                    "aws_account_id": {
+                        "type": "string",
+                        "description": "The AWS Account ID.",
+                        "pattern": "^[0-9]+$",
+                        "maxLength": 12,
+                        "minLength": 12
+                    },
+                    "aws_enabled_regions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsRegionEnum"
+                        },
+                        "description": "The AWS regions to integrate with."
+                    },
+                    "aws_enabled_services": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsServiceEnum"
+                        },
+                        "description": "The AWS services to integrate with."
+                    },
+                    "aws_external_id": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "This is a shared secret between the AWS Administrator who set up your IAM trust relationship and your CloudTruth AWS Integration.  If your AWS Administrator provided you with a value use it, otherwise we will generate a random value for you to give to your AWS Administrator."
+                    },
+                    "aws_role_name": {
+                        "type": "string",
+                        "description": "The role that CloudTruth will assume when interacting with your AWS Account through this integration.  The role is configured by your AWS Account Administrator.  If your AWS Administrator provided you with a value use it, otherwise make your own role name and give it to your AWS Administrator.",
+                        "pattern": "^[\\w+=,.@\\-]+$",
+                        "maxLength": 64
+                    }
+                },
+                "required": [
+                    "aws_account_id",
+                    "aws_enabled_regions",
+                    "aws_enabled_services",
+                    "aws_external_id",
+                    "aws_role_name",
+                    "created_at",
+                    "fqn",
+                    "id",
+                    "modified_at",
+                    "name",
+                    "status",
+                    "status_detail",
+                    "status_last_checked_at",
+                    "type",
+                    "url"
+                ]
+            },
+            "AwsIntegrationCreate": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description for the integration."
+                    },
+                    "writable": {
+                        "type": "boolean",
+                        "description": "Allow actions to write to the integration."
+                    },
+                    "aws_account_id": {
+                        "type": "string",
+                        "description": "The AWS Account ID.",
+                        "pattern": "^[0-9]+$",
+                        "maxLength": 12,
+                        "minLength": 12
+                    },
+                    "aws_enabled_regions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsRegionEnum"
+                        },
+                        "description": "The AWS regions to integrate with."
+                    },
+                    "aws_enabled_services": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsServiceEnum"
+                        },
+                        "description": "The AWS services to integrate with."
+                    },
+                    "aws_external_id": {
+                        "type": "string",
+                        "description": "This is a shared secret between the AWS Administrator who set up your IAM trust relationship and your CloudTruth AWS Integration.  If your AWS Administrator provided you with a value use it, otherwise we will generate a random value for you to give to your AWS Administrator.",
+                        "minLength": 2,
+                        "pattern": "^[\\w+=,.@:/\\-]*$",
+                        "maxLength": 1224
+                    },
+                    "aws_role_name": {
+                        "type": "string",
+                        "description": "The role that CloudTruth will assume when interacting with your AWS Account through this integration.  The role is configured by your AWS Account Administrator.  If your AWS Administrator provided you with a value use it, otherwise make your own role name and give it to your AWS Administrator.",
+                        "pattern": "^[\\w+=,.@\\-]+$",
+                        "maxLength": 64
+                    }
+                },
+                "required": [
+                    "aws_account_id",
+                    "aws_enabled_regions",
+                    "aws_enabled_services",
+                    "aws_role_name"
+                ]
+            },
+            "AwsPull": {
+                "type": "object",
+                "description": "Pull actions can be configured to get configuration and secrets from\nintegrations on demand.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "Unique identifier for the action."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The action name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "The optional description for the action."
+                    },
+                    "latest_task": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AwsPullTask"
+                            }
+                        ],
+                        "readOnly": true,
+                        "nullable": true,
+                        "description": "The most recent task run for this action."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "When set to dry-run mode an action will report the changes that it would have made in task steps, however those changes are not actually performed."
+                    },
+                    "region": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AwsRegionEnum"
+                            }
+                        ],
+                        "description": "The AWS region this pull uses.  This region must be enabled in the integration."
+                    },
+                    "service": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AwsServiceEnum"
+                            }
+                        ],
+                        "description": "The AWS service this pull uses.  This service must be enabled in the integration."
+                    },
+                    "resource": {
+                        "type": "string",
+                        "description": "Defines a path through the integration to the location where values will be pulled.\n\nThe following mustache-style substitutions must be used in the resource locator string:\n\n  - ``{{ environment }}`` to identify the environment name\n  - ``{{ parameter }}`` to identify the parameter name\n  - ``{{ project }}`` to identify the project name",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "id",
+                    "latest_task",
+                    "modified_at",
+                    "name",
+                    "region",
+                    "resource",
+                    "service",
+                    "url"
+                ]
+            },
+            "AwsPullTask": {
+                "type": "object",
+                "description": "Pull task for an AWS integration.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "The unique identifier for the push action task."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The reason why this task was triggered.",
+                        "maxLength": 256
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "Indicates task steps were only simulated, not actually performed."
+                    },
+                    "state": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/StateEnum"
+                            }
+                        ],
+                        "description": "The current state of this task."
+                    },
+                    "error_code": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "If an error occurs early during processing, before attempting to process values, this code may be helpful in determining the problem.",
+                        "maxLength": 256
+                    },
+                    "error_detail": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "If an error occurs early during processing, before attempting to process values, this detail may be helpful in determining the problem."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "id",
+                    "modified_at",
+                    "url"
+                ]
+            },
+            "AwsPush": {
+                "type": "object",
+                "description": "Push actions can be configured to send configuration and secrets to\nintegrations when tags are updated.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "Unique identifier for the action."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The action name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "The optional description for the action."
+                    },
+                    "latest_task": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AwsPushTask"
+                            }
+                        ],
+                        "readOnly": true,
+                        "nullable": true,
+                        "description": "The most recent task run for this action."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "projects": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Projects that are included in the push."
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Tags are used to select parameters by environment from the projects included in the push.  You cannot have two tags from the same environment in the same push."
+                    },
+                    "region": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AwsRegionEnum"
+                            }
+                        ],
+                        "description": "The AWS region this push targets.  This region must be enabled in the integration."
+                    },
+                    "service": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AwsServiceEnum"
+                            }
+                        ],
+                        "description": "The AWS service this push targets.  This service must be enabled in the integration."
+                    },
+                    "resource": {
+                        "type": "string",
+                        "description": "Defines a path through the integration to the location where values will be pushed.\n\nThe following mustache-style substitutions can be used in the string:\n\n  - ``{{ environment }}`` to insert the environment name\n  - ``{{ parameter }}`` to insert the parameter name\n  - ``{{ project }}`` to insert the project name\n  - ``{{ push }}`` to insert the push name\n  - ``{{ tag }}`` to insert the tag name\n\nWe recommend that you use project, environment, and parameter at a minimum to disambiguate your pushed resource identifiers.\n\nIf you include multiple projects in the push, the `project` substitution is required.  If you include multiple tags from different environments in the push, the `environment` substitution is required.  If you include multiple tags from the same environment in the push, the `tag` substitution is required.  In all cases, the `parameter` substitution is always required.",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "id",
+                    "latest_task",
+                    "modified_at",
+                    "name",
+                    "projects",
+                    "region",
+                    "resource",
+                    "service",
+                    "tags",
+                    "url"
+                ]
+            },
+            "AwsPushTask": {
+                "type": "object",
+                "description": "Push task for an AWS integration.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "The unique identifier for the push action task."
+                    },
+                    "reason": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The reason why this task was triggered.",
+                        "maxLength": 256
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "Indicates task steps were only simulated, not actually performed."
+                    },
+                    "state": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/StateEnum"
+                            }
+                        ],
+                        "description": "The current state of this task."
+                    },
+                    "error_code": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "If an error occurs early during processing, before attempting to process values, this code may be helpful in determining the problem.",
+                        "maxLength": 256
+                    },
+                    "error_detail": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "If an error occurs early during processing, before attempting to process values, this detail may be helpful in determining the problem."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "id",
+                    "modified_at",
+                    "url"
+                ]
+            },
+            "AwsPushTaskStep": {
+                "type": "object",
+                "description": "Push task step for an AWS integration.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "Unique identifier for a task step."
+                    },
+                    "operation": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/OperationEnum"
+                            }
+                        ],
+                        "description": "The operation performed, if any.\n\nWhen the operation is an update, there may be additional details in the success_detail field to describe the change.\n\nWhen the project is filled in but the environment and parameterare not, the operation is on the project.  When the environmentis filled in but the project and parameter are not, the operationis on the environment.  When the project and parameter are filledin but the environment is not, the operation is on the parameter.When all three are filled in, the operation is on the value ofthe parameter of the project in the specified environment."
+                    },
+                    "success": {
+                        "type": "boolean",
+                        "description": "Indicates if the operation was successful."
+                    },
+                    "success_detail": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Additional details about the successful operation, if any."
+                    },
+                    "fqn": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The fully-qualified name (FQN) this of the value that was changed.",
+                        "maxLength": 1024
+                    },
+                    "environment": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "nullable": true,
+                        "description": "The environment affected by this step."
+                    },
+                    "environment_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "nullable": true,
+                        "description": "The environment id involved in the operation."
+                    },
+                    "environment_name": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The environment name involved in the operation.",
+                        "maxLength": 256
+                    },
+                    "project": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "nullable": true,
+                        "description": "The project affected by this step."
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "nullable": true,
+                        "description": "The project id involved in the operation."
+                    },
+                    "project_name": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The project name involved in the operation.",
+                        "maxLength": 256
+                    },
+                    "parameter": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "nullable": true,
+                        "description": "The parameter affected by this step."
+                    },
+                    "parameter_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "nullable": true,
+                        "description": "The parameter id involved in the operation."
+                    },
+                    "parameter_name": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The parameter name involved in the operation.",
+                        "maxLength": 256
+                    },
+                    "venue_id": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The integration-native id for the resource.",
+                        "maxLength": 1024
+                    },
+                    "venue_name": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "The name of the item or resource as known by the integration.",
+                        "maxLength": 256
+                    },
+                    "error_code": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "An error code, if not successful.",
+                        "maxLength": 256
+                    },
+                    "error_detail": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "Details on the error that occurred during processing."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "environment",
+                    "id",
+                    "modified_at",
+                    "operation",
+                    "parameter",
+                    "project",
+                    "success",
+                    "url"
+                ]
+            },
+            "AwsPushUpdate": {
+                "type": "object",
+                "description": "Update a push.  The `region` and `service` cannot be changed on an existing push.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The action name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "The optional description for the action."
+                    },
+                    "projects": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Projects that are included in the push."
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Tags are used to select parameters by environment from the projects included in the push.  You cannot have two tags from the same environment in the same push."
+                    },
+                    "resource": {
+                        "type": "string",
+                        "description": "Defines a path through the integration to the location where values will be pushed.\n\nThe following mustache-style substitutions can be used in the string:\n\n  - ``{{ environment }}`` to insert the environment name\n  - ``{{ parameter }}`` to insert the parameter name\n  - ``{{ project }}`` to insert the project name\n  - ``{{ push }}`` to insert the push name\n  - ``{{ tag }}`` to insert the tag name\n\nWe recommend that you use project, environment, and parameter at a minimum to disambiguate your pushed resource identifiers.\n\nIf you include multiple projects in the push, the `project` substitution is required.  If you include multiple tags from different environments in the push, the `environment` substitution is required.  If you include multiple tags from the same environment in the push, the `tag` substitution is required.  In all cases, the `parameter` substitution is always required.",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "name",
+                    "projects",
+                    "resource",
+                    "tags"
+                ]
+            },
+            "AwsRegionEnum": {
+                "enum": [
+                    "af-south-1",
+                    "ap-east-1",
+                    "ap-northeast-1",
+                    "ap-northeast-2",
+                    "ap-northeast-3",
+                    "ap-south-1",
+                    "ap-southeast-1",
+                    "ap-southeast-2",
+                    "ca-central-1",
+                    "cn-north-1",
+                    "cn-northwest-1",
+                    "eu-central-1",
+                    "eu-north-1",
+                    "eu-south-1",
+                    "eu-west-1",
+                    "eu-west-2",
+                    "eu-west-3",
+                    "me-south-1",
+                    "sa-east-1",
+                    "us-east-1",
+                    "us-east-2",
+                    "us-west-1",
+                    "us-west-2"
+                ],
+                "type": "string"
+            },
+            "AwsServiceEnum": {
+                "enum": [
+                    "s3",
+                    "secretsmanager",
+                    "ssm"
+                ],
+                "type": "string"
+            },
+            "Environment": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the environment."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The environment name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the environment.  You may find it helpful to document how this environment is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "parent": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Environments can inherit from a single parent environment which provides values for parameters when specific environments do not have a value set.  Every organization has one default environment that cannot be removed."
+                    },
+                    "children": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "readOnly": true,
+                        "description": "This is the opposite of `parent`, see that field for more details."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "children",
+                    "created_at",
+                    "id",
+                    "modified_at",
+                    "name",
+                    "url"
+                ]
+            },
+            "EnvironmentCreate": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The environment name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the environment.  You may find it helpful to document how this environment is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "parent": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Environments can inherit from a single parent environment which provides values for parameters when specific environments do not have a value set.  Every organization has one default environment that cannot be removed."
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "GitHubIntegration": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "The unique identifier for the integration."
+                    },
+                    "name": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description for the integration."
+                    },
+                    "status": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/StatusEnum"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The status of the integration connection with the third-party provider as of the `status_last_checked_at` field.  The status is updated automatically by the server when the integration is modified."
+                    },
+                    "status_detail": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "If an error occurs, more details will be available in this field."
+                    },
+                    "status_last_checked_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "The last time the status was evaluated."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "fqn": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "type": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The type of integration."
+                    },
+                    "writable": {
+                        "type": "boolean",
+                        "description": "Allow actions to write to the integration."
+                    },
+                    "gh_installation_id": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": 0
+                    },
+                    "gh_organization_slug": {
+                        "type": "string",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "fqn",
+                    "gh_installation_id",
+                    "gh_organization_slug",
+                    "id",
+                    "modified_at",
+                    "name",
+                    "status",
+                    "status_detail",
+                    "status_last_checked_at",
+                    "type",
+                    "url"
+                ]
+            },
+            "GitHubIntegrationCreate": {
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description for the integration."
+                    },
+                    "writable": {
+                        "type": "boolean",
+                        "description": "Allow actions to write to the integration."
+                    },
+                    "gh_installation_id": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": 0
+                    }
+                },
+                "required": [
+                    "gh_installation_id"
+                ]
+            },
+            "HistoryModelEnum": {
+                "enum": [
+                    "Parameter",
+                    "ParameterRule",
+                    "Value"
+                ],
+                "type": "string"
+            },
+            "HistoryTypeEnum": {
+                "enum": [
+                    "create",
+                    "update",
+                    "delete",
+                    "nothing"
+                ],
+                "type": "string"
+            },
+            "IntegrationExplorer": {
+                "type": "object",
+                "description": "Describes the content available at a given location.",
+                "properties": {
+                    "fqn": {
+                        "type": "string"
+                    },
+                    "node_type": {
+                        "$ref": "#/components/schemas/NodeTypeEnum"
+                    },
+                    "secret": {
+                        "type": "boolean"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "content_type": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "content_data": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "content_size": {
+                        "type": "integer",
+                        "nullable": true
+                    },
+                    "content_keys": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "fqn",
+                    "node_type"
+                ]
+            },
+            "Invitation": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "The unique identifier of an invitation."
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The email address of the user to be invited.",
+                        "maxLength": 254
+                    },
+                    "role": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RoleEnum"
+                            }
+                        ],
+                        "description": "The role that the user will have in the organization, should the user accept."
+                    },
+                    "inviter": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The user that created the invitation."
+                    },
+                    "inviter_name": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The name of the user that created the invitation."
+                    },
+                    "state": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The current state of the invitation."
+                    },
+                    "state_detail": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Additional details about the state of the invitation."
+                    },
+                    "membership": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The resulting membership, should the user accept."
+                    }
+                },
+                "required": [
+                    "email",
+                    "id",
+                    "inviter",
+                    "inviter_name",
+                    "membership",
+                    "role",
+                    "state",
+                    "state_detail",
+                    "url"
+                ]
+            },
+            "InvitationCreate": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The email address of the user to be invited.",
+                        "maxLength": 254
+                    },
+                    "role": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RoleEnum"
+                            }
+                        ],
+                        "description": "The role that the user will have in the organization, should the user accept."
+                    }
+                },
+                "required": [
+                    "email",
+                    "role"
+                ]
+            },
+            "Membership": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the membership."
+                    },
+                    "user": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The user of the membership."
+                    },
+                    "organization": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The organization that the user is a member of."
+                    },
+                    "role": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RoleEnum"
+                            }
+                        ],
+                        "description": "The role that the user has in the organization."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "id",
+                    "modified_at",
+                    "organization",
+                    "role",
+                    "url",
+                    "user"
+                ]
+            },
+            "MembershipCreate": {
+                "type": "object",
+                "properties": {
+                    "user": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The user of the membership."
+                    },
+                    "role": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RoleEnum"
+                            }
+                        ],
+                        "description": "The role that the user has in the organization."
+                    }
+                },
+                "required": [
+                    "role",
+                    "user"
+                ]
+            },
+            "NodeTypeEnum": {
+                "enum": [
+                    "directory",
+                    "file"
+                ],
+                "type": "string"
+            },
+            "ObjectTypeEnum": {
+                "enum": [
+                    "AwsIntegration",
+                    "Environment",
+                    "GitHubIntegration",
+                    "Invitation",
+                    "Membership",
+                    "Organization",
+                    "Parameter",
+                    "ParameterRule",
+                    "Project",
+                    "Pull",
+                    "Push",
+                    "ServiceAccount",
+                    "Tag",
+                    "Template",
+                    "Value"
+                ],
+                "type": "string"
+            },
+            "OperationEnum": {
+                "enum": [
+                    "create",
+                    "read",
+                    "update",
+                    "delete"
+                ],
+                "type": "string"
+            },
+            "Organization": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "A unique identifier for the organization."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The organization name.",
+                        "maxLength": 256
+                    },
+                    "current": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "Indicates if this Organization is the one currently targeted by the Bearer token used by the client to authorize."
+                    },
+                    "subscription_expires_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "subscription_id": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "subscription_plan_id": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "subscription_plan_name": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "current",
+                    "id",
+                    "modified_at",
+                    "name",
+                    "subscription_expires_at",
+                    "subscription_id",
+                    "subscription_plan_id",
+                    "subscription_plan_name",
+                    "url"
+                ]
+            },
+            "OrganizationCreate": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The organization name.",
+                        "maxLength": 256
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "PaginatedAuditTrailList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AuditTrail"
+                        }
+                    }
+                }
+            },
+            "PaginatedAwsIntegrationList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsIntegration"
+                        }
+                    }
+                }
+            },
+            "PaginatedAwsPullList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsPull"
+                        }
+                    }
+                }
+            },
+            "PaginatedAwsPushList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsPush"
+                        }
+                    }
+                }
+            },
+            "PaginatedAwsPushTaskList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsPushTask"
+                        }
+                    }
+                }
+            },
+            "PaginatedAwsPushTaskStepList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsPushTaskStep"
+                        }
+                    }
+                }
+            },
+            "PaginatedEnvironmentList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Environment"
+                        }
+                    }
+                }
+            },
+            "PaginatedGitHubIntegrationList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/GitHubIntegration"
+                        }
+                    }
+                }
+            },
+            "PaginatedIntegrationExplorerList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/IntegrationExplorer"
+                        }
+                    }
+                }
+            },
+            "PaginatedInvitationList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Invitation"
+                        }
+                    }
+                }
+            },
+            "PaginatedMembershipList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Membership"
+                        }
+                    }
+                }
+            },
+            "PaginatedOrganizationList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Organization"
+                        }
+                    }
+                }
+            },
+            "PaginatedParameterList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Parameter"
+                        }
+                    }
+                }
+            },
+            "PaginatedParameterRuleList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ParameterRule"
+                        }
+                    }
+                }
+            },
+            "PaginatedProjectList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Project"
+                        }
+                    }
+                }
+            },
+            "PaginatedServiceAccountList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ServiceAccount"
+                        }
+                    }
+                }
+            },
+            "PaginatedTagList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Tag"
+                        }
+                    }
+                }
+            },
+            "PaginatedTemplateList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Template"
+                        }
+                    }
+                }
+            },
+            "PaginatedUserList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/User"
+                        }
+                    }
+                }
+            },
+            "PaginatedValueList": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "example": 123
+                    },
+                    "next": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                        "type": "string",
+                        "nullable": true,
+                        "format": "uri",
+                        "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Value"
+                        }
+                    }
+                }
+            },
+            "Parameter": {
+                "type": "object",
+                "description": "A single parameter inside of a project.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the parameter."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The parameter name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the parameter.  You may find it helpful to document how this parameter is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "secret": {
+                        "type": "boolean",
+                        "description": "Indicates if this content is secret or not.  When a parameter is considered to be a secret, any internal values are stored in a dedicated vault for your organization for maximum security.  External values are inspected on-demand to ensure they align with the parameter's secret setting and if they do not, those external values are not allowed to be used."
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ParameterTypeEnum"
+                    },
+                    "rules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ParameterRule"
+                        },
+                        "readOnly": true,
+                        "description": "Rules applied to this parameter."
+                    },
+                    "project": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The project that the parameter is within."
+                    },
+                    "project_name": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The project name that the parameter is within"
+                    },
+                    "referencing_templates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Templates that reference this Parameter."
+                    },
+                    "referencing_values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Dynamic values that reference this Parameter."
+                    },
+                    "values": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/Value"
+                                }
+                            ],
+                            "nullable": true
+                        },
+                        "readOnly": true,
+                        "description": "\n            Each parameter has an effective value in every environment based on\n            environment inheritance and which environments have had a value set.\n\n            Environments inherit from a single parent to form a tree, as a result\n            a single parameter may have different values present for each environment.\n            When a value is not explicitly set in an environment, the parent environment\n            is consulted to see if it has a value defined, and so on.\n\n            The dictionary of values has an environment url as the key, and the optional\n            Value record that it resolves to.  If the Value.environment matches the key,\n            then it is an explicit value set for that environment.  If they differ, the\n            value was obtained from a parent environment (directly or indirectly).  If the\n            value is None then no value has ever been set in any environment for this\n            parameter.\n\n            key: Environment url\n            value: optional Value record\n        "
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "id",
+                    "modified_at",
+                    "name",
+                    "project",
+                    "project_name",
+                    "referencing_templates",
+                    "referencing_values",
+                    "rules",
+                    "url",
+                    "values"
+                ]
+            },
+            "ParameterCreate": {
+                "type": "object",
+                "description": "A single parameter inside of a project.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The parameter name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the parameter.  You may find it helpful to document how this parameter is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "secret": {
+                        "type": "boolean",
+                        "description": "Indicates if this content is secret or not.  When a parameter is considered to be a secret, any internal values are stored in a dedicated vault for your organization for maximum security.  External values are inspected on-demand to ensure they align with the parameter's secret setting and if they do not, those external values are not allowed to be used."
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ParameterTypeEnum"
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "ParameterExport": {
+                "type": "object",
+                "properties": {
+                    "body": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "body"
+                ]
+            },
+            "ParameterRule": {
+                "type": "object",
+                "description": "A type of `ModelSerializer` that uses hyperlinked relationships with compound keys instead\nof primary key relationships.  Specifically:\n\n* A 'url' field is included instead of the 'id' field.\n* Relationships to other instances are hyperlinks, instead of primary keys.\n\nNOTE: this only works with DRF 3.1.0 and above.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true
+                    },
+                    "parameter": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The parameter this rule is for."
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ParameterRuleTypeEnum"
+                    },
+                    "constraint": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "constraint",
+                    "created_at",
+                    "id",
+                    "modified_at",
+                    "parameter",
+                    "type",
+                    "url"
+                ]
+            },
+            "ParameterRuleCreate": {
+                "type": "object",
+                "description": "A type of `ModelSerializer` that uses hyperlinked relationships with compound keys instead\nof primary key relationships.  Specifically:\n\n* A 'url' field is included instead of the 'id' field.\n* Relationships to other instances are hyperlinks, instead of primary keys.\n\nNOTE: this only works with DRF 3.1.0 and above.",
+                "properties": {
+                    "type": {
+                        "$ref": "#/components/schemas/ParameterRuleTypeEnum"
+                    },
+                    "constraint": {
+                        "type": "string",
+                        "maxLength": 1024
+                    }
+                },
+                "required": [
+                    "constraint",
+                    "type"
+                ]
+            },
+            "ParameterRuleTypeEnum": {
+                "enum": [
+                    "min",
+                    "max",
+                    "min_len",
+                    "max_len",
+                    "regex"
+                ],
+                "type": "string"
+            },
+            "ParameterTimeline": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "description": "The number of records in this response."
+                    },
+                    "next_as_of": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "If present, additional history can be retrieved using this timestamp in the next call for the as_of query parameter value."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ParameterTimelineEntry"
+                        }
+                    }
+                },
+                "required": [
+                    "count",
+                    "results"
+                ]
+            },
+            "ParameterTimelineEntry": {
+                "type": "object",
+                "description": "Details about a single change.",
+                "properties": {
+                    "history_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "history_type": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/HistoryTypeEnum"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "history_user": {
+                        "type": "string",
+                        "description": "The unique identifier of a user.",
+                        "nullable": true
+                    },
+                    "history_environments": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ParameterTimelineEntryEnvironment"
+                        },
+                        "readOnly": true,
+                        "description": "The affected environment(s)."
+                    },
+                    "history_model": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/HistoryModelEnum"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The component of the parameter that changed."
+                    },
+                    "history_parameter": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ParameterTimelineEntryParameter"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The affected parameter."
+                    }
+                },
+                "required": [
+                    "history_date",
+                    "history_environments",
+                    "history_model",
+                    "history_parameter",
+                    "history_type"
+                ]
+            },
+            "ParameterTimelineEntryEnvironment": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the environment."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The environment name.",
+                        "maxLength": 256
+                    },
+                    "override": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "Indicates if the value change was direct or if it flowed into the environment. If `true` then the value was actually set directly into this environment. If `false` then the environment has no value set directly so it inherited the value from its parent."
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "override"
+                ]
+            },
+            "ParameterTimelineEntryParameter": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the parameter."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The parameter name.",
+                        "maxLength": 256
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
+            },
+            "ParameterTypeEnum": {
+                "enum": [
+                    "string",
+                    "integer",
+                    "bool"
+                ],
+                "type": "string"
+            },
+            "PatchedAwsIntegration": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "The unique identifier for the integration."
+                    },
+                    "name": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description for the integration."
+                    },
+                    "status": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/StatusEnum"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The status of the integration connection with the third-party provider as of the `status_last_checked_at` field.  The status is updated automatically by the server when the integration is modified."
+                    },
+                    "status_detail": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "If an error occurs, more details will be available in this field."
+                    },
+                    "status_last_checked_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "The last time the status was evaluated."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "fqn": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "type": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The type of integration."
+                    },
+                    "writable": {
+                        "type": "boolean",
+                        "description": "Allow actions to write to the integration."
+                    },
+                    "aws_account_id": {
+                        "type": "string",
+                        "description": "The AWS Account ID.",
+                        "pattern": "^[0-9]+$",
+                        "maxLength": 12,
+                        "minLength": 12
+                    },
+                    "aws_enabled_regions": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsRegionEnum"
+                        },
+                        "description": "The AWS regions to integrate with."
+                    },
+                    "aws_enabled_services": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsServiceEnum"
+                        },
+                        "description": "The AWS services to integrate with."
+                    },
+                    "aws_external_id": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "This is a shared secret between the AWS Administrator who set up your IAM trust relationship and your CloudTruth AWS Integration.  If your AWS Administrator provided you with a value use it, otherwise we will generate a random value for you to give to your AWS Administrator."
+                    },
+                    "aws_role_name": {
+                        "type": "string",
+                        "description": "The role that CloudTruth will assume when interacting with your AWS Account through this integration.  The role is configured by your AWS Account Administrator.  If your AWS Administrator provided you with a value use it, otherwise make your own role name and give it to your AWS Administrator.",
+                        "pattern": "^[\\w+=,.@\\-]+$",
+                        "maxLength": 64
+                    }
+                }
+            },
+            "PatchedAwsPull": {
+                "type": "object",
+                "description": "Pull actions can be configured to get configuration and secrets from\nintegrations on demand.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "Unique identifier for the action."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The action name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "The optional description for the action."
+                    },
+                    "latest_task": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AwsPullTask"
+                            }
+                        ],
+                        "readOnly": true,
+                        "nullable": true,
+                        "description": "The most recent task run for this action."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "dry_run": {
+                        "type": "boolean",
+                        "description": "When set to dry-run mode an action will report the changes that it would have made in task steps, however those changes are not actually performed."
+                    },
+                    "region": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AwsRegionEnum"
+                            }
+                        ],
+                        "description": "The AWS region this pull uses.  This region must be enabled in the integration."
+                    },
+                    "service": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AwsServiceEnum"
+                            }
+                        ],
+                        "description": "The AWS service this pull uses.  This service must be enabled in the integration."
+                    },
+                    "resource": {
+                        "type": "string",
+                        "description": "Defines a path through the integration to the location where values will be pulled.\n\nThe following mustache-style substitutions must be used in the resource locator string:\n\n  - ``{{ environment }}`` to identify the environment name\n  - ``{{ parameter }}`` to identify the parameter name\n  - ``{{ project }}`` to identify the project name",
+                        "maxLength": 1024
+                    }
+                }
+            },
+            "PatchedAwsPushUpdate": {
+                "type": "object",
+                "description": "Update a push.  The `region` and `service` cannot be changed on an existing push.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The action name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "The optional description for the action."
+                    },
+                    "projects": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Projects that are included in the push."
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "description": "Tags are used to select parameters by environment from the projects included in the push.  You cannot have two tags from the same environment in the same push."
+                    },
+                    "resource": {
+                        "type": "string",
+                        "description": "Defines a path through the integration to the location where values will be pushed.\n\nThe following mustache-style substitutions can be used in the string:\n\n  - ``{{ environment }}`` to insert the environment name\n  - ``{{ parameter }}`` to insert the parameter name\n  - ``{{ project }}`` to insert the project name\n  - ``{{ push }}`` to insert the push name\n  - ``{{ tag }}`` to insert the tag name\n\nWe recommend that you use project, environment, and parameter at a minimum to disambiguate your pushed resource identifiers.\n\nIf you include multiple projects in the push, the `project` substitution is required.  If you include multiple tags from different environments in the push, the `environment` substitution is required.  If you include multiple tags from the same environment in the push, the `tag` substitution is required.  In all cases, the `parameter` substitution is always required.",
+                        "maxLength": 1024
+                    }
+                }
+            },
+            "PatchedEnvironment": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the environment."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The environment name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the environment.  You may find it helpful to document how this environment is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "parent": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Environments can inherit from a single parent environment which provides values for parameters when specific environments do not have a value set.  Every organization has one default environment that cannot be removed."
+                    },
+                    "children": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "readOnly": true,
+                        "description": "This is the opposite of `parent`, see that field for more details."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "PatchedInvitation": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "The unique identifier of an invitation."
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email",
+                        "description": "The email address of the user to be invited.",
+                        "maxLength": 254
+                    },
+                    "role": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RoleEnum"
+                            }
+                        ],
+                        "description": "The role that the user will have in the organization, should the user accept."
+                    },
+                    "inviter": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The user that created the invitation."
+                    },
+                    "inviter_name": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The name of the user that created the invitation."
+                    },
+                    "state": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The current state of the invitation."
+                    },
+                    "state_detail": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "Additional details about the state of the invitation."
+                    },
+                    "membership": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The resulting membership, should the user accept."
+                    }
+                }
+            },
+            "PatchedMembership": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the membership."
+                    },
+                    "user": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The user of the membership."
+                    },
+                    "organization": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The organization that the user is a member of."
+                    },
+                    "role": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/RoleEnum"
+                            }
+                        ],
+                        "description": "The role that the user has in the organization."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "PatchedOrganization": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "A unique identifier for the organization."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The organization name.",
+                        "maxLength": 256
+                    },
+                    "current": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "Indicates if this Organization is the one currently targeted by the Bearer token used by the client to authorize."
+                    },
+                    "subscription_expires_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "subscription_id": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "subscription_plan_id": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "subscription_plan_name": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "PatchedParameter": {
+                "type": "object",
+                "description": "A single parameter inside of a project.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the parameter."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The parameter name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the parameter.  You may find it helpful to document how this parameter is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "secret": {
+                        "type": "boolean",
+                        "description": "Indicates if this content is secret or not.  When a parameter is considered to be a secret, any internal values are stored in a dedicated vault for your organization for maximum security.  External values are inspected on-demand to ensure they align with the parameter's secret setting and if they do not, those external values are not allowed to be used."
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ParameterTypeEnum"
+                    },
+                    "rules": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/ParameterRule"
+                        },
+                        "readOnly": true,
+                        "description": "Rules applied to this parameter."
+                    },
+                    "project": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The project that the parameter is within."
+                    },
+                    "project_name": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The project name that the parameter is within"
+                    },
+                    "referencing_templates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Templates that reference this Parameter."
+                    },
+                    "referencing_values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Dynamic values that reference this Parameter."
+                    },
+                    "values": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/components/schemas/Value"
+                                }
+                            ],
+                            "nullable": true
+                        },
+                        "readOnly": true,
+                        "description": "\n            Each parameter has an effective value in every environment based on\n            environment inheritance and which environments have had a value set.\n\n            Environments inherit from a single parent to form a tree, as a result\n            a single parameter may have different values present for each environment.\n            When a value is not explicitly set in an environment, the parent environment\n            is consulted to see if it has a value defined, and so on.\n\n            The dictionary of values has an environment url as the key, and the optional\n            Value record that it resolves to.  If the Value.environment matches the key,\n            then it is an explicit value set for that environment.  If they differ, the\n            value was obtained from a parent environment (directly or indirectly).  If the\n            value is None then no value has ever been set in any environment for this\n            parameter.\n\n            key: Environment url\n            value: optional Value record\n        "
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "PatchedParameterRule": {
+                "type": "object",
+                "description": "A type of `ModelSerializer` that uses hyperlinked relationships with compound keys instead\nof primary key relationships.  Specifically:\n\n* A 'url' field is included instead of the 'id' field.\n* Relationships to other instances are hyperlinks, instead of primary keys.\n\nNOTE: this only works with DRF 3.1.0 and above.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true
+                    },
+                    "parameter": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The parameter this rule is for."
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ParameterRuleTypeEnum"
+                    },
+                    "constraint": {
+                        "type": "string",
+                        "maxLength": 1024
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "PatchedProject": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the project."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The project name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the project.  You may find it helpful to document how this project is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "dependents": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "readOnly": true,
+                        "description": "This is the opposite of `depends_on`, see that field for more details."
+                    },
+                    "depends_on": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Project dependencies allow projects to be used for shared configuration, for example a database used by many applications needs to advertise its port number.\n\nProjects can depend on another project which will add the parameters from the parent project into the current project.  All of the parameter names between the two projects must be unique.  When retrieving values or rendering templates, all of the parameters from the parent project will also be available in the current project."
+                    },
+                    "pushes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsPush"
+                        },
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "PatchedServiceAccount": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "user": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description of the process or system using the service account."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "last_used_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "The most recent date and time the service account was used."
+                    }
+                }
+            },
+            "PatchedTagUpdate": {
+                "type": "object",
+                "description": "Details for updating a tag.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the tag."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The tag name. Tag names may contain alphanumeric, hyphen, underscore, or period characters. Tag names are case sensitive. The name cannot be modified.",
+                        "pattern": "^[\\w.-]+$",
+                        "maxLength": 64
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the tag.  You may find it helpful to document how this tag is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true,
+                        "description": "The point in time this tag represents.  If explicitly set to `null` then the current time will be used."
+                    }
+                }
+            },
+            "PatchedTemplate": {
+                "type": "object",
+                "description": "A parameter template in a given project, optionally instantiated against an environment.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The templates this value references, if interpolated."
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the template."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The template name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "('A description of the template.  You may find it helpful to document how this template is used to assist others when they need to maintain software that uses this content.',)"
+                    },
+                    "evaluated": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "If true, the `body` field has undergone evaluation."
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "The content of the template.  Use mustache-style templating delimiters of `{{` and `}}` to reference parameter values by name for substitution into the template result."
+                    },
+                    "referenced_parameters": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Parameters that this template references."
+                    },
+                    "referenced_templates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Other templates that this template references."
+                    },
+                    "referencing_templates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Other templates that reference this template."
+                    },
+                    "referencing_values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "The dynamic values that reference this template."
+                    },
+                    "has_secret": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "If True, this template contains secrets."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "PatchedValue": {
+                "type": "object",
+                "description": "A value for a parameter in a given environment.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the value."
+                    },
+                    "environment": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The environment this value is set in."
+                    },
+                    "environment_name": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The environment name for this value.  This is a convenience to avoid another query against the server to resolve the environment url into a name."
+                    },
+                    "earliest_tag": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true,
+                        "description": "The earliest tag name this value appears in (within the value's environment)."
+                    },
+                    "parameter": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The parameter this value is for."
+                    },
+                    "external": {
+                        "type": "boolean",
+                        "description": "An external parameter leverages a CloudTruth integration to retrieve content on-demand from an external source.  When this is `false` the value is stored by CloudTruth and considered to be _internal_.  When this is `true`, the `external_fqn` field must be set."
+                    },
+                    "external_fqn": {
+                        "type": "string",
+                        "description": "The FQN, or Fully-Qualified Name, is the path through the integration to get to the desired content.  This must be present and reference a valid integration when the value is `external`.",
+                        "maxLength": 1024
+                    },
+                    "external_filter": {
+                        "type": "string",
+                        "description": "If the value is `external`, the content returned by the integration can be reduced by applying a JMESpath expression.  This is valid as long as the content is structured and of a supported format.  JMESpath expressions are supported on `json`, `yaml`, and `dotenv` content.",
+                        "maxLength": 1024
+                    },
+                    "external_error": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true,
+                        "description": "If the value is external, and an error occurs retrieving it, the reason for the retrieval error will be placed into this field.  The query parameter `partial_success` can be used to control whether this condition causes an HTTP error response or not."
+                    },
+                    "internal_value": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "This is the content to use when resolving the Value for an internal non-secret, or when storing a secret.  When storing a secret, this content is stored in your organization's dedicated vault and this field is cleared.  This field is required if the value is being created or updated and is `internal`.  This field cannot be specified when creating or updating an `external` value.",
+                        "maxLength": 16384
+                    },
+                    "interpolated": {
+                        "type": "boolean",
+                        "description": "If `true`, apply template substitution rules to this value.  If `false`, this value is a literal value.  Note: secrets cannot be interpolated."
+                    },
+                    "value": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true,
+                        "description": "This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:\n\nFor values that are not `external` and parameters that are not `secret`, the system will use the content in `internal_value` to satisfy the request.\n\nFor values that are not `external` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.\n\nFor values that are `external`, the system will retrieve the content from the integration on-demand.  You can control the error handling behavior of the server through the `partial_success` query parameter.\n\nIf the content from the integration is `secret` and the parameter is not, an error will occur.  If an `external_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.\n\nIf you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.\n\nClients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable."
+                    },
+                    "evaluated": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "If true, the `value` field has undergone template evaluation."
+                    },
+                    "secret": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "readOnly": true,
+                        "description": "Indicates the value content is a secret.  Normally this is `true` when the parameter is a secret, however it is possible for a parameter to be a secret with a external value that is not a secret.  It is not possible to convert a parameter from a secret to a non-secret if any of the values are external and a secret.  Clients can check this condition by leveraging this field."
+                    },
+                    "referenced_parameters": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "readOnly": true,
+                        "description": "The parameters this value references, if interpolated."
+                    },
+                    "referenced_templates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "readOnly": true,
+                        "description": "The templates this value references, if interpolated."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                }
+            },
+            "Project": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the project."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The project name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the project.  You may find it helpful to document how this project is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "dependents": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "readOnly": true,
+                        "description": "This is the opposite of `depends_on`, see that field for more details."
+                    },
+                    "depends_on": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Project dependencies allow projects to be used for shared configuration, for example a database used by many applications needs to advertise its port number.\n\nProjects can depend on another project which will add the parameters from the parent project into the current project.  All of the parameter names between the two projects must be unique.  When retrieving values or rendering templates, all of the parameters from the parent project will also be available in the current project."
+                    },
+                    "pushes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsPush"
+                        },
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "dependents",
+                    "id",
+                    "modified_at",
+                    "name",
+                    "pushes",
+                    "url"
+                ]
+            },
+            "ProjectCreate": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The project name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the project.  You may find it helpful to document how this project is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "depends_on": {
+                        "type": "string",
+                        "format": "uri",
+                        "nullable": true,
+                        "description": "Project dependencies allow projects to be used for shared configuration, for example a database used by many applications needs to advertise its port number.\n\nProjects can depend on another project which will add the parameters from the parent project into the current project.  All of the parameter names between the two projects must be unique.  When retrieving values or rendering templates, all of the parameters from the parent project will also be available in the current project."
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "RoleEnum": {
+                "enum": [
+                    "OWNER",
+                    "ADMIN",
+                    "CONTRIB",
+                    "VIEWER"
+                ],
+                "type": "string"
+            },
+            "ServiceAccount": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "user": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description of the process or system using the service account."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "last_used_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "The most recent date and time the service account was used."
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "id",
+                    "last_used_at",
+                    "modified_at",
+                    "url",
+                    "user"
+                ]
+            },
+            "ServiceAccountCreateRequest": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the process or system using the service account.",
+                        "maxLength": 128
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description of the process or system using the service account."
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "ServiceAccountCreateResponse": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "readOnly": true
+                    },
+                    "user": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/User"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "An optional description of the process or system using the service account."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "last_used_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true,
+                        "description": "The most recent date and time the service account was used."
+                    },
+                    "apikey": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The API Key to use as a Bearer token for the service account."
+                    }
+                },
+                "required": [
+                    "apikey",
+                    "created_at",
+                    "id",
+                    "last_used_at",
+                    "modified_at",
+                    "url",
+                    "user"
+                ]
+            },
+            "StateEnum": {
+                "enum": [
+                    "queued",
+                    "running",
+                    "skipped",
+                    "success",
+                    "failure"
+                ],
+                "type": "string"
+            },
+            "StatusEnum": {
+                "enum": [
+                    "unknown",
+                    "pending",
+                    "checking",
+                    "connected",
+                    "errored",
+                    "missing"
+                ],
+                "type": "string"
+            },
+            "Tag": {
+                "type": "object",
+                "description": "The details of a tag.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the tag."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The tag name. Tag names may contain alphanumeric, hyphen, underscore, or period characters. Tag names are case sensitive. The name cannot be modified.",
+                        "pattern": "^[\\w.-]+$",
+                        "maxLength": 64
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the tag.  You may find it helpful to document how this tag is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "The point in time this tag represents."
+                    },
+                    "pushes": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/AwsPush"
+                        },
+                        "readOnly": true
+                    },
+                    "usage": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/TagReadUsage"
+                            }
+                        ],
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "id",
+                    "name",
+                    "pushes",
+                    "timestamp",
+                    "url",
+                    "usage"
+                ]
+            },
+            "TagCreate": {
+                "type": "object",
+                "description": "Details for creating a tag.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The tag name. Tag names may contain alphanumeric, hyphen, underscore, or period characters. Tag names are case sensitive. The name cannot be modified.",
+                        "pattern": "^[\\w.-]+$",
+                        "maxLength": 64
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the tag.  You may find it helpful to document how this tag is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true,
+                        "description": "The point in time this tag represents. If not specified then the current time will be used."
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "TagReadUsage": {
+                "type": "object",
+                "description": "The read usage details of a tag.",
+                "properties": {
+                    "last_read": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true,
+                        "description": "The last time a configuration was retrieved with this tag."
+                    },
+                    "last_read_by": {
+                        "type": "string",
+                        "description": "The last user (id) to use this tag to read configuration.",
+                        "maxLength": 256
+                    },
+                    "total_reads": {
+                        "type": "integer",
+                        "maximum": 2147483647,
+                        "minimum": -2147483648,
+                        "description": "The number of times the tag has been used to read configuration."
+                    }
+                },
+                "required": [
+                    "last_read",
+                    "total_reads"
+                ]
+            },
+            "TagUpdate": {
+                "type": "object",
+                "description": "Details for updating a tag.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the tag."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The tag name. Tag names may contain alphanumeric, hyphen, underscore, or period characters. Tag names are case sensitive. The name cannot be modified.",
+                        "pattern": "^[\\w.-]+$",
+                        "maxLength": 64
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the tag.  You may find it helpful to document how this tag is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "timestamp": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true,
+                        "description": "The point in time this tag represents.  If explicitly set to `null` then the current time will be used."
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
+            },
+            "Template": {
+                "type": "object",
+                "description": "A parameter template in a given project, optionally instantiated against an environment.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The templates this value references, if interpolated."
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the template."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The template name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "('A description of the template.  You may find it helpful to document how this template is used to assist others when they need to maintain software that uses this content.',)"
+                    },
+                    "evaluated": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "If true, the `body` field has undergone evaluation."
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "The content of the template.  Use mustache-style templating delimiters of `{{` and `}}` to reference parameter values by name for substitution into the template result."
+                    },
+                    "referenced_parameters": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Parameters that this template references."
+                    },
+                    "referenced_templates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Other templates that this template references."
+                    },
+                    "referencing_templates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "Other templates that reference this template."
+                    },
+                    "referencing_values": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "readOnly": true,
+                        "description": "The dynamic values that reference this template."
+                    },
+                    "has_secret": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "If True, this template contains secrets."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "evaluated",
+                    "has_secret",
+                    "id",
+                    "modified_at",
+                    "name",
+                    "referenced_parameters",
+                    "referenced_templates",
+                    "referencing_templates",
+                    "referencing_values",
+                    "url"
+                ]
+            },
+            "TemplateCreate": {
+                "type": "object",
+                "description": "A parameter template in a given project, optionally instantiated against an environment.",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The template name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "('A description of the template.  You may find it helpful to document how this template is used to assist others when they need to maintain software that uses this content.',)"
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "The content of the template.  Use mustache-style templating delimiters of `{{` and `}}` to reference parameter values by name for substitution into the template result."
+                    }
+                },
+                "required": [
+                    "name"
+                ]
+            },
+            "TemplateLookupError": {
+                "type": "object",
+                "description": "Indicates errors occurred while retrieving values to substitute into the template.",
+                "properties": {
+                    "detail": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TemplateLookupErrorEntry"
+                        }
+                    }
+                },
+                "required": [
+                    "detail"
+                ]
+            },
+            "TemplateLookupErrorEntry": {
+                "type": "object",
+                "properties": {
+                    "parameter_id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "description": "The parameter id."
+                    },
+                    "parameter_name": {
+                        "type": "string",
+                        "description": "The parameter name."
+                    },
+                    "error_code": {
+                        "type": "string",
+                        "description": "The error code."
+                    },
+                    "error_detail": {
+                        "type": "string",
+                        "description": "Details about the error."
+                    }
+                },
+                "required": [
+                    "error_code",
+                    "error_detail",
+                    "parameter_id",
+                    "parameter_name"
+                ]
+            },
+            "TemplatePreview": {
+                "type": "object",
+                "properties": {
+                    "body": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "body"
+                ]
+            },
+            "TemplateTimeline": {
+                "type": "object",
+                "properties": {
+                    "count": {
+                        "type": "integer",
+                        "description": "The number of records in this response."
+                    },
+                    "next_as_of": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "If present, additional history can be retrieved using this timestamp in the next call for the as_of query parameter value."
+                    },
+                    "results": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/TemplateTimelineEntry"
+                        }
+                    }
+                },
+                "required": [
+                    "count",
+                    "results"
+                ]
+            },
+            "TemplateTimelineEntry": {
+                "type": "object",
+                "description": "Details about a single change.",
+                "properties": {
+                    "history_date": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "history_type": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/HistoryTypeEnum"
+                            }
+                        ],
+                        "readOnly": true
+                    },
+                    "history_user": {
+                        "type": "string",
+                        "description": "The unique identifier of a user.",
+                        "nullable": true
+                    },
+                    "history_template": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/TemplateTimelineEntryTemplate"
+                            }
+                        ],
+                        "readOnly": true,
+                        "description": "The template record as it was when archived for history."
+                    }
+                },
+                "required": [
+                    "history_date",
+                    "history_template",
+                    "history_type"
+                ]
+            },
+            "TemplateTimelineEntryTemplate": {
+                "type": "object",
+                "description": "Helper methods for all views or serializers that expose template concepts.",
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the parameter."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "The parameter name.",
+                        "maxLength": 256
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "A description of the parameter.  You may find it helpful to document how this parameter is used to assist others when they need to maintain software that uses this content."
+                    },
+                    "body": {
+                        "type": "string",
+                        "description": "The content of the template.  Use mustache-style templating delimiters of `{{` and `}}` to reference parameter values by name for substitution into the template result."
+                    }
+                },
+                "required": [
+                    "id",
+                    "name"
+                ]
+            },
+            "User": {
+                "type": "object",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "description": "The unique identifier of a user.",
+                        "maxLength": 256
+                    },
+                    "type": {
+                        "type": "string",
+                        "description": "The type of user record.",
+                        "maxLength": 12
+                    },
+                    "name": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "email": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "picture_url": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "email",
+                    "id",
+                    "modified_at",
+                    "name",
+                    "picture_url",
+                    "url"
+                ]
+            },
+            "Value": {
+                "type": "object",
+                "description": "A value for a parameter in a given environment.",
+                "properties": {
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true
+                    },
+                    "id": {
+                        "type": "string",
+                        "format": "uuid",
+                        "readOnly": true,
+                        "description": "A unique identifier for the value."
+                    },
+                    "environment": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The environment this value is set in."
+                    },
+                    "environment_name": {
+                        "type": "string",
+                        "readOnly": true,
+                        "description": "The environment name for this value.  This is a convenience to avoid another query against the server to resolve the environment url into a name."
+                    },
+                    "earliest_tag": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true,
+                        "description": "The earliest tag name this value appears in (within the value's environment)."
+                    },
+                    "parameter": {
+                        "type": "string",
+                        "format": "uri",
+                        "readOnly": true,
+                        "description": "The parameter this value is for."
+                    },
+                    "external": {
+                        "type": "boolean",
+                        "description": "An external parameter leverages a CloudTruth integration to retrieve content on-demand from an external source.  When this is `false` the value is stored by CloudTruth and considered to be _internal_.  When this is `true`, the `external_fqn` field must be set."
+                    },
+                    "external_fqn": {
+                        "type": "string",
+                        "description": "The FQN, or Fully-Qualified Name, is the path through the integration to get to the desired content.  This must be present and reference a valid integration when the value is `external`.",
+                        "maxLength": 1024
+                    },
+                    "external_filter": {
+                        "type": "string",
+                        "description": "If the value is `external`, the content returned by the integration can be reduced by applying a JMESpath expression.  This is valid as long as the content is structured and of a supported format.  JMESpath expressions are supported on `json`, `yaml`, and `dotenv` content.",
+                        "maxLength": 1024
+                    },
+                    "external_error": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true,
+                        "description": "If the value is external, and an error occurs retrieving it, the reason for the retrieval error will be placed into this field.  The query parameter `partial_success` can be used to control whether this condition causes an HTTP error response or not."
+                    },
+                    "internal_value": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "This is the content to use when resolving the Value for an internal non-secret, or when storing a secret.  When storing a secret, this content is stored in your organization's dedicated vault and this field is cleared.  This field is required if the value is being created or updated and is `internal`.  This field cannot be specified when creating or updating an `external` value.",
+                        "maxLength": 16384
+                    },
+                    "interpolated": {
+                        "type": "boolean",
+                        "description": "If `true`, apply template substitution rules to this value.  If `false`, this value is a literal value.  Note: secrets cannot be interpolated."
+                    },
+                    "value": {
+                        "type": "string",
+                        "nullable": true,
+                        "readOnly": true,
+                        "description": "This is the actual content of the Value for the given parameter in the given environment.  Depending on the settings in the Value, the following things occur to calculate the `value`:\n\nFor values that are not `external` and parameters that are not `secret`, the system will use the content in `internal_value` to satisfy the request.\n\nFor values that are not `external` and parameters that are `secret`, the system will retrieve the content from your organization's dedicated vault.\n\nFor values that are `external`, the system will retrieve the content from the integration on-demand.  You can control the error handling behavior of the server through the `partial_success` query parameter.\n\nIf the content from the integration is `secret` and the parameter is not, an error will occur.  If an `external_filter` is present then the content will have a JMESpath query applied, and that becomes the resulting value.\n\nIf you request secret masking, no secret content will be included in the result and instead a series of asterisks will be used instead for the value.  If you request wrapping, the secret content will be wrapped in an envelope that is bound to your JWT token.  For more information about secret wrapping, see the docs.\n\nClients applying this value to a shell environment should set `<parameter_name>=<value>` even if `value` is the empty string.  If `value` is `null`, the client should unset that shell environment variable."
+                    },
+                    "evaluated": {
+                        "type": "boolean",
+                        "readOnly": true,
+                        "description": "If true, the `value` field has undergone template evaluation."
+                    },
+                    "secret": {
+                        "type": "boolean",
+                        "nullable": true,
+                        "readOnly": true,
+                        "description": "Indicates the value content is a secret.  Normally this is `true` when the parameter is a secret, however it is possible for a parameter to be a secret with a external value that is not a secret.  It is not possible to convert a parameter from a secret to a non-secret if any of the values are external and a secret.  Clients can check this condition by leveraging this field."
+                    },
+                    "referenced_parameters": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "readOnly": true,
+                        "description": "The parameters this value references, if interpolated."
+                    },
+                    "referenced_templates": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "format": "uri"
+                        },
+                        "readOnly": true,
+                        "description": "The templates this value references, if interpolated."
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    },
+                    "modified_at": {
+                        "type": "string",
+                        "format": "date-time",
+                        "readOnly": true
+                    }
+                },
+                "required": [
+                    "created_at",
+                    "earliest_tag",
+                    "environment",
+                    "environment_name",
+                    "evaluated",
+                    "external_error",
+                    "id",
+                    "modified_at",
+                    "parameter",
+                    "referenced_parameters",
+                    "referenced_templates",
+                    "secret",
+                    "url",
+                    "value"
+                ]
+            },
+            "ValueCreate": {
+                "type": "object",
+                "description": "A value for a parameter in a given environment.",
+                "properties": {
+                    "environment": {
+                        "type": "string",
+                        "format": "uri",
+                        "description": "The environment this value is set in."
+                    },
+                    "external": {
+                        "type": "boolean",
+                        "description": "An external parameter leverages a CloudTruth integration to retrieve content on-demand from an external source.  When this is `false` the value is stored by CloudTruth and considered to be _internal_.  When this is `true`, the `external_fqn` field must be set."
+                    },
+                    "external_fqn": {
+                        "type": "string",
+                        "description": "The FQN, or Fully-Qualified Name, is the path through the integration to get to the desired content.  This must be present and reference a valid integration when the value is `external`.",
+                        "maxLength": 1024
+                    },
+                    "external_filter": {
+                        "type": "string",
+                        "description": "If the value is `external`, the content returned by the integration can be reduced by applying a JMESpath expression.  This is valid as long as the content is structured and of a supported format.  JMESpath expressions are supported on `json`, `yaml`, and `dotenv` content.",
+                        "maxLength": 1024
+                    },
+                    "internal_value": {
+                        "type": "string",
+                        "nullable": true,
+                        "description": "This is the content to use when resolving the Value for an internal non-secret, or when storing a secret.  When storing a secret, this content is stored in your organization's dedicated vault and this field is cleared.  This field is required if the value is being created or updated and is `internal`.  This field cannot be specified when creating or updating an `external` value.",
+                        "maxLength": 16384
+                    },
+                    "interpolated": {
+                        "type": "boolean",
+                        "description": "If `true`, apply template substitution rules to this value.  If `false`, this value is a literal value.  Note: secrets cannot be interpolated."
+                    }
+                },
+                "required": [
+                    "environment"
+                ]
+            }
+        },
+        "securitySchemes": {
+            "ApiKeyAuth": {
+                "in": "header",
+                "name": "Authorization",
+                "type": "apiKey",
+                "description": "\nUse your CloudTruth API Key to authenticate to the API.  You can get\nan API Key by creating a Service Account.  During setup of the Service\nAccount you will generate a long-lived API key intended for use by automation\nand API clients.  Access through the service account will be audited separately\nfrom any other user.\n\nIf you are just trying to use the API in a normal workflow, this is likely the\nauthentication mechanism you want to use.\n\nTo use the API Key, place your API Key in the Authorization header as 'Api-Key APIKEY', where\nAPIKEY is your CloudTruth API Key.  For example:\n\n    Authorization: Api-Key fskur.ghlsiudhrg84so938r5u\n        "
+            },
+            "JWTAuth": {
+                "in": "header",
+                "name": "Authorization",
+                "type": "apiKey",
+                "description": "\nUse your JWT to authenticate to the API.  This is how the CloudTruth\nWeb UI authenticates to the backend.  It requires a user to have already logged in\nand gotten a JWT from the login process.  This is usually done by an Auth0 authentication\nflow from one of the Auth0 javascript libraries.  Alternatively, you can pull the\nJWT from your browser if you have a logged in session with the CloudTruth UI.\n\nThis authentication mechanism is intended for deeper integrations into the CloudTruth\nsystem, where you want to handle the user logins directly in your application.  For\nnormal API use, you likely want the Api-Key authentication header and not this one.\n\nTo use the JWT, place your JWT in the Authorization header as 'Bearer JWT', where\nJWT is your JWT.  For example:\n\n    Authorization: Bearer eyJhbGciOiJIkuydfy.eyJzdWIiOiIxMjM....\n        "
+            }
+        }
+    },
+    "externalDocs": {
+        "url": "https://docs.cloudtruth.com/"
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -273,6 +273,22 @@ fn environment_tag_validator(arg_value: String) -> Result<(), String> {
     }
 }
 
+fn schema_format_arg() -> Arg<'static, 'static> {
+    Arg::with_name(FORMAT_OPT)
+        .takes_value(true)
+        .short("f")
+        .long("format")
+        .possible_values(&["yaml", "json"])
+        .default_value("yaml")
+        .help("Schema output format")
+}
+
+fn schema_version_arg() -> Arg<'static, 'static> {
+    Arg::with_name("version")
+        .long("version")
+        .help("Display just the schema version")
+}
+
 pub fn build_cli() -> App<'static, 'static> {
     app_from_crate!()
         .setting(AppSettings::SubcommandRequiredElseHelp)
@@ -1083,20 +1099,23 @@ pub fn build_cli() -> App<'static, 'static> {
             ])
         )
         .subcommand(SubCommand::with_name("schema")
-            .arg(Arg::with_name("format")
-                .short("f")
-                .long("format")
-                .takes_value(true)
-                .possible_values(&["yaml", "json"])
-                .default_value("yaml")
-                .help("Schema format"))
-            .arg(Arg::with_name("local")
-                .short("l")
-                .long("local")
-                .help("Local schema version (compiled into CLI)"))
-            .arg(Arg::with_name("version")
-                .short("v")
-                .long("version")
-                .help("Show just the server schema version"))
-            .about("Get the schema"))
+            .about("View CloudTruth OpenAPI schema")
+            .subcommands([
+                SubCommand::with_name("server")
+                    .visible_aliases(&["serv", "s"])
+                    .arg(schema_format_arg())
+                    .arg(schema_version_arg())
+                    .about("Show the schema in use by the server"),
+                SubCommand::with_name("local")
+                    .visible_aliases(&["loc", "l"])
+                    .arg(schema_format_arg())
+                    .arg(schema_version_arg())
+                    .about("Show the schema used to compile the CLI"),
+                SubCommand::with_name(DIFF_SUBCMD)
+                    .visible_aliases(DIFF_ALIASES)
+                    .arg(schema_format_arg())
+                    .arg(schema_version_arg())
+                    .about("Compare the server and local schemas"),
+            ])
+        )
 }

--- a/src/database/api_error.rs
+++ b/src/database/api_error.rs
@@ -1,4 +1,4 @@
-use serde_yaml::Error;
+use serde_json::Error;
 use std::error;
 use std::fmt;
 use std::fmt::Formatter;
@@ -6,7 +6,7 @@ use std::fmt::Formatter;
 #[derive(Debug)]
 pub enum ApiError {
     Authentication(String),
-    MalformedApiFile(serde_yaml::Error),
+    MalformedApiFile(serde_json::Error),
     ResponseError(String),
     UnsupportedFormat(String),
     UnhandledError(String),
@@ -26,7 +26,7 @@ impl fmt::Display for ApiError {
     }
 }
 
-impl From<serde_yaml::Error> for ApiError {
+impl From<serde_json::Error> for ApiError {
     fn from(e: Error) -> Self {
         Self::MalformedApiFile(e)
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,30 +1,74 @@
+use crate::cli::{DIFF_SUBCMD, FORMAT_OPT};
 use crate::database::{Api, OpenApiConfig};
+use crate::warn_missing_subcommand;
 use clap::ArgMatches;
 use color_eyre::eyre::Result;
+use similar::TextDiff;
+use std::io;
+
+fn proc_schema_diff(subcmd_args: &ArgMatches, rest_cfg: &OpenApiConfig, api: &Api) -> Result<()> {
+    let show_version = subcmd_args.is_present("version");
+    let fmt = subcmd_args.value_of(FORMAT_OPT).unwrap();
+
+    let header1 = "CLI";
+    let header2 = "Server";
+    let server: String;
+    let local: String;
+    if show_version {
+        server = api.get_schema_version(rest_cfg)?;
+        local = api.get_local_schema_version()?;
+    } else {
+        server = api.get_schema(rest_cfg, fmt)?;
+        local = api.get_local_schema(fmt)?;
+    }
+    let diff = TextDiff::from_lines(&local, &server);
+    diff.unified_diff()
+        .header(header1, header2)
+        .to_writer(io::stdout())?;
+    Ok(())
+}
+
+fn proc_schema_local(subcmd_args: &ArgMatches, _rest_cfg: &OpenApiConfig, api: &Api) -> Result<()> {
+    let show_version = subcmd_args.is_present("version");
+    let fmt = subcmd_args.value_of(FORMAT_OPT).unwrap();
+
+    if show_version {
+        let version = api.get_local_schema_version()?;
+        println!("{}", version);
+    } else {
+        let schema = api.get_local_schema(fmt)?;
+        println!("{}", schema);
+    }
+    Ok(())
+}
+
+fn proc_schema_server(subcmd_args: &ArgMatches, rest_cfg: &OpenApiConfig, api: &Api) -> Result<()> {
+    let show_version = subcmd_args.is_present("version");
+    let fmt = subcmd_args.value_of(FORMAT_OPT).unwrap();
+
+    if show_version {
+        let version = api.get_schema_version(rest_cfg)?;
+        println!("{}", version);
+    } else {
+        let schema = api.get_schema(rest_cfg, fmt)?;
+        println!("{}", schema);
+    }
+    Ok(())
+}
 
 pub fn process_schema_command(
     subcmd_args: &ArgMatches,
     rest_cfg: &OpenApiConfig,
     api: &Api,
 ) -> Result<()> {
-    let fmt = subcmd_args.value_of("format").unwrap();
-    let show_version = subcmd_args.is_present("version");
-    let show_local = subcmd_args.is_present("local");
-
-    if show_local {
-        if show_version {
-            let version = api.get_local_schema_version()?;
-            println!("{}", version);
-        } else {
-            let schema = api.get_local_schema(fmt)?;
-            println!("{}", schema);
-        }
-    } else if show_version {
-        let version = api.get_schema_version(rest_cfg)?;
-        println!("{}", version);
+    if let Some(subcmd_args) = subcmd_args.subcommand_matches(DIFF_SUBCMD) {
+        proc_schema_diff(subcmd_args, rest_cfg, api)?;
+    } else if let Some(subcmd_args) = subcmd_args.subcommand_matches("local") {
+        proc_schema_local(subcmd_args, rest_cfg, api)?;
+    } else if let Some(subcmd_args) = subcmd_args.subcommand_matches("server") {
+        proc_schema_server(subcmd_args, rest_cfg, api)?;
     } else {
-        let schema = api.get_schema(rest_cfg, fmt)?;
-        println!("{}", schema);
+        warn_missing_subcommand("schema");
     }
     Ok(())
 }

--- a/tests/help.txt
+++ b/tests/help.txt
@@ -28,7 +28,7 @@ SUBCOMMANDS:
     parameters       Work with CloudTruth parameters [aliases: parameter, params, param, p]
     projects         Work with CloudTruth projects [aliases: project, proj]
     run              Run a shell with the parameters in place [aliases: run, r]
-    schema           Get the schema
+    schema           View CloudTruth OpenAPI schema
     templates        Work with CloudTruth templates [aliases: template, temp, t]
     users            Work with CloudTruth users [aliases: user, us]
 ============================================================
@@ -1040,18 +1040,59 @@ ARGS:
     <arguments>...    Treat the rest of the arguments as the command
 ============================================================
 cloudtruth-schema 
-Get the schema
+View CloudTruth OpenAPI schema
 
 USAGE:
-    cloudtruth schema [FLAGS] [OPTIONS]
+    cloudtruth schema [SUBCOMMAND]
 
 FLAGS:
     -h, --help       Prints help information
-    -l, --local      Local schema version (compiled into CLI)
-    -v, --version    Show just the server schema version
+    -V, --version    Prints version information
+
+SUBCOMMANDS:
+    differences    Compare the server and local schemas [aliases: difference, differ, diff, di]
+    help           Prints this message or the help of the given subcommand(s)
+    local          Show the schema used to compile the CLI [aliases: loc, l]
+    server         Show the schema in use by the server [aliases: serv, s]
+========================================
+cloudtruth-schema-differences 
+Compare the server and local schemas
+
+USAGE:
+    cloudtruth schema differences [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+        --version    Display just the schema version
 
 OPTIONS:
-    -f, --format <format>    Schema format [default: yaml]  [possible values: yaml, json]
+    -f, --format <format>    Schema output format [default: yaml]  [possible values: yaml, json]
+========================================
+cloudtruth-schema-local 
+Show the schema used to compile the CLI
+
+USAGE:
+    cloudtruth schema local [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+        --version    Display just the schema version
+
+OPTIONS:
+    -f, --format <format>    Schema output format [default: yaml]  [possible values: yaml, json]
+========================================
+cloudtruth-schema-server 
+Show the schema in use by the server
+
+USAGE:
+    cloudtruth schema server [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+        --version    Display just the schema version
+
+OPTIONS:
+    -f, --format <format>    Schema output format [default: yaml]  [possible values: yaml, json]
 ============================================================
 cloudtruth-templates 
 Work with CloudTruth templates

--- a/tests/pytest/test_misc.py
+++ b/tests/pytest/test_misc.py
@@ -15,40 +15,70 @@ class TestMiscellaneous(TestCase):
         base_cmd = self.get_cli_base_cmd()
         yaml = YAML()
 
-        result = self.run_cli(cmd_env, base_cmd + "schema")
+        result = self.run_cli(cmd_env, base_cmd + "schema server")
         self.assertResultSuccess(result)
+        default_text = result.out()
         default_schema = yaml.load(result.out())
 
         # specify the output type -- yaml
-        result = self.run_cli(cmd_env, base_cmd + "schema --format yaml")
+        result = self.run_cli(cmd_env, base_cmd + "schema server --format yaml")
         self.assertResultSuccess(result)
+        yaml_text = result.out()
         yaml_schema = yaml.load(result.out())
 
         # specify the output type -- json
-        result = self.run_cli(cmd_env, base_cmd + "schema -f json")
+        result = self.run_cli(cmd_env, base_cmd + "schema server -f json")
         self.assertResultSuccess(result)
         json_schema = json.loads(result.out())
 
         # check equivalence of the different methods
+        self.assertEqual(default_text, yaml_text)  # pre-evaluation should be same
         self.assertEqual(default_schema, yaml_schema)
         self.assertEqual(default_schema, json_schema)
 
         # check the version
-        result = self.run_cli(cmd_env, base_cmd + "schema --version")
+        result = self.run_cli(cmd_env, base_cmd + "schema server --version")
         self.assertResultSuccess(result)
         version = result.out().strip()
         self.assertEqual(version, default_schema["info"]["version"])
 
         # check local
-        result = self.run_cli(cmd_env, base_cmd + "schema --local")
+        result = self.run_cli(cmd_env, base_cmd + "schema local")
         self.assertResultSuccess(result)
+        local_text = result.out()
         local_schema = yaml.load(result.out())
 
+        # check local using yaml
+        result = self.run_cli(cmd_env, base_cmd + "schema local -f yaml")
+        self.assertResultSuccess(result)
+        local_yaml_text = result.out()
+        local_yaml = yaml.load(result.out())
+
+        # check local using json
+        result = self.run_cli(cmd_env, base_cmd + "schema local --format json")
+        self.assertResultSuccess(result)
+        local_json = json.loads(result.out())
+
+        # check equivalence of the different methods
+        self.assertEqual(local_schema, local_yaml)
+        self.assertEqual(local_schema, local_json)
+        self.assertEqual(local_text, local_yaml_text)
+
         # check the local version
-        result = self.run_cli(cmd_env, base_cmd + "schema --local --version")
+        result = self.run_cli(cmd_env, base_cmd + "schema local --version")
         self.assertResultSuccess(result)
         version = result.out().strip()
         self.assertEqual(version, local_schema["info"]["version"])
+
+        # check the diff -- nothing really to compare, just that options succeed
+        result = self.run_cli(cmd_env, base_cmd + "schema diff")
+        self.assertResultSuccess(result)
+
+        result = self.run_cli(cmd_env, base_cmd + "schema diff --format json")
+        self.assertResultSuccess(result)
+
+        result = self.run_cli(cmd_env, base_cmd + "schema diff --format yaml")
+        self.assertResultSuccess(result)
 
     def test_misc_completions(self):
         cmd_env = self.get_cmd_env()


### PR DESCRIPTION
1. Add `schema diff` command
2. Return same schema each time
   * Pass through server response (yaml, or json) instead of processing to local version
   * Include openapi.json file to give local json formatted output