### PR TITLE
Workflow actions updates part 1

### DIFF
--- a/.github/workflows/check-pre-release.yml
+++ b/.github/workflows/check-pre-release.yml
@@ -16,7 +16,7 @@ jobs:
       CT_TEST_VALUE: Speicla
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -51,7 +51,7 @@ jobs:
       CT_TEST_VALUE: Speicla
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -78,7 +78,7 @@ jobs:
       CT_TEST_VALUE: Speicla
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -121,7 +121,7 @@ jobs:
       CT_TEST_VALUE: Speicla
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -145,7 +145,7 @@ jobs:
       CT_TEST_VALUE: Speicla
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -196,7 +196,7 @@ jobs:
       CT_TEST_VALUE: Speicla
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: ShellCheck
         uses: ludeeus/action-shellcheck@master
@@ -75,7 +75,7 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -112,7 +112,7 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
         id: rust

--- a/.github/workflows/create-draft-release.yml
+++ b/.github/workflows/create-draft-release.yml
@@ -98,7 +98,7 @@ jobs:
           name: artifacts
           path: artifacts
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -369,7 +369,7 @@ jobs:
       CT_TEST_VALUE: Speicla
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -416,7 +416,7 @@ jobs:
       CT_TEST_VALUE: Speicla
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
@@ -455,7 +455,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v3
         with:
           name: artifacts
           path: artifacts
@@ -514,7 +514,7 @@ jobs:
         with:
           fetch-depth: 1
 
-      - uses: actions/download-artifact@v1
+      - uses: actions/download-artifact@v3
         with:
           name: artifacts
           path: artifacts

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -61,7 +61,7 @@ jobs:
       CLOUDTRUTH_TEST_COMPLETE_INTEGRATION_NAME: ct-stage-write@943604981792
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
         id: rust

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
         id: rust
@@ -69,7 +69,7 @@ jobs:
           override: true
           components: rustfmt, clippy
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/registry
@@ -100,7 +100,7 @@ jobs:
           - windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
         id: rust

--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -16,7 +16,7 @@ jobs:
       RUST_BACKTRACE: 1
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: CLI installation
         run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -22,7 +22,7 @@ jobs:
       CLOUDTRUTH_TEST_BASIC_BAD_INTEGRATION_NAME: my-missing-integration
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Rust
         id: rust


### PR DESCRIPTION
Node 12 deprecation action updates

still to do......
actions-rs/toolchain waiting on fix
nightly still will fail
mac error that I'll have to look into