### PR TITLE
update broken integration tests related to secrets in templates (and other small fixes; see description)

### DIFF
--- a/tests/pytest/cleanup.py
+++ b/tests/pytest/cleanup.py
@@ -100,7 +100,7 @@ def cloudtruth_cleanup(*args):
     if not(any([x for x in elements if x.items])):
         types = [x.name for x in elements]
         type_list = ", ".join(types[:-1])
-        type_list.append(f", or {types[-1]}")
+        type_list += f", or {types[-1]}"
         search_list = ", ".join(args.needles)
         print(f"No {type_list} items found matching: {search_list}")
         return 0

--- a/tests/pytest/test_integrations.py
+++ b/tests/pytest/test_integrations.py
@@ -437,7 +437,7 @@ PARAMETER_2 = PARAM2
         self.assertIn("Did not find parameter", result.out())  # TODO: message goes away
 
         # attempt adding in other order -- adding external template with broken references
-        eval_err = "Evaluation error: references parameter(s) that do not exist"
+        eval_err = "Evaluation error: Template contains references that do not exist"
         result = self.run_cli(cmd_env, proj_cmd + f"param set {param2} -f '{temp_fqn}' -e true")
         self.assertResultError(result, eval_err)
         self.assertIn(param1, result.err())


### PR DESCRIPTION
Most changes are related to templates becoming secret when referencing secret parameters

other fixes:
* error message changed when a missing reference is found in a template
* fixed TypeError bug in the test cleanup script
* made some of the test environments easier to cleanup by giving them prefixes
* small fix to param diff test in case when comparing same env at two identical timestamps