### PR TITLE
move from_name method from TestResource to NameConstructors

### DIFF
--- a/crates/integration-test-harness/src/data/environment.rs
+++ b/crates/integration-test-harness/src/data/environment.rs
@@ -41,14 +41,16 @@ impl<'d, 'p> Environment<'d, 'p> {
     }
 }
 
+impl<'d, 'p> NameConstructors for Environment<'d, 'p> {
+    fn from_name<N: Into<Name>>(name: N) -> Self {
+        Self::new(name.into(), None, None)
+    }
+}
+
 impl<'d, 'p> TestResource for Environment<'d, 'p> {
     fn name(&self) -> &Name {
         &self.name
     }
-    fn from_name<N: Into<Name>>(name: N) -> Self {
-        Self::new(name.into(), None, None)
-    }
-
     fn create(&self) {
         let mut cmd = Command::new(cli_bin_path("cloudtruth"));
         cmd.args(["environments", "set", self.name.as_str()]);
@@ -88,25 +90,9 @@ pub struct EnvironmentBuilder<'d, 'p> {
 }
 
 impl<'d, 'p> NameConstructors for EnvironmentBuilder<'d, 'p> {
-    fn from_string<S: Into<String>>(name: S) -> Self {
+    fn from_name<N: Into<Name>>(name: N) -> Self {
         EnvironmentBuilder {
-            name: Name::from_string(name),
-            description: None,
-            parent: None,
-        }
-    }
-
-    fn generated() -> Self {
-        EnvironmentBuilder {
-            name: Name::generated(),
-            description: None,
-            parent: None,
-        }
-    }
-
-    fn with_prefix<S: AsRef<str>>(prefix: S) -> Self {
-        EnvironmentBuilder {
-            name: Name::with_prefix(prefix),
+            name: name.into(),
             description: None,
             parent: None,
         }

--- a/crates/integration-test-harness/src/data/name.rs
+++ b/crates/integration-test-harness/src/data/name.rs
@@ -18,23 +18,33 @@ pub struct Name(String);
 
 /// Trait for name constructors.
 ///
-/// A blanket implementation is provided for any types that implement
-/// TestResource so that newtype wrappers for specific entity
-/// types only need to implement those trait methods to have standardized constructor functions
-/// and the auto-delete behavior via the Drop implementation for Scoped.
-///
-/// See src/name/project.rs for an example of how this is done.
-pub trait NameConstructors {
+/// Default implementations for all other methods are provided as long as from_name is implemented.
+pub trait NameConstructors
+where
+    Self: Sized,
+{
+    /// Construct a test resource from an existing name.
+    fn from_name<N: Into<Name>>(name: N) -> Self;
+
     /// Construct a new name exactly from a given String.
-    fn from_string<S: Into<String>>(name: S) -> Self;
+    fn from_string<S: Into<String>>(string: S) -> Self {
+        Self::from_name(Name::from_string(string))
+    }
     /// Construct a new name that's automatically generated
-    fn generated() -> Self;
+    fn generated() -> Self {
+        Self::from_name(Name::generated())
+    }
     /// Construct a name that's automatically generated with a static prefix
-    fn with_prefix<S: AsRef<str>>(prefix: S) -> Self;
+    fn with_prefix<S: AsRef<str>>(prefix: S) -> Self {
+        Self::from_name(Name::with_prefix(prefix))
+    }
 }
 
 /// Name constructors
 impl NameConstructors for Name {
+    fn from_name<N: Into<Name>>(name: N) -> Self {
+        name.into()
+    }
     fn from_string<S: Into<String>>(name: S) -> Self {
         Self(name.into())
     }

--- a/crates/integration-test-harness/src/data/project.rs
+++ b/crates/integration-test-harness/src/data/project.rs
@@ -41,14 +41,16 @@ impl<'d, 'p> Project<'d, 'p> {
     }
 }
 
+impl<'d, 'p> NameConstructors for Project<'d, 'p> {
+    fn from_name<N: Into<Name>>(name: N) -> Self {
+        Self::new(name.into(), None, None)
+    }
+}
+
 impl<'d, 'p> TestResource for Project<'d, 'p> {
     fn name(&self) -> &Name {
         &self.name
     }
-    fn from_name<N: Into<Name>>(name: N) -> Self {
-        Self::new(name.into(), None, None)
-    }
-
     fn create(&self) {
         let mut cmd = Command::new(cli_bin_path("cloudtruth"));
         cmd.args(["projects", "set", self.name.as_str()]);
@@ -88,25 +90,9 @@ pub struct ProjectBuilder<'d, 'p> {
 }
 
 impl<'d, 'p> NameConstructors for ProjectBuilder<'d, 'p> {
-    fn from_string<S: Into<String>>(name: S) -> Self {
+    fn from_name<N: Into<Name>>(name: N) -> Self {
         ProjectBuilder {
-            name: Name::from_string(name),
-            description: None,
-            parent: None,
-        }
-    }
-
-    fn generated() -> Self {
-        ProjectBuilder {
-            name: Name::generated(),
-            description: None,
-            parent: None,
-        }
-    }
-
-    fn with_prefix<S: AsRef<str>>(prefix: S) -> Self {
-        ProjectBuilder {
-            name: Name::with_prefix(prefix),
+            name: name.into(),
             description: None,
             parent: None,
         }

--- a/crates/integration-test-harness/src/data/resource.rs
+++ b/crates/integration-test-harness/src/data/resource.rs
@@ -1,30 +1,12 @@
-use super::{Name, NameConstructors};
+use super::Name;
 
 /// Trait for test resources that have a name and can be created and deleted. Used by the Scoped type to initialize
 /// test data in CloudTruth
 pub trait TestResource {
     /// Access a reference to the Name of this resource
     fn name(&self) -> &Name;
-    /// Construct a test resource from a name
-    fn from_name<N: Into<Name>>(name: N) -> Self;
     /// Create the test resource on the server
     fn create(&self);
     /// Delete the test resource from the server
     fn delete(&self);
-}
-
-/// Blanket implementation of NameConstructors for types that implement TestResource
-impl<Resource> NameConstructors for Resource
-where
-    Resource: TestResource,
-{
-    fn from_string<S: Into<String>>(string: S) -> Self {
-        Self::from_name(Name::from_string(string))
-    }
-    fn generated() -> Self {
-        Self::from_name(Name::generated())
-    }
-    fn with_prefix<S: AsRef<str>>(prefix: S) -> Self {
-        Self::from_name(Name::with_prefix(prefix))
-    }
 }

--- a/crates/integration-test-harness/src/data/scope.rs
+++ b/crates/integration-test-harness/src/data/scope.rs
@@ -32,22 +32,10 @@ where
 /// Constructors for Scoped
 impl<R> NameConstructors for Scope<R>
 where
-    R: TestResource,
+    R: TestResource + NameConstructors,
 {
-    ///Generate custom name
-    fn from_string<S: Into<String>>(string: S) -> Self {
-        Self::new(R::from_string(string.into()))
-    }
-
-    fn generated() -> Self {
-        Scope::new(R::from_name(Name::generated()))
-    }
-
-    fn with_prefix<S>(prefix: S) -> Self
-    where
-        S: AsRef<str>,
-    {
-        Scope::new(R::from_name(Name::with_prefix(prefix)))
+    fn from_name<N: Into<Name>>(name: N) -> Self {
+        Self::new(R::from_name(name))
     }
 }
 


### PR DESCRIPTION
test harness improvement in preparation for templates, which can be a TestResource but can't be constructed from only a name (they need a body as well)