### PR TITLE
fix issue with datetime format incompatibility with latest API server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ansi_term"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -261,14 +270,16 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.19"
+version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
 dependencies = [
- "libc",
+ "iana-time-zone",
+ "js-sys",
  "num-integer",
  "num-traits",
  "time",
+ "wasm-bindgen",
  "winapi 0.3.9",
 ]
 
@@ -368,6 +379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
+]
+
+[[package]]
 name = "color-eyre"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "cpufeatures"
@@ -559,6 +580,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "049bb91fb4aaf0e3c7efa6cd5ef877dbbbd15b39dad06d9948de4ec8a75761ea"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e599641dff337570f6aa9c304ecca92341d30bf72e1c50287869ed6a36615a6"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.62"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b49af8e551e84f85d6def97c42b8d93bc5bb0817cce96b56a472b1b19b5bfc2"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3894ad0c6d517cb5a4ce8ec20b37cd0ea31b480fe582a104c5db67ae21270853"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fa7e395dc1c001083c7eed28c8f0f0b5a225610f3b6284675f444af6fab86b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1002,6 +1067,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+dependencies = [
+ "cxx",
+ "cxx-build",
+]
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1108,9 +1197,18 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.98"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "linked-hash-map"
@@ -1878,6 +1976,12 @@ name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "scratch"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ clap = "2.33.3"
 aes-gcm = "0.9.2"
 base64 = "0.13.0"
 chacha20poly1305 = "0.8.0"
-chrono = "0.4.19"
+chrono = "0.4.23"
 clap = "2.33.3"
 cloudtruth-restapi = { path = "client" }
 color-eyre = "0.5"

--- a/integration-tests/test_parameters.py
+++ b/integration-tests/test_parameters.py
@@ -1573,7 +1573,7 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         ####################
         # negative cases with times before when the project was created
         timestamp = "3/24/2021"
-        no_project = "No HistoricalProject matches the given query"
+        no_project = "No ProjectLedger matches the given query"
         param_cmd = base_cmd + f"--project '{proj_name}' param "
         result = self.run_cli(cmd_env, param_cmd + f"ls -v --as-of '{timestamp}'")
         self.assertResultError(result, no_project)
@@ -1582,7 +1582,7 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         result = self.run_cli(cmd_env, param_cmd + f"env '{param1}' --as-of '{timestamp}'")
         self.assertResultError(result, no_project)
 
-        no_environment = "No HistoricalEnvironment matches the given query"
+        no_environment = "No EnvironmentLedger matches the given query"
         result = self.run_cli(cmd_env, param_cmd + f"export shell --as-of '{timestamp}'")
         self.assertResultError(result, no_environment)
 
@@ -2406,7 +2406,7 @@ Parameter,{env_a} ({modified_p2_a}),{env_b} ({modified_p2_b})
         result = self.run_cli(cmd_env, tag_set + f"--time '{timestamp}'")
         self.assertResultSuccess(result)
 
-        no_project = "No HistoricalProject matches the given query"
+        no_project = "No ProjectLedger matches the given query"
         param_cmd = base_cmd + f"--env '{env_name}' --project '{proj_name}' param "
         result = self.run_cli(cmd_env, param_cmd + f"ls -v --as-of '{tag_name}'")
         self.assertResultError(result, no_project)

--- a/integration-tests/test_templates.py
+++ b/integration-tests/test_templates.py
@@ -309,7 +309,7 @@ references = PARAM
 
         # this is before the project exists
         result = self.run_cli(cmd_env, get_cmd + "--as-of 2020-02-02")
-        self.assertResultError(result, "No HistoricalProject matches the given query")
+        self.assertResultError(result, "No ProjectLedger matches the given query")
 
         ##################
         # check preview
@@ -332,7 +332,7 @@ this.is.a.template.value=PARAM1
 
         # this is before the project exists
         result = self.run_cli(cmd_env, preview_cmd + "--as-of 2020-02-02")
-        self.assertResultError(result, "No HistoricalProject matches the given query")
+        self.assertResultError(result, "No ProjectLedger matches the given query")
 
         # cleanup
         self.delete_file(filename)
@@ -835,7 +835,7 @@ PARAMETER={{{{{param1}}}}}
         self.assertResultError(result, tag_err)
 
         # before the project exists
-        no_proj_err = "No HistoricalProject matches the given query"
+        no_proj_err = "No ProjectLedger matches the given query"
         result = self.run_cli(cmd_env, sub_cmd + f"difference '{temp_name}' --as-of 2021-01-20")
         self.assertResultError(result, no_proj_err)
 

--- a/integration-tests/testcase.py
+++ b/integration-tests/testcase.py
@@ -66,12 +66,18 @@ def get_cli_base_cmd() -> str:
 
     # leverage current structure... walk back up a maximum of 2 levels
     for _ in range(3):
-        possible_release = curr.parent / exec_path_release
-        if possible_release.exists():
-            return str(possible_release) + " "
         possible_debug = curr.parent / exec_path_debug
+        possible_release = curr.parent / exec_path_release
+        # prefer latest build if both exist
+        if possible_debug.exists() and possible_release.exists():
+            if os.path.getmtime(possible_debug) > os.path.getmtime(possible_release):
+                return str(possible_debug) + " "
+            else:
+                return str(possible_release) + " "
         if possible_debug.exists():
             return str(possible_debug) + " "
+        if possible_release.exists():
+            return str(possible_release) + " "
         curr = curr.parent
 
     # we failed to find this, so just use the "default".

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -1111,7 +1111,7 @@ mod tests {
         let updates = Updates {
             check: true,
             action: Some(Action::Error),
-            last_checked: Some(NaiveDate::from_ymd(2021, 1, 20)),
+            last_checked: Some(NaiveDate::from_ymd_opt(2021, 1, 20)).unwrap(),
             frequency: Some(Frequency::Monthly),
         };
 

--- a/src/config/update.rs
+++ b/src/config/update.rs
@@ -68,7 +68,8 @@ impl Updates {
         }
         let last = self
             .last_checked
-            .unwrap_or_else(|| NaiveDate::from_ymd(2021, 6, 1));
+            .or_else(|| NaiveDate::from_ymd_opt(2021, 6, 1))
+            .unwrap();
         let freq = self.frequency.unwrap_or_default();
         let delta = Duration::days(freq.days());
         last.checked_add_signed(delta)
@@ -116,24 +117,24 @@ mod tests {
         // bogus default that always triggers an update
         assert_eq!(
             update.next_update().unwrap(),
-            NaiveDate::from_ymd(2021, 6, 8)
+            NaiveDate::from_ymd_opt(2021, 6, 8).unwrap()
         );
 
         // change frequency and see differences
         update.frequency = Some(Frequency::Daily);
         assert_eq!(
             update.next_update().unwrap(),
-            NaiveDate::from_ymd(2021, 6, 2)
+            NaiveDate::from_ymd_opt(2021, 6, 2).unwrap()
         );
         update.frequency = Some(Frequency::Weekly);
         assert_eq!(
             update.next_update().unwrap(),
-            NaiveDate::from_ymd(2021, 6, 8)
+            NaiveDate::from_ymd_opt(2021, 6, 8).unwrap()
         );
         update.frequency = Some(Frequency::Monthly);
         assert_eq!(
             update.next_update().unwrap(),
-            NaiveDate::from_ymd(2021, 7, 1)
+            NaiveDate::from_ymd_opt(2021, 7, 1).unwrap()
         );
 
         // with checking disabled, a None is returned
@@ -142,21 +143,21 @@ mod tests {
         update.check = true;
 
         // different date with 31 days in the month (even in the future!)
-        update.last_checked = Some(NaiveDate::from_ymd(2050, 3, 1));
+        update.last_checked = Some(NaiveDate::from_ymd_opt(2050, 3, 1)).unwrap();
         update.frequency = Some(Frequency::Daily);
         assert_eq!(
             update.next_update().unwrap(),
-            NaiveDate::from_ymd(2050, 3, 2)
+            NaiveDate::from_ymd_opt(2050, 3, 2).unwrap()
         );
         update.frequency = Some(Frequency::Weekly);
         assert_eq!(
             update.next_update().unwrap(),
-            NaiveDate::from_ymd(2050, 3, 8)
+            NaiveDate::from_ymd_opt(2050, 3, 8).unwrap()
         );
         update.frequency = Some(Frequency::Monthly);
         assert_eq!(
             update.next_update().unwrap(),
-            NaiveDate::from_ymd(2050, 3, 31)
+            NaiveDate::from_ymd_opt(2050, 3, 31).unwrap()
         );
     }
 
@@ -201,7 +202,7 @@ mod tests {
         assert_eq!(update.frequency.unwrap(), Frequency::Daily);
         assert_eq!(
             update.last_checked.unwrap(),
-            NaiveDate::from_ymd(2021, 1, 1)
+            NaiveDate::from_ymd_opt(2021, 1, 1).unwrap()
         );
 
         let content = indoc!(
@@ -219,7 +220,7 @@ mod tests {
         assert_eq!(update.frequency.unwrap(), Frequency::Weekly);
         assert_eq!(
             update.last_checked.unwrap(),
-            NaiveDate::from_ymd(2050, 12, 31)
+            NaiveDate::from_ymd_opt(2050, 12, 31).unwrap()
         );
     }
 
@@ -231,7 +232,7 @@ mod tests {
         last_checked: DATE
         "#
         );
-        let expected = NaiveDate::from_ymd(2021, 4, 1);
+        let expected = NaiveDate::from_ymd_opt(2021, 4, 1).unwrap();
         for date in &["2021-04-01", "2021-4-1", "4-1-2021", "4/1/2021"] {
             let update: Updates = serde_yaml::from_str(&content.replace("DATE", date)).unwrap();
             assert_eq!(update.last_checked.unwrap(), expected);

--- a/src/database/templates.rs
+++ b/src/database/templates.rs
@@ -26,7 +26,7 @@ fn response_error(
                     env_name.unwrap_or_default().to_string(),
                     "".to_string(),
                 )
-            } else if msg.contains("No HistoricalEnvironment matches") {
+            } else if msg.contains("No EnvironmentLedger matches") {
                 TemplateError::EnvironmentMissing(
                     env_name.unwrap_or_default().to_string(),
                     " at specified time/tag".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ use crate::types::process_parameter_type_command;
 use crate::users::process_users_command;
 use crate::utils::{error_message, help_message, warning_message};
 use crate::versions::process_version_command;
-use chrono::{Utc};
+use chrono::Utc;
 use clap::ArgMatches;
 use color_eyre::eyre::Result;
 use std::io;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ use crate::types::process_parameter_type_command;
 use crate::users::process_users_command;
 use crate::utils::{error_message, help_message, warning_message};
 use crate::versions::process_version_command;
-use chrono::{Datelike, NaiveDate, Utc};
+use chrono::{Utc};
 use clap::ArgMatches;
 use color_eyre::eyre::Result;
 use std::io;
@@ -105,8 +105,7 @@ fn validate_config(config: &Config) -> Result<()> {
 fn check_updates(updates: &Updates) -> Result<()> {
     // NOTE: the next_update() returns None if the check is disabled...
     if let Some(next_update) = updates.next_update() {
-        let now = Utc::today();
-        let today = NaiveDate::from_ymd(now.year(), now.month(), now.day());
+        let today = Utc::now().date_naive();
         if today >= next_update {
             let latest_str = get_latest_version();
             let latest_ver = Version::from(&latest_str).unwrap();


### PR DESCRIPTION
the old format for `--as-of` option no longer works with the latest server API, so this changes the formatting to match what the server currently accepts.

also updated `chrono` dependency to clean up some of the datetime logic, fixed a few tests related to the issue, and fixed deprecation warnings from chrono