### PR TITLE
add strict arg to run command

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1011,6 +1011,9 @@ pub fn build_cli() -> App<'static, 'static> {
                         .long("permissive")
                         .short("p")
                         .help("Allow CloudTruth application variables through"),
+                    Arg::with_name("strict")
+                        .long("strict")
+                        .help("Fail when any parameters are unset"),
                     param_as_of_arg(),
                 ])
         )

--- a/src/run.rs
+++ b/src/run.rs
@@ -70,7 +70,8 @@ pub fn process_run_command(
     let overrides = subcmd_args.values_of_lossy("set").unwrap_or_default();
     let removals = subcmd_args.values_of_lossy("remove").unwrap_or_default();
     let permissive = subcmd_args.is_present("permissive");
-    sub_proc.set_environment(resolved, inherit, &overrides, &removals)?;
+    let strict = subcmd_args.is_present("strict");
+    sub_proc.set_environment(resolved, inherit, &overrides, &removals, strict)?;
     if !permissive {
         sub_proc.remove_ct_app_vars();
     }

--- a/tests/pytest/test_run.py
+++ b/tests/pytest/test_run.py
@@ -151,3 +151,29 @@ class TestRun(TestCase):
 
         # cleanup
         self.delete_project(cmd_env, proj_name)
+
+    def test_run_strict(self):
+        base_cmd = self.get_cli_base_cmd()
+        cmd_env = self.get_cmd_env()
+        proj_name = self.make_name("run-strict")
+        printenv = self.get_display_env_command()
+        param_name = "SOME_PARAM_NAME"
+        param_value = "some-value"
+
+        param_cmd = base_cmd + f"--project {proj_name} parameters set {param_name}"
+        self.create_project(cmd_env, proj_name)
+        self.run_cli(cmd_env, param_cmd)
+
+        # assert failure when a cloudtruth parameter has no value
+        cmd = base_cmd + f"--project {proj_name} run --strict -- {printenv}"
+        result = self.run_cli(cmd_env, cmd)
+        self.assertIn("parameter found without a value", result.err())
+
+        # assert success when all cloudtruth parameters have values
+        value_cmd = param_cmd + f" --value {param_value}"
+        self.run_cli(cmd_env, value_cmd)
+        result = self.run_cli(cmd_env, cmd)
+        self.assertIn(param_name, result.out())
+
+        # cleanup
+        self.delete_project(cmd_env, proj_name)


### PR DESCRIPTION
Adds `--strict` flag to cloudtruth run command.
Returns an error if any cloudtruth parameter is unset. 

This PR uses client side logic, checking to see if a value is "-" (this is the closest equivalent for null)