### PR TITLE
allow RUST_BACKTRACE to be configurable in CI tests

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -27,7 +27,7 @@ on:
         description: Alphanumeric snapshot string to add to end of RPM version.
         type: string
 env:
-  CI: true
+  # CI: true
   RELEASE_UPLOAD_URL: ${{ inputs.releaseUploadUrl }}
   RELEASE_TAG: ${{ inputs.releaseTag }}
   PACKAGE_VERSION: ${{ inputs.packageVersion }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ on:
         default: v0-cli-build
 
 env:
+  CI: true
   RUST_BACKTRACE: 1
 
 jobs:

--- a/.github/workflows/check-pre-release.yml
+++ b/.github/workflows/check-pre-release.yml
@@ -6,6 +6,9 @@ on:
 name: 'Check Pre-Release'
 run-name: 'Check Pre-Release ${{ github.event.release.tag_name }}'
 
+env:
+  CI: true
+
 jobs:
   test-release:
     name: Test Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,5 +53,6 @@ jobs:
       runsOn: ${{ matrix.os }}
       artifactId: cloudtruth-ci-${{ matrix.os }}
       testRunnerOptions: ${{ matrix.options }} --reports
+      rustBacktrace: "full"
     secrets: inherit
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,6 @@ jobs:
       runsOn: ${{ matrix.os }}
       artifactId: cloudtruth-ci-${{ matrix.os }}
       testRunnerOptions: ${{ matrix.options }} --reports
-      rustBacktrace: "full"
+      rustBacktrace: "1"
     secrets: inherit
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,6 +20,7 @@ on:
         default: v0-cli-lint
 env:
   CI: true
+
 jobs:
   lint:
     name: CLI Lint

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -114,9 +114,3 @@ jobs:
         with:
           event-type: nightly-release
           client-payload: '{"tagName": "${{ needs.create-release.outputs.tagName }}"}'
-
-      
-
-
-
-  

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -6,6 +6,9 @@ on:
   repository_dispatch:
     types: [nightly-release]
 
+env:
+  CI: true
+
 jobs:
   test-nightly:
     name: Nightly Test

--- a/.github/workflows/test-production.yml
+++ b/.github/workflows/test-production.yml
@@ -17,6 +17,9 @@ on:
         description: "Production API Key"
         required: true
 
+env:
+  CI: true
+
 jobs:
   test:
     name: CLI E2E Test (Production)

--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -18,6 +18,9 @@ on:
       CLOUDTRUTH_API_KEY:
         description: CloudTruth API Key
         required: true
+env:
+  CI: true
+
 jobs:
   matrix:
     name: Read Job Matrix

--- a/.github/workflows/test-staging.yml
+++ b/.github/workflows/test-staging.yml
@@ -18,6 +18,9 @@ on:
         description: The runner to run the workflow on
         type: string
         default: ubuntu-latest
+      rustBacktrace:
+        description: Value of the RUST_BACKTRACE variable (default no backtrace)
+        type: string
     secrets:
       CT_STAGING_CI_ADMIN_API_KEY:
         description: "Staging API Key"
@@ -27,7 +30,7 @@ env:
   CI: true
   # ID to append to test data to avoid name collisions
   JOB_ID: ${{github.repository_id}}-${{github.run_id}}-${{github.run_attempt}}-${{inputs.runsOn}}
-  RUST_BACKTRACE: 1
+  RUST_BACKTRACE: ${{ inputs.rustBacktrace }}
 
 jobs:
   test:


### PR DESCRIPTION
tests that run off of the nightly and staging releases do not have debug information, so logging backtraces by default is not useful and spams the test reports.

this change adds an input to the `test-staging` workflow to enable/disable backtraces, which is by default disabled. the CI tests enable this option to continue showing backtrace information.