### PR TITLE
add ability for test cases to pass with REST debug logging enabled

### DIFF
--- a/integration-tests/live_test.py
+++ b/integration-tests/live_test.py
@@ -202,9 +202,7 @@ def debugTestRunner(enable_debug: bool, verbosity: int, failfast: bool):
             self.testCaseData[name].endtime = datetime.now()
 
     return unittest.TextTestRunner(
-        verbosity=verbosity,
-        failfast=failfast,
-        resultclass=DebugTestResult,
+        verbosity=verbosity, failfast=failfast, resultclass=DebugTestResult, stream=sys.stdout
     )
 
 

--- a/integration-tests/live_test.py
+++ b/integration-tests/live_test.py
@@ -16,7 +16,7 @@ from typing import List
 from typing import Optional
 
 from testcase import get_cli_base_cmd
-from testcase import CT_API_KEY, CT_URL, CT_PROFILE
+from testcase import CT_API_KEY, CT_URL, CT_PROFILE, CT_REST_DEBUG
 from testcase import CT_TEST_JOB_ID, CT_TEST_LOG_COMMANDS, CT_TEST_LOG_OUTPUT
 from testcase import CT_TEST_LOG_COMMANDS_ON_FAILURE, CT_TEST_LOG_OUTPUT_ON_FAILURE
 from testcase import CT_TEST_KNOWN_ISSUES
@@ -63,6 +63,7 @@ def parse_args(*args) -> argparse.Namespace:
         default=3,
         help="Unittest verbosity level",
     )
+    parser.add_argument("--rest-debug", dest="rest_debug", action="store_true", help="Enable REST debug logging")
     parser.add_argument("--pdb", dest="pdb", action="store_true", help="Open the debugger when a test fails")
 
     parser.add_argument("--debug", dest="debug", action="store_true", help="Equivalent of --pdb --failfast")
@@ -303,6 +304,8 @@ def live_test(*args):
         env[CT_API_KEY] = args.api_key
     if args.profile:
         env[CT_PROFILE] = args.profile
+    if args.rest_debug:
+        env[CT_REST_DEBUG] = "true"
     if args.log_all:
         args.log_commands = True
         args.log_output = True

--- a/integration-tests/testcase.py
+++ b/integration-tests/testcase.py
@@ -382,7 +382,8 @@ class TestCase(unittest.TestCase):
             command=cmd,
         )
 
-        ## Log outputs (TODO: may want to consider using TextTestRunners buffer option for log-on-failure behavior)
+        ## Log outputs
+        ## TODO: may want to consider using TextTestRunners buffer option for log-on-failure behavior)
         if self.log_output:
             if result.stdout:
                 print("\n".join(result.stdout))
@@ -394,16 +395,15 @@ class TestCase(unittest.TestCase):
             if result.stderr:
                 self._failure_logs.append("\n".join(result.stderr))
 
-        ## if stripping debug output, re-enable original CLOUDTRUTH_REST_DEBUGvalues if previously found and strip logs
-        ## from output. Do this after the logging steps above so that console has complete logs, but test cases have
-        ## stripped logs
-        ## NOTE: re.match caches compiled version of recent patterns. no need to re.compile
-
         if strip_rest_debug:
+            ## if stripping debug output, re-enable original CLOUDTRUTH_REST_DEBUG value if previously found
             if orig_rest_debug_value is not None:
                 env[CT_REST_DEBUG] = orig_rest_debug_value
             else:
                 del env[CT_REST_DEBUG]
+            ## now strip logs from output before returning. do this after the logging steps above so that console has
+            ## complete logs, but test cases have stripped logs
+            ## NOTE: re.match caches compiled version of recent patterns. no need to re.compile
             result.stdout = [
                 line for line in result.stdout if not re.match("^URL \\w+ .+? elapsed: [\\d\\.]+\\w+$", line)
             ]

--- a/integration-tests/testcase.py
+++ b/integration-tests/testcase.py
@@ -140,7 +140,7 @@ class TestCase(unittest.TestCase):
         self.log_commands_on_failure = int(os.environ.get(CT_TEST_LOG_COMMANDS_ON_FAILURE, "0"))
         self.log_output_on_failure = int(os.environ.get(CT_TEST_LOG_OUTPUT_ON_FAILURE, "0"))
         self.job_id = os.environ.get(CT_TEST_JOB_ID)
-        self.rest_debug = os.environ.get(CT_REST_DEBUG, "False").lower() in ("true", "1", "t")
+        self.rest_debug = os.environ.get(CT_REST_DEBUG, "False").lower() in ("true", "1", "y", "yes")
         self._failure_logs = None
         self._projects = None
         self._environments = None
@@ -257,7 +257,7 @@ class TestCase(unittest.TestCase):
         ## we should keep the debug logs in stdout for tests that explicitly assert on them (ex: test_timing.py),
         ## or if we should strip debug logs from stdout to prevent assertion failures in tests that are not
         ## expecting debug logs.
-        if env_copy.get(CT_REST_DEBUG):
+        if env_copy.get(CT_REST_DEBUG, "false").lower() in ("true", "1", "y", "yes"):
             del env_copy[CT_REST_DEBUG]
         return env_copy
 
@@ -370,7 +370,7 @@ class TestCase(unittest.TestCase):
         ## CLOUDTRUTH_REST_DEBUG variable from the local copy. this makes it possible to detect if a test case
         ## explicitly set it and thus wants the debug logs in its output
         orig_rest_debug_value = env.get(CT_REST_DEBUG)
-        strip_rest_debug = os.environ.get(CT_REST_DEBUG) and not orig_rest_debug_value
+        strip_rest_debug = self.rest_debug and not orig_rest_debug_value
         if strip_rest_debug:
             env[CT_REST_DEBUG] = "true"
 


### PR DESCRIPTION
debug logging output was causing test cases to fail on some assertions. this adds code to the test harness to hide debug lines from the test cases so that they continue to pass but the debug lines still get output to console.

this makes it possible to use the integration test runs to generate performance and profiling metrics