### PR TITLE
restore template history date and user

### DIFF
--- a/client/src/models/aws_integration.rs
+++ b/client/src/models/aws_integration.rs
@@ -51,8 +51,8 @@ pub struct AwsIntegration {
     #[serde(rename = "aws_enabled_services")]
     pub aws_enabled_services: Vec<crate::models::AwsServiceEnum>,
     /// This is a shared secret between the AWS Administrator who set up your IAM trust relationship and your CloudTruth AWS Integration.  CloudTruth will generate a random value for you to give to your AWS Administrator in order to create the necessary IAM role for proper access.
-    #[serde(rename = "aws_external_id", skip_serializing_if = "Option::is_none")]
-    pub aws_external_id: Option<String>,
+    #[serde(rename = "aws_external_id")]
+    pub aws_external_id: String,
     /// If present, this is the KMS Key Id that is used to push values.  This key must be accessible in the AWS account (it cannot be an ARN to a key in another AWS account).
     #[serde(rename = "aws_kms_key_id", skip_serializing_if = "Option::is_none")]
     pub aws_kms_key_id: Option<String>,
@@ -76,6 +76,7 @@ impl AwsIntegration {
         aws_account_id: String,
         aws_enabled_regions: Vec<crate::models::AwsRegionEnum>,
         aws_enabled_services: Vec<crate::models::AwsServiceEnum>,
+        aws_external_id: String,
         aws_role_name: String,
     ) -> AwsIntegration {
         AwsIntegration {
@@ -94,7 +95,7 @@ impl AwsIntegration {
             aws_account_id,
             aws_enabled_regions,
             aws_enabled_services,
-            aws_external_id: None,
+            aws_external_id,
             aws_kms_key_id: None,
             aws_role_name,
         }

--- a/client/src/models/features_response.rs
+++ b/client/src/models/features_response.rs
@@ -12,10 +12,26 @@
 pub struct FeaturesResponse {
     #[serde(rename = "self_hosted")]
     pub self_hosted: bool,
+    #[serde(rename = "aws_integration")]
+    pub aws_integration: bool,
+    #[serde(rename = "azure_integration")]
+    pub azure_integration: bool,
+    #[serde(rename = "github_integration")]
+    pub github_integration: bool,
 }
 
 impl FeaturesResponse {
-    pub fn new(self_hosted: bool) -> FeaturesResponse {
-        FeaturesResponse { self_hosted }
+    pub fn new(
+        self_hosted: bool,
+        aws_integration: bool,
+        azure_integration: bool,
+        github_integration: bool,
+    ) -> FeaturesResponse {
+        FeaturesResponse {
+            self_hosted,
+            aws_integration,
+            azure_integration,
+            github_integration,
+        }
     }
 }

--- a/integration-tests/test_templates.py
+++ b/integration-tests/test_templates.py
@@ -499,29 +499,31 @@ this.is.a.template.value=PARAM1
         result = self.run_cli(cmd_env, temp_cmd + f"set '{temp2}' -b '{filename}'")
         self.assertResultSuccess(result)
 
+        user = f"Service Account ({self.current_username(cmd_env)})"
+
         # get a complete history
         result = self.run_cli(cmd_env, temp_cmd + "history -f csv")
         self.assertResultSuccess(result)
-        self.assertIn("Action,Name,Changes", result.out())
-        self.assertIn(f"create,{temp1},", result.out())
+        self.assertIn("Date,User,Action,Name,Changes", result.out())
+        self.assertIn(f",{user},create,{temp1},", result.out())
         self.assertIn(body1a, result.out())
-        self.assertIn(f"update,{temp1},", result.out())
+        self.assertIn(f",{user},update,{temp1},", result.out())
         self.assertIn(body1b, result.out())
         self.assertIn(desc1, result.out())
-        self.assertIn(f"create,{temp2},", result.out())
+        self.assertIn(f",{user},create,{temp2},", result.out())
         self.assertIn(body2a, result.out())
-        self.assertIn(f"update,{temp2},", result.out())
+        self.assertIn(f",{user},update,{temp2},", result.out())
         self.assertIn(body2b, result.out())
 
         # get a focused history on just one
         result = self.run_cli(cmd_env, temp_cmd + f"history '{temp2}' -f csv")
         self.assertResultSuccess(result)
-        self.assertNotIn("Action,Name,Changes", result.out())
+        self.assertNotIn("Date,User,Action,Name,Changes", result.out())
         self.assertNotIn(temp1, result.out())
         self.assertNotIn(body1a, result.out())
         self.assertNotIn(body1b, result.out())
         self.assertNotIn(desc1, result.out())
-        self.assertIn("Action,Changes", result.out())  # drop Name since it is given
+        self.assertIn("Date,User,Action,Changes", result.out())  # drop Name since it is given
         self.assertIn(temp2, result.out())
         self.assertIn(body2a, result.out())
         self.assertIn(body2b, result.out())
@@ -549,9 +551,9 @@ this.is.a.template.value=PARAM1
         # see that the deleted show up in the full history
         result = self.run_cli(cmd_env, temp_cmd + "history -f csv")
         self.assertResultSuccess(result)
-        self.assertIn("Action,Name,Changes", result.out())
-        self.assertIn(f"delete,{temp1},", result.out())
-        self.assertIn(f"delete,{temp2},", result.out())
+        self.assertIn("Date,User,Action,Name,Changes", result.out())
+        self.assertIn(f",{user},delete,{temp1},", result.out())
+        self.assertIn(f",{user},delete,{temp2},", result.out())
 
         # now that it is deleted, see that we fail to resolve the template name
         result = self.run_cli(cmd_env, temp_cmd + f"history '{temp1}'")

--- a/openapi.json
+++ b/openapi.json
@@ -13622,10 +13622,8 @@
                     },
                     "aws_external_id": {
                         "type": "string",
-                        "description": "This is a shared secret between the AWS Administrator who set up your IAM trust relationship and your CloudTruth AWS Integration.  CloudTruth will generate a random value for you to give to your AWS Administrator in order to create the necessary IAM role for proper access.",
-                        "minLength": 2,
-                        "pattern": "^[\\w+=,.@:/\\-]*$",
-                        "maxLength": 1224
+                        "readOnly": true,
+                        "description": "This is a shared secret between the AWS Administrator who set up your IAM trust relationship and your CloudTruth AWS Integration.  CloudTruth will generate a random value for you to give to your AWS Administrator in order to create the necessary IAM role for proper access."
                     },
                     "aws_kms_key_id": {
                         "type": "string",
@@ -13646,6 +13644,7 @@
                     "aws_account_id",
                     "aws_enabled_regions",
                     "aws_enabled_services",
+                    "aws_external_id",
                     "aws_role_name",
                     "created_at",
                     "fqn",
@@ -15837,9 +15836,21 @@
                 "properties": {
                     "self_hosted": {
                         "type": "boolean"
+                    },
+                    "aws_integration": {
+                        "type": "boolean"
+                    },
+                    "azure_integration": {
+                        "type": "boolean"
+                    },
+                    "github_integration": {
+                        "type": "boolean"
                     }
                 },
                 "required": [
+                    "aws_integration",
+                    "azure_integration",
+                    "github_integration",
                     "self_hosted"
                 ]
             },
@@ -18797,10 +18808,8 @@
                     },
                     "aws_external_id": {
                         "type": "string",
-                        "description": "This is a shared secret between the AWS Administrator who set up your IAM trust relationship and your CloudTruth AWS Integration.  CloudTruth will generate a random value for you to give to your AWS Administrator in order to create the necessary IAM role for proper access.",
-                        "minLength": 2,
-                        "pattern": "^[\\w+=,.@:/\\-]*$",
-                        "maxLength": 1224
+                        "readOnly": true,
+                        "description": "This is a shared secret between the AWS Administrator who set up your IAM trust relationship and your CloudTruth AWS Integration.  CloudTruth will generate a random value for you to give to your AWS Administrator in order to create the necessary IAM role for proper access."
                     },
                     "aws_kms_key_id": {
                         "type": "string",

--- a/openapi.yml
+++ b/openapi.yml
@@ -8484,13 +8484,11 @@ components:
           description: The AWS services to integrate with.
         aws_external_id:
           type: string
+          readOnly: true
           description: This is a shared secret between the AWS Administrator who set
             up your IAM trust relationship and your CloudTruth AWS Integration.  CloudTruth
             will generate a random value for you to give to your AWS Administrator
             in order to create the necessary IAM role for proper access.
-          minLength: 2
-          pattern: ^[\w+=,.@:/\-]*$
-          maxLength: 1224
         aws_kms_key_id:
           type: string
           nullable: true
@@ -8513,6 +8511,7 @@ components:
       - aws_account_id
       - aws_enabled_regions
       - aws_enabled_services
+      - aws_external_id
       - aws_role_name
       - created_at
       - fqn
@@ -10432,7 +10431,16 @@ components:
       properties:
         self_hosted:
           type: boolean
+        aws_integration:
+          type: boolean
+        azure_integration:
+          type: boolean
+        github_integration:
+          type: boolean
       required:
+      - aws_integration
+      - azure_integration
+      - github_integration
       - self_hosted
     GeneratedPasswordResponse:
       type: object
@@ -12800,13 +12808,11 @@ components:
           description: The AWS services to integrate with.
         aws_external_id:
           type: string
+          readOnly: true
           description: This is a shared secret between the AWS Administrator who set
             up your IAM trust relationship and your CloudTruth AWS Integration.  CloudTruth
             will generate a random value for you to give to your AWS Administrator
             in order to create the necessary IAM role for proper access.
-          minLength: 2
-          pattern: ^[\w+=,.@:/\-]*$
-          maxLength: 1224
         aws_kms_key_id:
           type: string
           nullable: true

--- a/src/database/template_history.rs
+++ b/src/database/template_history.rs
@@ -8,6 +8,8 @@ pub struct TemplateHistory {
     pub description: String,
     pub body: String,
     pub change_type: HistoryAction,
+    pub modified_at: String,
+    pub user_name: String,
 }
 
 impl From<&TemplateTimelineEntry> for TemplateHistory {
@@ -19,6 +21,8 @@ impl From<&TemplateTimelineEntry> for TemplateHistory {
             description: api_template.description.clone().unwrap_or_default(),
             body: api_template.body.clone().unwrap_or_default(),
             change_type: HistoryAction::from(*api.history_type.clone().unwrap_or_default()),
+            modified_at: api.modified_at.clone().unwrap_or_default(),
+            user_name: api.modified_by.clone().unwrap_or_default(),
         }
     }
 }
@@ -29,6 +33,8 @@ impl TemplateHistory {
             "name" => self.name.clone(),
             "body" => self.body.clone(),
             "description" => self.description.clone(),
+            "modified_at" => self.modified_at.clone(),
+            "user_name" => self.user_name.clone(),
             x => format!("Unhandled property: {x}"),
         }
     }

--- a/src/database/templates.rs
+++ b/src/database/templates.rs
@@ -7,6 +7,7 @@ use cloudtruth_restapi::apis::Error::ResponseError;
 use cloudtruth_restapi::models::{
     PatchedTemplateUpdate, TemplateCreate, TemplatePreviewCreateRequest,
 };
+
 use std::result::Result;
 
 const NO_ORDERING: Option<&str> = None;

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -401,19 +401,27 @@ fn proc_template_history(
     if history.is_empty() {
         println!("No template history {modifier}in project '{proj_name}'.");
     } else {
-        let name_index = 1;
+        let name_index = 3;
         let mut table = Table::new("template-history");
-        let mut hdr: Vec<&str> = vec!["Action", "Changes"];
+        let mut hdr: Vec<&str> = vec!["Date", "User", "Action", "Changes"];
         if add_name {
             hdr.insert(name_index, "Name");
         }
         table.set_header(&hdr);
 
         for (index, entry) in history.iter().enumerate() {
+            // Looks for the earlier time than this... It relies on the reverse time order.
             let history_tail = &history[index + 1..];
-            let prev = history_tail.iter().find(|e| entry.get_id() == e.get_id());
+            let prev = history_tail
+                .iter()
+                .find(|e| entry.get_id() == e.get_id() && entry.modified_at > e.modified_at);
             let changes = get_changes(entry, prev, TEMPLATE_HISTORY_PROPERTIES);
-            let mut row = vec![entry.change_type.to_string(), changes.join("\n")];
+            let mut row = vec![
+                entry.modified_at.clone(),
+                entry.user_name.clone(),
+                entry.change_type.to_string(),
+                changes.join("\n"),
+            ];
             if add_name {
                 row.insert(name_index, entry.name.clone())
             }


### PR DESCRIPTION
This was temporarily removed but is now re-implemented. Field names have changed from `history_date` and `history_user` to `modified_at` and `modified_by` respectively. Also the user field has changed from being an ID to being either an email address for users or `Service Account (<NAME>)` for service accounts.