### PR TITLE
add config option to accept invalid certs

### DIFF
--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,7 +1,7 @@
 use crate::config::profiles::Profile;
 use crate::config::{
-    CT_API_KEY, CT_ENVIRONMENT, CT_PROJECT, CT_REQ_TIMEOUT, CT_REST_DEBUG, CT_REST_PAGE_SIZE,
-    CT_REST_SUCCESS, CT_SERVER_URL, CT_ACCEPT_INVALID_CERTS
+    CT_ACCEPT_INVALID_CERTS, CT_API_KEY, CT_ENVIRONMENT, CT_PROJECT, CT_REQ_TIMEOUT, CT_REST_DEBUG,
+    CT_REST_PAGE_SIZE, CT_REST_SUCCESS, CT_SERVER_URL,
 };
 use std::env;
 
@@ -20,7 +20,7 @@ impl ConfigEnv {
             rest_page_size: Self::get_rest_page_size(),
             server_url: Self::get_override(CT_SERVER_URL),
             source_profile: None,
-            accept_invalid_certs: Self::get_accept_invalid_certs()
+            accept_invalid_certs: Self::get_accept_invalid_certs(),
         }
     }
 

--- a/src/config/env.rs
+++ b/src/config/env.rs
@@ -1,7 +1,7 @@
 use crate::config::profiles::Profile;
 use crate::config::{
     CT_API_KEY, CT_ENVIRONMENT, CT_PROJECT, CT_REQ_TIMEOUT, CT_REST_DEBUG, CT_REST_PAGE_SIZE,
-    CT_REST_SUCCESS, CT_SERVER_URL,
+    CT_REST_SUCCESS, CT_SERVER_URL, CT_ACCEPT_INVALID_CERTS
 };
 use std::env;
 
@@ -20,6 +20,7 @@ impl ConfigEnv {
             rest_page_size: Self::get_rest_page_size(),
             server_url: Self::get_override(CT_SERVER_URL),
             source_profile: None,
+            accept_invalid_certs: Self::get_accept_invalid_certs()
         }
     }
 
@@ -45,6 +46,11 @@ impl ConfigEnv {
 
     pub fn get_rest_debug() -> Option<bool> {
         Self::get_override(CT_REST_DEBUG)
+            .map(|e| matches!(e.to_lowercase().as_str(), "true" | "1" | "yes"))
+    }
+
+    pub fn get_accept_invalid_certs() -> Option<bool> {
+        Self::get_override(CT_ACCEPT_INVALID_CERTS)
             .map(|e| matches!(e.to_lowercase().as_str(), "true" | "1" | "yes"))
     }
 
@@ -84,6 +90,7 @@ mod tests {
         env::remove_var(CT_REST_DEBUG);
         env::remove_var(CT_REST_SUCCESS);
         env::remove_var(CT_REST_PAGE_SIZE);
+        env::remove_var(CT_ACCEPT_INVALID_CERTS);
     }
 
     #[test]
@@ -109,6 +116,7 @@ mod tests {
         env::set_var(CT_SERVER_URL, "http://localhost:7001/graphql");
         env::set_var(CT_REST_DEBUG, "true");
         env::set_var(CT_REST_SUCCESS, "sna,foo,bar");
+        env::set_var(CT_ACCEPT_INVALID_CERTS, "1");
 
         assert_eq!(
             Profile {
@@ -121,7 +129,8 @@ mod tests {
                 rest_success: vec!["sna".to_string(), "foo".to_string(), "bar".to_string()],
                 rest_page_size: None,
                 server_url: Some("http://localhost:7001/graphql".to_string()),
-                source_profile: None
+                source_profile: None,
+                accept_invalid_certs: Some(true)
             },
             ConfigEnv::load_profile()
         );

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -134,7 +134,7 @@ impl ConfigFile {
             rest_page_size: None,
             server_url: None,
             source_profile: source.map(String::from),
-            accept_invalid_certs: None
+            accept_invalid_certs: None,
         };
 
         let profiles = config_file.profiles.borrow_mut();
@@ -188,7 +188,7 @@ impl ConfigFile {
             rest_debug: profile.rest_debug,
             rest_success: profile.rest_success.clone(),
             rest_page_size: profile.rest_page_size,
-            accept_invalid_certs: profile.accept_invalid_certs
+            accept_invalid_certs: profile.accept_invalid_certs,
         }
     }
 

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -134,6 +134,7 @@ impl ConfigFile {
             rest_page_size: None,
             server_url: None,
             source_profile: source.map(String::from),
+            accept_invalid_certs: None
         };
 
         let profiles = config_file.profiles.borrow_mut();
@@ -187,6 +188,7 @@ impl ConfigFile {
             rest_debug: profile.rest_debug,
             rest_success: profile.rest_success.clone(),
             rest_page_size: profile.rest_page_size,
+            accept_invalid_certs: profile.accept_invalid_certs
         }
     }
 
@@ -731,6 +733,7 @@ mod tests {
                 rest_success: vec![],
                 rest_page_size: None,
                 request_timeout: None,
+                accept_invalid_certs: None
             },
         );
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -98,7 +98,7 @@ pub struct Config {
     pub rest_debug: bool,
     pub rest_page_size: Option<i32>,
     pub rest_success: Vec<String>,
-    pub accept_invalid_certs: Option<bool>
+    pub accept_invalid_certs: Option<bool>,
 }
 
 pub struct ValidationError {
@@ -130,7 +130,7 @@ fn profile_into_config(prof_name: &str, profile: &Profile) -> Config {
         rest_debug: profile.rest_debug.unwrap_or(false),
         rest_success: profile.rest_success.clone(),
         rest_page_size: profile.rest_page_size,
-        accept_invalid_certs: profile.accept_invalid_certs
+        accept_invalid_certs: profile.accept_invalid_certs,
     }
 }
 
@@ -272,7 +272,7 @@ impl Config {
         description: Option<&str>,
         environment: Option<&str>,
         project: Option<&str>,
-        source: Option<&str>
+        source: Option<&str>,
     ) -> Result<()> {
         if let Some(filename) = Self::config_file() {
             if !filename.exists() {
@@ -667,7 +667,7 @@ impl Config {
             value,
             source,
             secret: false,
-            extension: true
+            extension: true,
         });
 
         Ok(results)

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -24,7 +24,7 @@ pub struct Profile {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_profile: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub accept_invalid_certs: Option<bool>
+    pub accept_invalid_certs: Option<bool>,
 }
 
 // TODO: Rick Porter 4/21, fix this so don't have to udpate when Profile is updated
@@ -41,7 +41,7 @@ pub struct ProfileDetails {
     pub rest_debug: Option<bool>,
     pub rest_success: Vec<String>,
     pub rest_page_size: Option<i32>,
-    pub accept_invalid_certs: Option<bool>
+    pub accept_invalid_certs: Option<bool>,
 }
 
 fn empty_to_none(value: &Option<String>) -> Option<String> {
@@ -78,7 +78,10 @@ impl Profile {
             rest_page_size: other.rest_page_size.or(self.rest_page_size),
             server_url: other.server_url.clone().or_else(|| self.server_url.clone()),
             source_profile: self.source_profile.clone(),
-            accept_invalid_certs: other.accept_invalid_certs.or(self.accept_invalid_certs).clone()
+            accept_invalid_certs: other
+                .accept_invalid_certs
+                .or(self.accept_invalid_certs)
+                .clone(),
         }
     }
 
@@ -95,7 +98,7 @@ impl Profile {
             rest_page_size: self.rest_page_size,
             server_url: empty_to_none(&self.server_url),
             source_profile: empty_to_none(&self.source_profile),
-            accept_invalid_certs: self.accept_invalid_certs
+            accept_invalid_certs: self.accept_invalid_certs,
         }
     }
 
@@ -230,7 +233,7 @@ mod tests {
             rest_page_size: None,
             server_url: Some("".to_string()),
             source_profile: Some("".to_string()),
-            accept_invalid_certs: None
+            accept_invalid_certs: None,
         };
 
         let prof2 = prof.remove_empty();
@@ -248,7 +251,7 @@ mod tests {
             rest_page_size: None,
             server_url: Some("url".to_string()),
             source_profile: Some("src-prof".to_string()),
-            accept_invalid_certs: None
+            accept_invalid_certs: None,
         };
         let prof2 = prof.remove_empty();
         assert_eq!(prof, prof2);

--- a/src/config/profiles.rs
+++ b/src/config/profiles.rs
@@ -23,6 +23,8 @@ pub struct Profile {
     pub server_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub source_profile: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub accept_invalid_certs: Option<bool>
 }
 
 // TODO: Rick Porter 4/21, fix this so don't have to udpate when Profile is updated
@@ -39,6 +41,7 @@ pub struct ProfileDetails {
     pub rest_debug: Option<bool>,
     pub rest_success: Vec<String>,
     pub rest_page_size: Option<i32>,
+    pub accept_invalid_certs: Option<bool>
 }
 
 fn empty_to_none(value: &Option<String>) -> Option<String> {
@@ -75,6 +78,7 @@ impl Profile {
             rest_page_size: other.rest_page_size.or(self.rest_page_size),
             server_url: other.server_url.clone().or_else(|| self.server_url.clone()),
             source_profile: self.source_profile.clone(),
+            accept_invalid_certs: other.accept_invalid_certs.or(self.accept_invalid_certs).clone()
         }
     }
 
@@ -91,6 +95,7 @@ impl Profile {
             rest_page_size: self.rest_page_size,
             server_url: empty_to_none(&self.server_url),
             source_profile: empty_to_none(&self.source_profile),
+            accept_invalid_certs: self.accept_invalid_certs
         }
     }
 
@@ -104,6 +109,7 @@ impl Profile {
             && self.rest_page_size.is_none()
             && self.server_url.is_none()
             && self.source_profile.is_none()
+            && self.accept_invalid_certs.is_none()
     }
 }
 
@@ -125,6 +131,7 @@ mod tests {
             project: Some("skunkworks".to_string()),
             request_timeout: Some(100),
             rest_debug: Some(true),
+            accept_invalid_certs: Some(true),
             rest_success: vec!["proj".to_string(), "env".to_string()],
             server_url: Some("http://localhost:7001/graphql".to_string()),
             ..Profile::default()
@@ -142,6 +149,7 @@ mod tests {
             project: Some("skunkworks".to_string()),
             request_timeout: Some(23),
             rest_debug: Some(false),
+            accept_invalid_certs: Some(true),
             rest_success: vec!["proj".to_string(), "env".to_string()],
             rest_page_size: Some(500),
             server_url: Some("http://localhost:7001/graphql".to_string()),
@@ -222,6 +230,7 @@ mod tests {
             rest_page_size: None,
             server_url: Some("".to_string()),
             source_profile: Some("".to_string()),
+            accept_invalid_certs: None
         };
 
         let prof2 = prof.remove_empty();
@@ -239,6 +248,7 @@ mod tests {
             rest_page_size: None,
             server_url: Some("url".to_string()),
             source_profile: Some("src-prof".to_string()),
+            accept_invalid_certs: None
         };
         let prof2 = prof.remove_empty();
         assert_eq!(prof, prof2);

--- a/src/database/openapi.rs
+++ b/src/database/openapi.rs
@@ -156,7 +156,7 @@ mod tests {
             rest_debug: true,
             rest_success: vec!["abc".to_string(), "def".to_string()],
             rest_page_size: Some(2300),
-            accept_invalid_certs: None
+            accept_invalid_certs: None,
         };
         let openapi_cfg = OpenApiConfig::from(&ct_cfg);
         // check that the trailing slash removed from the URL

--- a/src/database/openapi.rs
+++ b/src/database/openapi.rs
@@ -118,6 +118,7 @@ impl From<&CloudTruthConfig> for OpenApiConfig {
             client: reqwest::Client::builder()
                 .timeout(ct_cfg.request_timeout.unwrap())
                 .cookie_store(true)
+                .danger_accept_invalid_certs(ct_cfg.accept_invalid_certs.unwrap_or(false))
                 .build()
                 .unwrap(),
             basic_auth: None,
@@ -155,6 +156,7 @@ mod tests {
             rest_debug: true,
             rest_success: vec!["abc".to_string(), "def".to_string()],
             rest_page_size: Some(2300),
+            accept_invalid_certs: None
         };
         let openapi_cfg = OpenApiConfig::from(&ct_cfg);
         // check that the trailing slash removed from the URL

--- a/tests/pytest/test_configuration.py
+++ b/tests/pytest/test_configuration.py
@@ -208,7 +208,7 @@ class TestConfiguration(TestCase):
         extended = [
             "Profile", "API key", "Organization", "User", "Role", "Project", "Environment",
             "CLI version", "Server URL", "Request timeout", "REST debug", "REST success",
-            "REST page size",
+            "REST page size", "Accept Invalid Certs"
         ]
         self.assertEqual(param_names, extended)
 


### PR DESCRIPTION
Adds `CLOUDTRUTH_ACCEPT_INVALID_CERTS` environment variable and yaml config key `accept_invalid_certs` to trust any credentials from the server