### PR TITLE
add attempt number to job ID of CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         if: runner.os == 'macOs'
         run: |
           cd tests/pytest
-          python3 live_test.py --job-id "${OS}-${GITHUB_RUN_NUMBER}" --before ${{ env.PART_A_END }}
+          python3 live_test.py --job-id "${OS}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" --before ${{ env.PART_A_END }}
 
       - name: Integration Test - Part B
         env:
@@ -144,7 +144,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           cd tests/pytest
-          python3 live_test.py --job-id "${OS}-${GITHUB_RUN_NUMBER}" --after ${{ env.PART_A_END }} --before ${{ env.PART_C_START }}
+          python3 live_test.py --job-id "${OS}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" --after ${{ env.PART_A_END }} --before ${{ env.PART_C_START }}
 
       - name: Integration Test - Part C
         env:
@@ -152,4 +152,4 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           cd tests\pytest
-          py live_test.py --job-id "$ENV:OS-$ENV:GITHUB_RUN_NUMBER" --after ${{ env.PART_C_START }}
+          py live_test.py --job-id "$ENV:OS-$ENV:GITHUB_RUN_NUMBER-$ENV:GITHUB_RUN_ATTEMPT" --after ${{ env.PART_C_START }}

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -82,4 +82,4 @@ jobs:
           OS: ${{ runner.os }}
         run: |
           cd tests/pytest
-          python3 live_test.py --job-id "dev-${GITHUB_RUN_NUMBER}" ${{ env.CLOUDTRUTH_TEST_EXTRA_ARGS }} --filter ${{ env.CLOUDTRUTH_TEST_FILTER }}
+          python3 live_test.py --job-id "dev-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" ${{ env.CLOUDTRUTH_TEST_EXTRA_ARGS }} --filter ${{ env.CLOUDTRUTH_TEST_FILTER }}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -124,7 +124,7 @@ jobs:
         if: runner.os != 'Windows'
         run: |
           cd tests/pytest
-          python3 live_test.py --job-id "${OS}-${GITHUB_RUN_NUMBER}" --exclude backup
+          python3 live_test.py --job-id "${OS}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" --exclude backup
 
       - name: Integration Test - Windows
         env:
@@ -132,4 +132,4 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           cd tests\pytest
-          py live_test.py --job-id "$ENV:OS-$ENV:GITHUB_RUN_NUMBER" --exclude backup
+          py live_test.py --job-id "$ENV:OS-$ENV:GITHUB_RUN_NUMBER-$ENV:GITHUB_RUN_ATTEMPT" --exclude backup

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Integration Test
         run: |
           cd tests/pytest
-          python3 live_test.py --job-id "prod-${GITHUB_RUN_NUMBER}" --filter ${{ env.CLOUDTRUTH_TEST_FILTER }} --exclude backup
+          python3 live_test.py --job-id "prod-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" --filter ${{ env.CLOUDTRUTH_TEST_FILTER }} --exclude backup

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -40,4 +40,4 @@ jobs:
       - name: Integration Test
         run: |
           cd tests/pytest
-          python3 live_test.py --job-id "stage-${GITHUB_RUN_NUMBER}" --filter ${{ env.CLOUDTRUTH_TEST_FILTER }} --exclude backup
+          python3 live_test.py --job-id "stage-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}" --filter ${{ env.CLOUDTRUTH_TEST_FILTER }} --exclude backup


### PR DESCRIPTION
this should prevent data collisions from re-running test workflows