### PR TITLE
update Cargo.toml and CHANGELOG for 1.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.0 - 2023-02-16
+* Updates to API client for compatibility with the latest server release
+* Fixed various issues with the install scripts on some platforms and networks
+* Azure integrations now show up in `integrations list` #388
+* Removed tag usage stats from the tag commands as they are no longer used #409 
+* Fixed race condition in `projects list` on large data sets #410
+  
 # 1.1.8 - 2022-08-28
 * Added the `groups` subcommand for group management
 * Updated `actions pushes` commands with new options

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 # 1.2.0 - 2023-02-16
 * Updates to API client for compatibility with the latest server release
 * Fixed various issues with the install scripts on some platforms and networks
-* Azure integrations now show up in `integrations list` #388
-* Removed tag usage stats from the tag commands as they are no longer used #409 
-* Fixed race condition in `projects list` on large data sets #410
+* Azure integrations now show up in `integrations list` [#388](https://github.com/cloudtruth/cloudtruth-cli/pull/388)
+* Removed tag usage stats from the tag commands as they are no longer used [#409](https://github.com/cloudtruth/cloudtruth-cli/pull/409) 
+* Fixed race condition in `projects list` on large data sets [#410](https://github.com/cloudtruth/cloudtruth-cli/pull/410)
   
 # 1.1.8 - 2022-08-28
 * Added the `groups` subcommand for group management

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,7 +318,7 @@ dependencies = [
 
 [[package]]
 name = "cloudtruth"
-version = "1.1.9"
+version = "1.2.0"
 dependencies = [
  "aes-gcm",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cloudtruth"
-version = "1.1.9"
+version = "1.2.0"
 description = "A command-line interface to the CloudTruth configuration management service."
 authors = ["CloudTruth <support@cloudtruth.com>"]
 edition = "2021"

--- a/build/help.txt
+++ b/build/help.txt
@@ -1,4 +1,4 @@
-cloudtruth 1.1.9
+cloudtruth 1.2.0
 CloudTruth <support@cloudtruth.com>
 A command-line interface to the CloudTruth configuration management service.
 

--- a/build/templates/test-release/workflow-header.yaml
+++ b/build/templates/test-release/workflow-header.yaml
@@ -13,7 +13,7 @@ on:
       serverUrl:
         description: URL to the CloudTruth server (defaults to production)
         type: string
-        default: https://app.cloudtruth.io
+        default: https://api.cloudtruth.io
     secrets:
       CLOUDTRUTH_API_KEY:
         description: CloudTruth API Key


### PR DESCRIPTION
also fixes a leftover typo in one of the workflow templates. the fix was already in the workflow, but the template was not updated.