### PR TITLE
Refactoring to improve stability/usability of integration test suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   RUST_VERSION: 1.63.0
 
   # These are based on pre-configured integrations in the CLI CI account.
+  # this test currently does not work. need to recreate the test data
   # CLOUDTRUTH_TEST_BROKEN_PROJECT: proj-int-broken
   # CLOUDTRUTH_TEST_BROKEN_TEMPLATE: temp-int-broken
   # CLOUDTRUTH_TEST_BROKEN_PARAM1: param1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,19 +16,19 @@ env:
   RUST_VERSION: 1.63.0
 
   # These are based on pre-configured integrations in the CLI CI account.
-  CLOUDTRUTH_TEST_BROKEN_PROJECT: proj-int-broken
-  CLOUDTRUTH_TEST_BROKEN_TEMPLATE: temp-int-broken
-  CLOUDTRUTH_TEST_BROKEN_PARAM1: param1
-  CLOUDTRUTH_TEST_BROKEN_PARAM2: param2
-  CLOUDTRUTH_TEST_BROKEN_PARAM3: param3
-  CLOUDTRUTH_TEST_BROKEN_PARAM4: param4
-  CLOUDTRUTH_TEST_BROKEN_VALUE1: value1
-  CLOUDTRUTH_TEST_BROKEN_VALUE2: King
-  CLOUDTRUTH_TEST_BROKEN_VALUE3: voluptas
-  CLOUDTRUTH_TEST_BROKEN_JMES2: speicla.beef_brocolli
-  CLOUDTRUTH_TEST_BROKEN_JMES3: numquam.doloremque
-  CLOUDTRUTH_TEST_BROKEN_FQN2: github://cloudtruth/another-test-repo/main/jade.yaml
-  CLOUDTRUTH_TEST_BROKEN_FQN3: github://cloudtruth/github-integration-test-repo/trimmed/more_config/anotherconfig.yaml
+  # CLOUDTRUTH_TEST_BROKEN_PROJECT: proj-int-broken
+  # CLOUDTRUTH_TEST_BROKEN_TEMPLATE: temp-int-broken
+  # CLOUDTRUTH_TEST_BROKEN_PARAM1: param1
+  # CLOUDTRUTH_TEST_BROKEN_PARAM2: param2
+  # CLOUDTRUTH_TEST_BROKEN_PARAM3: param3
+  # CLOUDTRUTH_TEST_BROKEN_PARAM4: param4
+  # CLOUDTRUTH_TEST_BROKEN_VALUE1: value1
+  # CLOUDTRUTH_TEST_BROKEN_VALUE2: King
+  # CLOUDTRUTH_TEST_BROKEN_VALUE3: voluptas
+  # CLOUDTRUTH_TEST_BROKEN_JMES2: speicla.beef_brocolli
+  # CLOUDTRUTH_TEST_BROKEN_JMES3: numquam.doloremque
+  # CLOUDTRUTH_TEST_BROKEN_FQN2: github://cloudtruth/another-test-repo/main/jade.yaml
+  # CLOUDTRUTH_TEST_BROKEN_FQN3: github://cloudtruth/github-integration-test-repo/trimmed/more_config/anotherconfig.yaml
 
   CLOUDTRUTH_TEST_EXPLORE_FQN: github://cloudtruth/github-integration-test-repo/main/short.yaml
   CLOUDTRUTH_TEST_EXPLORE_JMES: speicla.POrk_Egg_Foo_Young

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,7 +27,7 @@ const CONFIG_FILE_NAME: &str = "cli.yml";
 pub const DEFAULT_SERVER_URL: &str = "https://api.cloudtruth.io";
 
 /// Default OpenApi server request timeout
-pub const DEFAULT_REQUEST_TIMEOUT: u64 = 30;
+pub const DEFAULT_REQUEST_TIMEOUT: u64 = 90;
 
 /// Default environment name.
 pub const DEFAULT_ENV_NAME: &str = "default";

--- a/tests/pytest/cleanup.py
+++ b/tests/pytest/cleanup.py
@@ -80,6 +80,7 @@ def cloudtruth_cleanup(*args):
         CleanupItem(name="projects", list_cmd="proj tree", del_cmd="proj del -y"),
         CleanupItem(name="environments", list_cmd="env tree", del_cmd="env del -y"),
         CleanupItem(name="users", list_cmd="user ls", del_cmd="user del -y"),
+        CleanupItem(name="groups", list_cmd="group ls", del_cmd="group del -y"),
         CleanupItem(name="invitations", list_cmd="user invite ls", del_cmd="user invite del -y"),
         CleanupItem(name="types", list_cmd="types tree", del_cmd="types del -y"),
         CleanupItem(name="pushes", list_cmd="action push ls", del_cmd="action push del -y"),

--- a/tests/pytest/test_actions.py
+++ b/tests/pytest/test_actions.py
@@ -70,9 +70,9 @@ class TestActions(TestCase):
 
         ########################
         # create a couple projects
-        proj_name1 = self.make_name("test-push-proj1")
+        proj_name1 = self.make_name("push-proj1")
         self.create_project(cmd_env, proj_name1)
-        proj_name2 = self.make_name("test-push-proj2")
+        proj_name2 = self.make_name("push-proj2")
         self.create_project(cmd_env, proj_name2)
 
         ########################
@@ -96,7 +96,7 @@ class TestActions(TestCase):
         default_resource = "/{{ environment }}/{{ project }}/{{ parameter }}"
         default_service = "ssm"
         default_region = "us-east-1"
-        push_name1 = self.make_name("my-test-push")
+        push_name1 = self.make_name("mypush")
         desc1 = "original comment"
         resource1 = "/{{ environment }}/{{ project }}/{{ parameter }}"
         self._pushes.append((integ_name, push_name1))
@@ -131,7 +131,7 @@ class TestActions(TestCase):
         self.assertIn(f"Integration: {integ_name}", result.out())
 
         # rename push, change resource, add another project, and another tag
-        push_name2 = self.make_name("updated-test-push")
+        push_name2 = self.make_name("updatedpush")
         resource2 = "/{{ project }}/{{ parameter }}/{{ environment }}"
         self._pushes.append((integ_name, push_name2))
         tag2 = f"{env_name2}:{env2_tag1}"
@@ -394,7 +394,7 @@ class TestActions(TestCase):
         # create the import -- use a bogus resource string the would not exist
         default_service = "ssm"
         default_region = "us-east-1"
-        import_name1 = self.make_name("my-test-import")
+        import_name1 = self.make_name("myimport")
         desc1 = "original comment"
         resource1 = "/bogus_resource_path/{{ project }}/{{ environment }}/{{ parameter }}"
         self._pulls.append((integ_name, import_name1))
@@ -428,7 +428,7 @@ class TestActions(TestCase):
         self.assertIn("Flags: none", result.out())
 
         # rename import, change resource, add another project, and another tag
-        import_name2 = self.make_name("updated-test-imp")
+        import_name2 = self.make_name("updatedimp")
         resource2 = "/another_path_should_not_exist/{{ project }}/{{ parameter }}/{{ environment }}"
         self._pulls.append((integ_name, import_name2))
         cmd = set_cmd + f"'{import_name1}' --resource '{resource2}' -r '{import_name2}'"
@@ -686,7 +686,7 @@ class TestActions(TestCase):
 
         ########################
         # define a couple projects, parameters, and values
-        proj_name1 = self.make_name("test-comp-army")
+        proj_name1 = self.make_name("comp-army")
         param11 = "soldier"
         value11a = "private"
         value11b = "infantryman"
@@ -694,7 +694,7 @@ class TestActions(TestCase):
         value21a = "captain"
         value21b = "engineer"
 
-        proj_name2 = self.make_name("test-comp-airforce")
+        proj_name2 = self.make_name("comp-airforce")
         param12 = "officer"
         value12a = "navigator"
         value12b = "major"
@@ -770,7 +770,7 @@ class TestActions(TestCase):
         # create the push of both projects -- the path includes a test-specific
         prefix = self.make_name("action-complete")
         resource = f"/{prefix}" + "/{{ environment }}/{{ project }}/{{ parameter }}"
-        push_name = self.make_name("test-comp-push")
+        push_name = self.make_name("comp-push")
         self._pushes.append((integ_name, push_name))
         create_push_cmd = (
             push_cmd + f"set {push_name} --integration '{integ_name}' "

--- a/tests/pytest/test_args.py
+++ b/tests/pytest/test_args.py
@@ -12,8 +12,8 @@ class TestTopLevelArgs(TestCase):
         cmd_env = self.get_cmd_env()
         printenv = f" run -i none -- {self.get_display_env_command()}"
         cfg_cmd = " config current -f csv"
-        proj1 = self.make_name("test-arg-project-1")
-        proj2 = self.make_name("test-arg-proj2")
+        proj1 = self.make_name("arg-project-1")
+        proj2 = self.make_name("arg-proj2")
         env1 = self.make_name("dev a")
         env2 = self.make_name("dev B")
 
@@ -147,8 +147,8 @@ class TestTopLevelArgs(TestCase):
     def test_arg_resolution(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = self.make_name("test-unknown-proj")
-        env_name = self.make_name("test-env-unknown")
+        proj_name = self.make_name("unknown-proj")
+        env_name = self.make_name("env-unknown")
         checked_commands = [
             "param ls -v",
             "templates ls -v",

--- a/tests/pytest/test_audit_log.py
+++ b/tests/pytest/test_audit_log.py
@@ -77,7 +77,7 @@ class TestAuditLogs(TestCase):
         orig_summary = result.out()
 
         # add some things
-        proj_name = self.make_name("test-audit")
+        proj_name = self.make_name("audit")
         self.create_project(cmd_env, proj_name)
         env_name = self.make_name("aud-env")
         self.create_environment(cmd_env, env_name)

--- a/tests/pytest/test_backup.py
+++ b/tests/pytest/test_backup.py
@@ -8,14 +8,14 @@ class TestProjects(TestCase):
         backup_cmd = base_cmd + "backup "
         snap_cmd = backup_cmd + "snapshot -y "
 
-        type1 = self.make_name("test-back-int")
-        type2 = self.make_name("test-back-str")
+        type1 = self.make_name("back-int")
+        type2 = self.make_name("back-str")
         type1_max = "4096"
         type1_min = "-511"
-        env_a = self.make_name("test-back-env_a")
-        env_b = self.make_name("test-back-env_b")
-        proj1 = self.make_name("test-back-proj1")
-        proj2 = self.make_name("test-back-proj2")
+        env_a = self.make_name("back-env_a")
+        env_b = self.make_name("back-env_b")
+        proj1 = self.make_name("back-proj1")
+        proj2 = self.make_name("back-proj2")
         p2_max_len = "100"
         p2_min_len = "10"
         temp1 = "my_temp"

--- a/tests/pytest/test_environments.py
+++ b/tests/pytest/test_environments.py
@@ -8,8 +8,8 @@ class TestEnvironments(TestCase):
         # verify `env_name` does not yet exist
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        env_name = self.make_name("test-env-name")
-        rename_name = self.make_name("test-env-rename")
+        env_name = self.make_name("env-name")
+        rename_name = self.make_name("env-rename")
         sub_cmd = base_cmd + "environments "
         result = self.run_cli(cmd_env, sub_cmd + "ls -v -f json")
         self.assertResultSuccess(result)
@@ -77,7 +77,7 @@ class TestEnvironments(TestCase):
     def test_environment_cannot_delete_default(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = self.make_name("default-env-del-test")
+        proj_name = self.make_name("default-env-del")
         self.create_project(cmd_env, proj_name)
 
         # set the proj/env to 'default', and do not expose secrets
@@ -178,14 +178,14 @@ class TestEnvironments(TestCase):
         env_count = page_size + 1
 
         for idx in range(env_count):
-            env_name = self.make_name(f"test-pag-{idx}")
+            env_name = self.make_name(f"pag-{idx}")
             self.create_environment(cmd_env, env_name)
 
         self.assertPaginated(cmd_env, base_cmd + "env ls", "/environments/?")
 
         # cleanup
         for idx in range(env_count):
-            env_name = self.make_name(f"test-pag-{idx}")
+            env_name = self.make_name(f"pag-{idx}")
             self.delete_environment(cmd_env, env_name)
 
     def test_environment_tagging(self):
@@ -194,7 +194,7 @@ class TestEnvironments(TestCase):
 
         proj_name = self.make_name("proj-env-tag")
         self.create_project(cmd_env, proj_name)
-        env_name = self.make_name("test-env-tag")
+        env_name = self.make_name("env-tag")
         self.create_environment(cmd_env, env_name)
 
         # set a parameter
@@ -334,7 +334,7 @@ class TestEnvironments(TestCase):
     def test_environment_tag_pagination(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        env_name = self.make_name("test-env-pag-tag")
+        env_name = self.make_name("env-pag-tag")
         self.create_environment(cmd_env, env_name)
 
         page_size = TEST_PAGE_SIZE

--- a/tests/pytest/test_groups.py
+++ b/tests/pytest/test_groups.py
@@ -142,7 +142,7 @@ class TestGroups(TestCase):
         result = self.run_cli(cmd_env, add_all_users_cmd)
         self.assertResultSuccess(result)
 
-    # remove all users with one command
+        # remove all users from group with one command
         rm_all_users_cmd = group_cmd + f"set {group_name} "
         rm_all_users_cmd += " ".join(f"--remove-user {user_name}" for user_name in user_names)
         result = self.run_cli(cmd_env, rm_all_users_cmd)

--- a/tests/pytest/test_groups.py
+++ b/tests/pytest/test_groups.py
@@ -16,7 +16,7 @@ class TestGroups(TestCase):
     def test_group_basic(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        group_name = self.make_name("test-group-name")
+        group_name = self.make_name("group-name")
         sub_cmd = base_cmd + "groups "
         result = self.run_cli(cmd_env, sub_cmd + "ls -v -f csv")
         self.assertResultSuccess(result)
@@ -107,7 +107,7 @@ class TestGroups(TestCase):
     def test_group_users(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        group_name = self.make_name("test-group-name")
+        group_name = self.make_name("group-name")
         group_cmd = base_cmd + "groups "
         user_cmd = base_cmd + "users "
 

--- a/tests/pytest/test_import.py
+++ b/tests/pytest/test_import.py
@@ -53,7 +53,7 @@ class ImportTestCase(TestCase):
     def test_import_basic(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = self.make_name("test-import")
+        proj_name = self.make_name("import")
         env1_name = self.make_name("imp-env")
         env2_name = self.make_name("imp-child")
         imp_base = base_cmd + "import param "

--- a/tests/pytest/test_integrations.py
+++ b/tests/pytest/test_integrations.py
@@ -76,7 +76,7 @@ class TestIntegrations(TestCase):
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-int-explore-errors")
+        proj_name = self.make_name("int-explore-errors")
         self.create_project(cmd_env, proj_name)
 
         # check that we get notification about no provider
@@ -155,7 +155,7 @@ class TestIntegrations(TestCase):
     def test_integration_parameters(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = self.make_name("test-int-params")
+        proj_name = self.make_name("int-params")
         empty_msg = f"No parameters found in project {proj_name}"
         param_cmd = base_cmd + f"--project '{proj_name}' param "
         show_cmd = param_cmd + "list -vsf csv"
@@ -404,7 +404,7 @@ PARAMETER_2 = PARAM2
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-int-ext-temp")
+        proj_name = self.make_name("int-ext-temp")
         self.create_project(cmd_env, proj_name)
         proj_cmd = base_cmd + f"--project '{proj_name}' "
 

--- a/tests/pytest/test_parameters.py
+++ b/tests/pytest/test_parameters.py
@@ -24,7 +24,7 @@ class TestParameters(TestCase):
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-param-basic")
+        proj_name = self.make_name("param-basic")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -207,7 +207,7 @@ my_param,cRaZy value,default,string,0,internal,false,this is just a test descrip
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-param-secret")
+        proj_name = self.make_name("param-secret")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -446,9 +446,9 @@ SNA=fu
         self.create_project(cmd_env, proj_name)
 
         env_name1 = DEFAULT_ENV_NAME  # no job-id variation
-        env_name2 = self.make_name("test-mets")
+        env_name2 = self.make_name("mets")
         self.create_environment(cmd_env, env_name2)
-        env_name3 = self.make_name("test-redsox")
+        env_name3 = self.make_name("redsox")
         self.create_environment(cmd_env, env_name3, parent=env_name2)
 
         var1_name = "base"
@@ -624,7 +624,7 @@ SNA=fu
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-param-export")
+        proj_name = self.make_name("param-export")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -759,7 +759,7 @@ SECOND_SECRET='sensitive value with spaces'
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-secret-switch")
+        proj_name = self.make_name("secret-switch")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -841,7 +841,7 @@ SECOND_SECRET='sensitive value with spaces'
         self.write_file(filename, value1)
 
         # add a new project
-        proj_name = self.make_name("test-local-file")
+        proj_name = self.make_name("local-file")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -910,7 +910,7 @@ SECOND_SECRET='sensitive value with spaces'
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-param-int-err")
+        proj_name = self.make_name("param-int-err")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -1028,7 +1028,7 @@ SECOND_SECRET='sensitive value with spaces'
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-param-tables")
+        proj_name = self.make_name("param-tables")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -1209,7 +1209,7 @@ parameter:
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-param-names")
+        proj_name = self.make_name("param-names")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
@@ -1254,14 +1254,14 @@ parameter:
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-param-cmp")
+        proj_name = self.make_name("param-cmp")
         empty_msg = self._empty_message(proj_name)
         self.create_project(cmd_env, proj_name)
 
         # add a couple environments
-        env_a = self.make_name("test-param-left")
+        env_a = self.make_name("param-left")
         self.create_environment(cmd_env, env_a)
-        env_b = self.make_name("test-param-right")
+        env_b = self.make_name("param-right")
         self.create_environment(cmd_env, env_b)
 
         # check that there are no parameters
@@ -1461,7 +1461,7 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-param-times")
+        proj_name = self.make_name("param-times")
         self.create_project(cmd_env, proj_name)
 
         # add a couple environments
@@ -1599,11 +1599,11 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         cmd_env = self.get_cmd_env()
 
         # add a new project, and a couple environments
-        proj_name = self.make_name("test-evaluated")
+        proj_name = self.make_name("evaluated")
         self.create_project(cmd_env, proj_name)
-        env_name_a = self.make_name("test-eval-a")
+        env_name_a = self.make_name("eval-a")
         self.create_environment(cmd_env, env_name_a)
-        env_name_b = self.make_name("test-eval-b")
+        env_name_b = self.make_name("eval-b")
         self.create_environment(cmd_env, env_name_b)
 
         # create an internal parameter
@@ -1758,7 +1758,7 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-basic-types")
+        proj_name = self.make_name("basic-types")
         self.create_project(cmd_env, proj_name)
         param_cmd = base_cmd + f"--project {proj_name} param "
         list_cmd = param_cmd + "ls -v -f csv"
@@ -1870,7 +1870,7 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-string-rules")
+        proj_name = self.make_name("string-rules")
         self.create_project(cmd_env, proj_name)
         env_name = self.make_name("string-env")
         self.create_environment(cmd_env, env_name)
@@ -2101,7 +2101,7 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-integer-rules")
+        proj_name = self.make_name("integer-rules")
         self.create_project(cmd_env, proj_name)
         env_name = self.make_name("int-env")
         self.create_environment(cmd_env, env_name)
@@ -2305,7 +2305,7 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-boolean-rules")
+        proj_name = self.make_name("boolean-rules")
         self.create_project(cmd_env, proj_name)
         env_name = self.make_name("bool-env")
         self.create_environment(cmd_env, env_name)
@@ -2369,7 +2369,7 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-param-tags")
+        proj_name = self.make_name("param-tags")
         self.create_project(cmd_env, proj_name)
         env_name = self.make_name("ptag-env")
         self.create_environment(cmd_env, env_name)
@@ -2458,9 +2458,9 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         base_cmd = self.get_cli_base_cmd()
 
         # add a set of projects
-        parent_name = self.make_name("test-param-proj-parent")
-        child1_name = self.make_name("test-param-proj-child1")
-        child2_name = self.make_name("test-param-proj-child2")
+        parent_name = self.make_name("param-proj-parent")
+        child1_name = self.make_name("param-proj-child1")
+        child2_name = self.make_name("param-proj-child2")
 
         self.create_project(cmd_env, parent_name)
         self.create_project(cmd_env, child1_name, parent=parent_name)
@@ -2563,7 +2563,7 @@ Name,Value,Project
 
         #########################
         # another level on project inheritance
-        grandchild_name = self.make_name("test-param-proj-grand")
+        grandchild_name = self.make_name("param-proj-grand")
         self.create_project(cmd_env, grandchild_name, parent=child1_name)
         result = self.list_params(cmd_env, child1_name, show_parents=True, fmt="csv", secrets=True)
         self.assertEqual(expected, result.out())
@@ -2642,7 +2642,7 @@ Name,Value,Project
         base_cmd = self.get_cli_base_cmd()
 
         # add a project
-        proj_name = self.make_name("test-param-pagination")
+        proj_name = self.make_name("param-pagination")
         self.create_project(cmd_env, proj_name)
 
         param_base = "param"
@@ -2667,7 +2667,7 @@ Name,Value,Project
         base_cmd = self.get_cli_base_cmd()
 
         # add a project
-        proj_name = self.make_name("test-param-overdone")
+        proj_name = self.make_name("param-overdone")
         self.create_project(cmd_env, proj_name)
 
         filename = self.make_name("cooked")
@@ -2699,7 +2699,7 @@ Name,Value,Project
         default_len = 12
 
         # add a project
-        proj_name = self.make_name("test-param-overdone")
+        proj_name = self.make_name("param-overdone")
         self.create_project(cmd_env, proj_name)
 
         param_cmd = base_cmd + f"--project {proj_name} param "
@@ -2786,7 +2786,7 @@ Name,Value,Project
         PROP_CHANGE = "Difference"
 
         # add a project with some variables
-        proj_name = self.make_name("test-param-drift")
+        proj_name = self.make_name("param-drift")
         param1 = "PARAM1"
         value1 = "my-param-value"
         param2 = "PARAM2"

--- a/tests/pytest/test_projects.py
+++ b/tests/pytest/test_projects.py
@@ -8,7 +8,7 @@ class TestProjects(TestCase):
         # verify `proj_name` does not yet exist
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = self.make_name("test-proj-name")
+        proj_name = self.make_name("proj-name")
         sub_cmd = base_cmd + "projects "
         result = self.run_cli(cmd_env, sub_cmd + "ls -v")
         self.assertResultSuccess(result)
@@ -36,7 +36,7 @@ class TestProjects(TestCase):
 
         # rename
         orig_name = proj_name
-        proj_name = self.make_name("test-proj-rename")
+        proj_name = self.make_name("proj-rename")
         result = self.run_cli(cmd_env, sub_cmd + f"set {orig_name} --rename \"{proj_name}\"")
         self.assertResultSuccess(result)
         self.assertIn(f"Updated project '{proj_name}'", result.out())
@@ -142,8 +142,8 @@ class TestProjects(TestCase):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
 
-        proj_name1 = self.make_name("test-ppp-parent")
-        proj_name2 = self.make_name("test-ppp-child")
+        proj_name1 = self.make_name("ppp-parent")
+        proj_name2 = self.make_name("ppp-child")
         self.create_project(cmd_env, proj_name1)
         self.create_project(cmd_env, proj_name2)
         proj1_cmd = base_cmd + f"--project '{proj_name1}' param "
@@ -281,12 +281,12 @@ class TestProjects(TestCase):
         proj_count = page_size + 1
 
         for idx in range(proj_count):
-            proj_name = self.make_name(f"test-pag-{idx}")
+            proj_name = self.make_name(f"pag-{idx}")
             self.create_project(cmd_env, proj_name)
 
         self.assertPaginated(cmd_env, base_cmd + "proj ls", "/projects/?")
 
         # cleanup
         for idx in range(proj_count):
-            proj_name = self.make_name(f"test-pag-{idx}")
+            proj_name = self.make_name(f"pag-{idx}")
             self.delete_project(cmd_env, proj_name)

--- a/tests/pytest/test_templates.py
+++ b/tests/pytest/test_templates.py
@@ -18,7 +18,7 @@ class TestTemplates(TestCase):
     def test_template_basic(self) -> None:
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = self.make_name("test-template-proj")
+        proj_name = self.make_name("template-proj")
         temp_name = "orig-template"  # templates are scoped to a project, so no need to "randomize"
         filename = self.make_name("basic-body") + ".txt"
         body = "Text with no params\n"
@@ -127,7 +127,7 @@ class TestTemplates(TestCase):
     def test_template_evaluate_environments(self) -> None:
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        proj_name = self.make_name("test-temp-eval")
+        proj_name = self.make_name("temp-eval")
         temp_name = "my_template"  # templates are scoped to a project, so no need to "randomize"
         env_a = self.make_name("env_eval_a")
         env_b = self.make_name("env_eval_b")
@@ -246,7 +246,7 @@ ANOTHER_PARAM=PARAM2
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-temp-times")
+        proj_name = self.make_name("temp-times")
         self.create_project(cmd_env, proj_name)
 
         ##################
@@ -265,7 +265,7 @@ ANOTHER_PARAM=PARAM2
         # create a template
         temp_name = "my-test-template"
         temp_cmd = base_cmd + f"--project '{proj_name}' template "
-        filename = self.make_name("test-temp-times") + ".txt"
+        filename = self.make_name("temp-times") + ".txt"
 
         body = """\
 # just a different template
@@ -343,11 +343,11 @@ this.is.a.template.value=PARAM1
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-temp-tag")
+        proj_name = self.make_name("temp-tag")
         self.create_project(cmd_env, proj_name)
 
         # add an environment (needed for tagging)
-        env_name = self.make_name("test-tag-temp")
+        env_name = self.make_name("tag-temp")
         self.create_environment(cmd_env, env_name)
 
         ##################
@@ -366,7 +366,7 @@ this.is.a.template.value=PARAM1
         # create a template
         temp_name = "my-test-template"
         temp_cmd = base_cmd + f"--project '{proj_name}' --env '{env_name}' template "
-        filename = self.make_name("test-temp-tag") + ".txt"
+        filename = self.make_name("temp-tag") + ".txt"
 
         body = """\
 # just a different template
@@ -450,7 +450,7 @@ this.is.a.template.value=PARAM1
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-temp-hist")
+        proj_name = self.make_name("temp-hist")
         self.create_project(cmd_env, proj_name)
 
         env_name = self.make_name("env-temp-hist")
@@ -568,7 +568,7 @@ this.is.a.template.value=PARAM1
         cmd_env = self.get_cmd_env()
 
         # add a new project
-        proj_name = self.make_name("test-template-diff")
+        proj_name = self.make_name("template-diff")
         self.create_project(cmd_env, proj_name)
 
         # add a couple environments
@@ -888,7 +888,7 @@ PARAMETER={{{{{param1}}}}}
         body1 = "nothing to evaluate here"
         self.write_file(filename, body1)
 
-        proj_name = self.make_name("test-temp-ref-param")
+        proj_name = self.make_name("temp-ref-param")
         self.create_project(cmd_env, proj_name)
 
         # create a simple template with nothing to be evaluated
@@ -958,7 +958,7 @@ PARAMETER={{{{{param1}}}}}
         body1 = "nothing to evaluate here"
         self.write_file(filename, body1)
 
-        proj_name = self.make_name("test-temp-paged")
+        proj_name = self.make_name("temp-paged")
         self.create_project(cmd_env, proj_name)
 
         sub_cmd = base_cmd + f"--project '{proj_name}' template "

--- a/tests/pytest/test_timing.py
+++ b/tests/pytest/test_timing.py
@@ -117,7 +117,7 @@ class TestTiming(TestCase):
 
     def test_timing_secrets(self) -> None:
         cmd_env = self.get_cmd_env()
-        proj_name = self.make_name("test-timing-secrets")
+        proj_name = self.make_name("timing-secrets")
         self.create_project(cmd_env, proj_name)
 
         timing = self._parameter_create_timing(proj_name, self.param_count, True)
@@ -129,7 +129,7 @@ class TestTiming(TestCase):
 
     def test_timing_params(self) -> None:
         cmd_env = self.get_cmd_env()
-        proj_name = self.make_name("test-timing-params")
+        proj_name = self.make_name("timing-params")
         self.create_project(cmd_env, proj_name)
 
         timing = self._parameter_create_timing(proj_name, self.param_count, False)
@@ -142,7 +142,7 @@ class TestTiming(TestCase):
     def test_timing_template(self) -> None:
         cmd_env = self.get_cmd_env()
         base_cmd = self.get_cli_base_cmd()
-        proj_name = self.make_name("test-timing-template")
+        proj_name = self.make_name("timing-template")
         self.create_project(cmd_env, proj_name)
         env_name = self.make_name("template-timing-env")
         self.create_environment(cmd_env, env_name)

--- a/tests/pytest/test_types.py
+++ b/tests/pytest/test_types.py
@@ -16,7 +16,7 @@ class TestParameterTypes(TestCase):
         # verify `type_name` does not yet exist
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        type_name = self.make_name("test-type-name")
+        type_name = self.make_name("type-name")
         sub_cmd = base_cmd + "types "
         result = self.run_cli(cmd_env, sub_cmd + "ls -v")
         self.assertResultSuccess(result)
@@ -45,7 +45,7 @@ class TestParameterTypes(TestCase):
 
         # rename
         orig_name = type_name
-        type_name = self.make_name("test-type-rename")
+        type_name = self.make_name("type-rename")
         result = self.run_cli(cmd_env, sub_cmd + f"set {orig_name} --rename \"{type_name}\"")
         self.assertResultSuccess(result)
         self.assertIn(f"Updated parameter type '{type_name}'", result.out())
@@ -149,14 +149,14 @@ class TestParameterTypes(TestCase):
         type_count = page_size + 1
 
         for idx in range(type_count):
-            type_name = self.make_name(f"test-pag-{idx}")
+            type_name = self.make_name(f"pag-{idx}")
             self.create_type(cmd_env, type_name)
 
         self.assertPaginated(cmd_env, base_cmd + "type ls", "/types/?")
 
         # cleanup
         for idx in range(type_count):
-            type_name = self.make_name(f"test-pag-{idx}")
+            type_name = self.make_name(f"pag-{idx}")
             self.delete_type(cmd_env, type_name)
 
     def test_type_integers(self):
@@ -174,7 +174,7 @@ class TestParameterTypes(TestCase):
         ###################
         # create project/parameters to use
         invalid_type_err = "Rule violation: Value is not of type"
-        proj_name = self.make_name("type-int-test")
+        proj_name = self.make_name("type-int")
         self.create_project(cmd_env, proj_name)
         param1 = "param1"
         param2 = "param2"
@@ -362,7 +362,7 @@ class TestParameterTypes(TestCase):
         ###################
         # create project/parameters to use
         invalid_type_err = "Rule violation: Value is not of type"
-        proj_name = self.make_name("type-bool-test")
+        proj_name = self.make_name("type-bool")
         self.create_project(cmd_env, proj_name)
         param1 = "param1"
         param2 = "param2"
@@ -456,7 +456,7 @@ class TestParameterTypes(TestCase):
 
         ###################
         # create project/parameters to use
-        proj_name = self.make_name("type-str-test")
+        proj_name = self.make_name("type-str")
         self.create_project(cmd_env, proj_name)
         param1 = "param1"
         param2 = "param2"

--- a/tests/pytest/test_users.py
+++ b/tests/pytest/test_users.py
@@ -19,7 +19,7 @@ class TestUsers(TestCase):
     def test_user_basic(self):
         base_cmd = self.get_cli_base_cmd()
         cmd_env = self.get_cmd_env()
-        user_name = self.make_name("test-user-name")
+        user_name = self.make_name("user-name")
         sub_cmd = base_cmd + "users "
         result = self.run_cli(cmd_env, sub_cmd + "ls -v -f csv")
         self.assertResultSuccess(result)
@@ -97,7 +97,7 @@ class TestUsers(TestCase):
         self.assertResultSuccess(result)
 
         # try creating a new owner
-        user2_name = self.make_name("test-another")
+        user2_name = self.make_name("another")
         cmd = base_cmd + f"--api-key '{api_key}' user set '{user2_name}'"
         result = self.run_cli(cmd_env, cmd)
         self.assertResultError(result, permission_err)
@@ -240,7 +240,7 @@ class TestUsers(TestCase):
 
         ################
         # user cannot invite above their paygrade
-        temp_user = self.make_name("test-invite-user")
+        temp_user = self.make_name("invite-user")
         api_key = self.add_user(cmd_env, temp_user, role="admin")
 
         # NOTE: must be admin or owner to create a user

--- a/tests/pytest/test_users.py
+++ b/tests/pytest/test_users.py
@@ -149,10 +149,7 @@ class TestUsers(TestCase):
         user_count = page_size + 1
         user_names = []
         for idx in range(user_count):
-            name = f"ci-user+{idx}"
-            job_id = self.make_name("")
-            if job_id:
-                name += f"-{job_id}"
+            name = self.make_name(f"ci-user+{idx}")
             user_names.append(name)
 
         for name in user_names:


### PR DESCRIPTION
* Bumping the default request timeout from 30 seconds to 90 seconds. this more closely matches the server-side timeout value
* Added a standard prefix for all names created in test data. Now all `make_name` calls add a `testcli` prefix to the generated names. This makes it easier to run the cleanup script against test data
* Added the new group CLI commands to cleanup and teardown actions in the test suite

Additionally, I've manually wiped most of the old CI test data on the staging environment. The environment was very bloated with lingering test data and causing some tests to timeout from too much data (mainly backup and import tests)  