### PR TITLE
copy remaining python tests into Rust integration tests

### DIFF
--- a/tests/pytest/README.md
+++ b/tests/pytest/README.md
@@ -1,0 +1,83 @@
+CloudTruth CLI Integration Test
+===============================
+
+The CloudTruth CLI Integration, `live_test.py`, is a Python program designed to exercise the CLI and
+CloudTruth service.
+
+Sometimes the tests leave around remnants that can be cleaned up with `cleanup.py`. By default, it uses
+common filters to determine which items should be cleaned up, but the filters are an argument. Basically, the
+GitHub actions run the tests with a `--job-id` that puts the OS in the name, or something else that will 
+insure unique names in "global" items (e.g. projects, environments, users).
+
+Background
+----------
+
+The integration test uses Python unittest infrastructure to discover and run test files and cases.
+All the tests derive from the `testcase.py.TestCase` to provide a common set of interacting with 
+the CLI.
+
+There is an assumption that the user account exits, and has read/write access.
+
+No tests should rely on any projects or environments existing ahead of the test.  When looking at 
+project and environment lists, the code needs to be robust to not concern itself with other projects
+or environments that may exist in the account. All required projects and environments should be 
+created during the testcase -- they will be automatically deleted (assuming that they were created 
+with the `run_cli()` function).
+
+The intention is to allow multiple instances of each test to be running simultaneously in the CI 
+environment. To do this, a `--job-id <name>` is provided as a `live_test.py` argument.
+Internally, the test cases should use `make_name()` to append the job-id to the end of project and
+environment names.
+
+Developing
+----------
+
+New files should be added to the `pytest` directory with a `test_` prefix. 
+
+The runner will run the functions inside each TestCase that start with `test`.
+
+Breakpoints can be added to the code to check on values. However, it may also be useful just to
+`print()` values before trying to `self.assertEqual()` on the return.
+
+All new project, environment, user,  and action names should be passed through `make_name()` to insure 
+multiple test instances can be run concurrently. The `make_name()` appends the `--job-id` to the name
+to insure uniqueness.
+
+The `run_cli()` function returns a `Result` object. This needs to be checked, so a Makefile rule was
+put in to make sure each `run_cli()` result is checked with an `assertResult<Success|Warning|Error>()`. 
+
+Debugging
+---------
+
+While `breakpoint()`s are useful, it can be tedious to step through code after hitting a breakpoint.
+So, the `--pdb` option was added to allow for breaking into the debugger when the test  fails. Then,
+the parameters passed into the asserts can be examined.  The `--failfast` option can be used to stop
+after the first failure. The `--debug` option was added to do both pdb and failfast functionality 
+described above.
+
+The full integration suite may take several minutes to run. However, a `--filter <pattern>` argument
+can be used to filter the test cases based on the name -- this is very useful when working on a new
+test (so only that test gets run).  There is also a `--file <filename>` argument that can be used to
+limit the number of test cases run.
+
+Logging
+-------
+
+The logging in the test is just printed to the console.  The `--log-commands` option can be used to
+see the CLI commands that get run via `run_cli()`.  The `--log-output` option can be used to see the
+output from the CLI. 
+
+The logging options should not be used in the CI environment -- things get re-ordered and become 
+quite confusing.
+
+Other
+-----
+
+The API key and server URL can be specified as arguments, if you do not want them to use the current
+environment.
+
+Future
+------
+
+Some ideas for future enhancements:
+1. Add ability for `stdin` to be specified, so confirmation functions can be tested.

--- a/tests/pytest/live_test.py
+++ b/tests/pytest/live_test.py
@@ -1,0 +1,388 @@
+#!/usr/bin/env python3
+import argparse
+import dataclasses
+import inspect
+import os
+import pdb
+import subprocess
+import sys
+import traceback
+import unittest
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from testcase import get_cli_base_cmd
+from testcase import CT_API_KEY, CT_URL, CT_PROFILE, CT_REST_DEBUG
+from testcase import CT_TEST_JOB_ID, CT_TEST_LOG_COMMANDS, CT_TEST_LOG_OUTPUT
+from testcase import CT_TEST_LOG_COMMANDS_ON_FAILURE, CT_TEST_LOG_OUTPUT_ON_FAILURE
+from testcase import CT_TEST_KNOWN_ISSUES
+
+
+# NOTE: these constants are used to determine tag names
+ERROR = "error"
+FAILURE = "failure"
+SKIPPED = "skipped"
+SUCCESS = "success"
+
+
+@dataclasses.dataclass
+class TestCaseResults:
+    testname: str
+    classname: str
+    filename: str
+    line: int
+    result: Optional[str] = None
+    message: Optional[str] = None
+    starttime: Optional[datetime] = None
+    endtime: Optional[datetime] = None
+
+
+def parse_args(*args) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run the CloudTruth CLI tests")
+    parser.add_argument("-p", "--profile", type=str, help="CLI profile to use for tests")
+    parser.add_argument(
+        "-k",
+        "--api_key",
+        type=str,
+        help="CloudTruth API key for server GraphQL authorization",
+    )
+    parser.add_argument(
+        "-u",
+        "--url",
+        type=str,
+        help="CloudTruth server URL",
+    )
+    parser.add_argument(
+        "-v",
+        "--verbosity",
+        type=int,
+        default=3,
+        help="Unittest verbosity level",
+    )
+    parser.add_argument("--rest-debug", dest="rest_debug", action="store_true", help="Enable REST debug logging")
+    parser.add_argument("--pdb", dest="pdb", action="store_true", help="Open the debugger when a test fails")
+
+    parser.add_argument("--debug", dest="debug", action="store_true", help="Equivalent of --pdb --failfast")
+    parser.add_argument(
+        "--file",
+        dest="file_filter",
+        type=str,
+        default="test_*.py",
+        help="Filter the files run using the specified pattern",
+    )
+    parser.add_argument("--failfast", action="store_true", help="Stop the test on first error")
+    parser.add_argument(
+        "-lc", "--log-commands", dest="log_commands", action="store_true", help="Print the commands to stdout."
+    )
+    parser.add_argument(
+        "-lo", "--log-output", dest="log_output", action="store_true", help="Print the output to stdout."
+    )
+    parser.add_argument(
+        "-la", "--log-all", dest="log_all", action="store_true", help="Print the output and commands to stdout"
+    )
+    parser.add_argument(
+        "-lcf",
+        "--log-commands-on-failure",
+        dest="log_commands_on_failure",
+        action="store_true",
+        help="Print the commands to stdout when a test fails",
+    )
+    parser.add_argument(
+        "-lof",
+        "--log-output-on-failure",
+        dest="log_output_on_failure",
+        action="store_true",
+        help="Print the output to stdout when a test fails",
+    )
+    parser.add_argument(
+        "-laf",
+        "--log-all-on-failure",
+        dest="log_all_on_failure",
+        action="store_true",
+        help="Print the output and commands to stdout when a test fails",
+    )
+    parser.add_argument(
+        "--job-id",
+        type=str,
+        dest="job_id",
+        help="Job Identifier to use as a suffix on project and environment names (default: testcli)",
+    )
+    parser.add_argument(
+        "-f",
+        "--filter",
+        dest="test_filter",
+        nargs="+",
+        default=[],
+        help="Only include tests containing the provided string(s) in the name",
+    )
+    parser.add_argument(
+        "-l",
+        "--list",
+        dest="list_only",
+        action="store_true",
+        help="Only print the tests that will be run (without running them).",
+    )
+    parser.add_argument("--before", dest="before", help="Only run tests before the specified string")
+    parser.add_argument("--after", dest="after", help="Only run tests after the specified string")
+    parser.add_argument(
+        "--exclude",
+        dest="test_exclude",
+        nargs="+",
+        default=[],
+        help="Exclude tests containing the provided string(s) in the name",
+    )
+    parser.add_argument("-r", "--reports", dest="reports", action="store_true", help="Write summary report information")
+    parser.add_argument("--known-issues", dest="known_issues", action="store_true", help="don't skip known issues")
+    return parser.parse_args(*args)
+
+
+def error_message(tb: traceback, ae: AssertionError) -> str:
+    return "".join(traceback.format_tb(tb)) + "\n\nAssertion:\n" + str(ae)
+
+
+def name_from_test(test: unittest.case.TestCase) -> str:
+    return test._testMethodName
+
+
+def debugTestRunner(enable_debug: bool, verbosity: int, failfast: bool):
+    """Overload the TextTestRunner to conditionally drop into pdb on an error/failure."""
+
+    class DebugTestResult(unittest.TextTestResult):
+        def __init__(self, stream, descriptions, verbosity):
+            super().__init__(stream=stream, descriptions=descriptions, verbosity=verbosity)
+            self.testCaseData = {}
+
+        def addError(self, test: unittest.case.TestCase, err) -> None:
+            # called before tearDown()
+            traceback.print_exception(*err)
+            if enable_debug:
+                pdb.post_mortem(err[2])
+            name = name_from_test(test)
+            self.testCaseData[name].result = ERROR
+            self.testCaseData[name].message = error_message(err[2], err[1])
+            super().addError(test, err)
+
+        def addFailure(self, test: unittest.case.TestCase, err) -> None:
+            traceback.print_exception(*err)
+            if enable_debug:
+                pdb.post_mortem(err[2])
+            name = name_from_test(test)
+            self.testCaseData[name].result = FAILURE
+            self.testCaseData[name].message = error_message(err[2], err[1])
+            super().addFailure(test, err)
+
+        def addSuccess(self, test: unittest.case.TestCase) -> None:
+            name = name_from_test(test)
+            self.testCaseData[name].result = SUCCESS
+            super().addSuccess(test)
+
+        def addSkip(self, test: unittest.case.TestCase, reason: str) -> None:
+            name = name_from_test(test)
+            self.testCaseData[name].result = SKIPPED
+            self.testCaseData[name].message = reason
+            super().addSkip(test, reason)
+
+        def startTest(self, test: unittest.case.TestCase) -> None:
+            super().startTest(test)
+            topdir = Path(__file__).parent.absolute().as_posix() + "/"
+            name = name_from_test(test)
+            fullpath = inspect.getsourcefile(type(test))
+            _, line = inspect.getsourcelines(getattr(test, name))
+            filename = fullpath.replace(topdir, "")
+            classname = test.__module__ + "." + test.__class__.__name__
+            data = TestCaseResults(name, classname, filename, line, starttime=datetime.now())
+            self.testCaseData[name] = data
+
+        def stopTest(self, test: unittest.case.TestCase) -> None:
+            super().stopTest(test)
+            name = name_from_test(test)
+            self.testCaseData[name].endtime = datetime.now()
+
+    return unittest.TextTestRunner(
+        verbosity=verbosity, failfast=failfast, resultclass=DebugTestResult, stream=sys.stdout
+    )
+
+
+def count_result(items: List[TestCaseResults], result: str) -> int:
+    return len([x for x in items if x.result == result])
+
+
+def print_props(props: Dict) -> str:
+    return " ".join(f"{k}={v}" for k, v in props.items())
+
+
+def write_reports(results) -> None:
+    suites = {}
+    for item in results.testCaseData.values():
+        name = item.classname
+        entries = suites[name] if name in suites else []
+        entries.append(item)
+        suites[name] = entries
+
+    for classname, testcases in suites.items():
+        suite_props = {
+            "name": classname,
+            "tests": len(testcases),
+            "failures": count_result(testcases, FAILURE),
+            "errors": count_result(testcases, ERROR),
+            "skipped": count_result(testcases, SKIPPED),
+            "success": count_result(testcases, SUCCESS),
+            "filename": next(iter(testcases)).filename,  # just grab filename from the first item
+        }
+        print("Suite: " + print_props(suite_props))
+
+        for test in testcases:
+            delta = test.endtime - test.starttime
+            case_props = {
+                "name": test.testname,
+                # 'classname': test.classname,
+                # 'file': f"{test.filename}:{test.line}",
+                "line": test.line,
+                "timestamp": test.starttime.isoformat(),
+                "time": delta.total_seconds(),
+                "status": test.result,
+            }
+            print("    Case: " + print_props(case_props))
+
+
+def print_suite(suite):
+    if hasattr(suite, "__iter__"):
+        for x in suite:
+            print_suite(x)
+    elif hasattr(suite, "_testMethodName"):
+        name = getattr(suite, "_testMethodName")
+        print(f"{name}")
+    else:
+        print("invalid")
+
+
+def filter_suite(suite, func):
+    for testmodule in suite:
+        for testsuite in testmodule:
+            tests_to_remove = []
+            for index, testcase in enumerate(testsuite._tests):
+                if func(testcase):
+                    tests_to_remove.append(index)
+
+            # do this in reverse order, so index does not change
+            for index in reversed(tests_to_remove):
+                testsuite._tests.pop(index)
+    return suite
+
+
+def filter_before(suite, before: str):
+    def is_before(testcase: str) -> bool:
+        return testcase._testMethodName > before
+
+    return filter_suite(suite, is_before)
+
+
+def filter_after(suite, after: str):
+    def is_after(testcase: str) -> bool:
+        return testcase._testMethodName < after
+
+    return filter_suite(suite, is_after)
+
+
+def filter_exclude(suite, exclude: str):
+    def is_excluded(testcase: str) -> bool:
+        return exclude in testcase._testMethodName
+
+    return filter_suite(suite, is_excluded)
+
+
+def live_test(*args):
+    args = parse_args(*args)
+    env = os.environ
+    if args.url:
+        env[CT_URL] = args.url
+    if args.api_key:
+        env[CT_API_KEY] = args.api_key
+    if args.profile:
+        env[CT_PROFILE] = args.profile
+    if args.rest_debug:
+        env[CT_REST_DEBUG] = "true"
+    if args.log_all:
+        args.log_commands = True
+        args.log_output = True
+    if args.log_all_on_failure:
+        args.log_commands_on_failure = True
+        args.log_output_on_failure = True
+    env[CT_TEST_LOG_COMMANDS] = str(int(args.log_commands))
+    env[CT_TEST_LOG_OUTPUT] = str(int(args.log_output))
+    env[CT_TEST_LOG_COMMANDS_ON_FAILURE] = str(int(args.log_commands_on_failure))
+    env[CT_TEST_LOG_OUTPUT_ON_FAILURE] = str(int(args.log_output_on_failure))
+
+    if not args.job_id:
+        import uuid
+
+        args.job_id = f"local-{uuid.uuid4()}"
+    print(f"JOB_ID: {args.job_id}")
+    env[CT_TEST_JOB_ID] = args.job_id
+
+    if args.known_issues:
+        env[CT_TEST_KNOWN_ISSUES] = True
+
+    cli = get_cli_base_cmd()
+    print(f"CloudTruth command: {cli}")
+    subprocess.run(cli + "config current -x", shell=True)
+
+    # propagate the debug flags
+    if args.debug:
+        args.pdb = True
+        args.failfast = True
+
+    test_directory = "."
+    loader = unittest.TestLoader()
+    applied_filter = []
+    if args.file_filter:
+        applied_filter.append(f"file: {args.file_filter}")
+
+    if args.test_filter:
+        applied_filter.append(f"filters: {', '.join(args.test_filter)}")
+        loader.testNamePatterns = [f"*{_}*" for _ in args.test_filter]
+    suite = loader.discover(test_directory, pattern=args.file_filter)
+
+    if args.before:
+        applied_filter.append(f"before: {args.before}")
+        suite = filter_before(suite, args.before)
+
+    if args.after:
+        applied_filter.append(f"after: {args.after}")
+        suite = filter_after(suite, args.after)
+
+    if args.test_exclude:
+        applied_filter.append(f"excludes: {', '.join(args.test_exclude)}")
+        for ex in args.test_exclude:
+            suite = filter_exclude(suite, ex)
+
+    if suite.countTestCases() == 0:
+        # must be because of a filter or file filter
+        sep = "\n\t"
+        print(f"No tests matching:{sep}{sep.join(applied_filter)}")
+        return 3
+
+    if args.list_only:
+        print_suite(suite)
+        return 0
+
+    runner = debugTestRunner(enable_debug=args.pdb, verbosity=args.verbosity, failfast=args.failfast)
+    test_result = runner.run(suite)
+
+    if args.reports:
+        write_reports(test_result)
+
+    rval = 0
+    if len(test_result.errors):
+        rval += 1
+    if len(test_result.failures):
+        rval += 2
+    return rval
+
+
+if __name__ == "__main__":
+    sys.exit(live_test(sys.argv[1:]))

--- a/tests/pytest/test_backup.py
+++ b/tests/pytest/test_backup.py
@@ -1,0 +1,190 @@
+from testcase import TestCase
+from testcase import skip_known_issue
+
+
+class TestProjects(TestCase):
+    @skip_known_issue("SC-9666")
+    def test_backup_basic(self):
+        base_cmd = self.get_cli_base_cmd()
+        cmd_env = self.get_cmd_env()
+        backup_cmd = base_cmd + "backup "
+        snap_cmd = backup_cmd + "snapshot -y "
+
+        type1 = self.make_name("back-int")
+        type2 = self.make_name("back-str")
+        type1_max = "4096"
+        type1_min = "-511"
+        env_a = self.make_name("back-env_a")
+        env_b = self.make_name("back-env_b")
+        proj1 = self.make_name("back-proj1")
+        proj2 = self.make_name("back-proj2")
+        p2_max_len = "100"
+        p2_min_len = "10"
+        temp1 = "my_temp"
+        param1 = "my_param"
+        param2 = "another_param"
+        value1a = "1234"
+        value1b = "-42"
+        value2a = "sssssshhhhhh"
+        value2b = "be veeeewy qwiet"
+        body1 = f"This refers to {{{{ {param1} }}}}"
+
+        # create types with a couple rules
+        self.create_type(cmd_env, type1, parent="integer", extra=f"--max {type1_max} --min {type1_min}")
+        self.create_type(cmd_env, type2)
+
+        self.create_environment(cmd_env, env_a)
+        self.create_environment(cmd_env, env_b, parent=env_a)
+
+        self.create_project(cmd_env, proj1)
+        self.create_project(cmd_env, proj2, parent=proj1)
+
+        secret = True
+        self.set_param(cmd_env, proj1, param1, env=env_a, value=value1a, param_type=type1)
+        self.set_param(cmd_env, proj1, param1, env=env_b, value=value1b)
+        extra = f"--min-len {p2_min_len} --max-len {p2_max_len}"
+        self.set_param(cmd_env, proj2, param2, env=env_a, value=value2a, secret=secret, extra=extra)
+        self.set_param(cmd_env, proj2, param2, env=env_b, value=value2b)
+
+        self.set_template(cmd_env, proj1, temp1, body1)
+
+        result = self.run_cli(cmd_env, snap_cmd + "-f json")
+        self.assertResultSuccess(result)
+        # massaging to avoid using a real parser (and avoid issues on Windows)
+        modified = result.out()
+        modified = modified.replace(": null", ": None")
+        modified = modified.replace(": true", ": True")
+        modified = modified.replace(": false", ": False")
+        snapshot = eval(modified)
+
+        #############################
+        # types validation
+        cttypes = snapshot.get("types")
+        ct_type = cttypes.get(type1)
+        self.assertEqual(ct_type.get("name"), type1)
+        self.assertEqual(ct_type.get("parent"), "integer")
+        rules = ct_type.get("rules")
+        self.assertEqual(sorted(list(rules.keys())), ["max", "min"])
+        rule = rules.get("max")
+        self.assertEqual(rule.get("rule_type"), "max")
+        self.assertEqual(rule.get("constraint"), type1_max)
+        rule = rules.get("min")
+        self.assertEqual(rule.get("rule_type"), "min")
+        self.assertEqual(rule.get("constraint"), type1_min)
+
+        ct_type = cttypes.get(type2)
+        self.assertEqual(ct_type.get("name"), type2)
+        self.assertEqual(ct_type.get("parent"), "string")
+        rules = ct_type.get("rules")
+        self.assertEqual(list(rules.keys()), [])
+
+        #############################
+        # environment validation
+        environments = snapshot.get("environments")
+        env = environments.get(env_a)
+        self.assertEqual(env.get("name"), env_a)
+        self.assertIsNotNone(env.get("parent"))
+        env = environments.get(env_b)
+        self.assertEqual(env.get("name"), env_b)
+        self.assertEqual(env.get("parent"), env_a)
+
+        #############################
+        # project validation
+        projects = snapshot.get("projects")
+
+        proj = projects.get(proj1)
+        self.assertEqual(proj.get("name"), proj1)
+        self.assertEqual(proj.get("parent"), None)
+
+        templates = proj.get("templates")
+        self.assertEqual(sorted(list(templates.keys())), [temp1])
+        temp = templates.get(temp1)
+        self.assertEqual(temp.get("name"), temp1)
+        self.assertEqual(temp.get("text"), body1)
+
+        parameters = proj.get("parameters")
+        self.assertEqual(list(parameters.keys()), [param1])
+        param = parameters.get(param1)
+        self.assertEqual(param.get("name"), param1)
+        self.assertEqual(param.get("secret"), False)
+        self.assertEqual(param.get("param_type"), type1)
+        self.assertEqual(param.get("project"), proj1)
+        rules = param.get("rules")
+        self.assertEqual(sorted(list(rules.keys())), [])
+        values = param.get("values")
+        self.assertEqual(sorted(list(values.keys())), [env_a, env_b])
+        v = values.get(env_a)
+        self.assertEqual(v.get("environment"), env_a)
+        self.assertEqual(v.get("source"), env_a)
+        self.assertEqual(v.get("external"), None)
+        self.assertEqual(v.get("evaluated"), False)
+        self.assertEqual(v.get("value"), value1a)
+        v = values.get(env_b)
+        self.assertEqual(v.get("environment"), env_b)
+        self.assertEqual(v.get("source"), env_b)
+        self.assertEqual(v.get("external"), None)
+        self.assertEqual(v.get("evaluated"), False)
+        self.assertEqual(v.get("value"), value1b)
+
+        proj = projects.get(proj2)
+        self.assertEqual(proj.get("name"), proj2)
+        self.assertEqual(proj.get("parent"), proj1)
+
+        templates = proj.get("templates")
+        self.assertEqual(sorted(list(templates.keys())), [])
+
+        parameters = proj.get("parameters")
+        self.assertEqual(list(parameters.keys()), [param2])
+        param = parameters.get(param2)
+        self.assertEqual(param.get("name"), param2)
+        self.assertEqual(param.get("secret"), secret)
+        self.assertEqual(param.get("param_type"), "string")
+        self.assertEqual(param.get("project"), proj2)
+        rules = param.get("rules")
+        self.assertEqual(sorted(list(rules.keys())), ["max_len", "min_len"])
+        rule = rules.get("max_len")
+        self.assertEqual(rule.get("rule_type"), "max_len")
+        self.assertEqual(rule.get("constraint"), p2_max_len)
+        rule = rules.get("min_len")
+        self.assertEqual(rule.get("rule_type"), "min_len")
+        self.assertEqual(rule.get("constraint"), p2_min_len)
+        values = param.get("values")
+        self.assertEqual(sorted(list(values.keys())), [env_a, env_b])
+        v = values.get(env_a)
+        self.assertEqual(v.get("environment"), env_a)
+        self.assertEqual(v.get("source"), env_a)
+        self.assertEqual(v.get("external"), None)
+        self.assertEqual(v.get("evaluated"), False)
+        self.assertEqual(v.get("value"), value2a)
+        v = values.get(env_b)
+        self.assertEqual(v.get("environment"), env_b)
+        self.assertEqual(v.get("source"), env_b)
+        self.assertEqual(v.get("external"), None)
+        self.assertEqual(v.get("evaluated"), False)
+        self.assertEqual(v.get("value"), value2b)
+
+        #############################
+        # yaml and default (yaml) outputs
+        for extra in ["", "-f yaml"]:
+            result = self.run_cli(cmd_env, snap_cmd + extra)
+            self.assertResultSuccess(result)
+            text = result.out()
+            self.assertIn(f"{type1}:", text)
+            self.assertIn(f"{type2}:", text)
+            self.assertIn(f'constraint: "{type1_min}"', text)
+            self.assertIn(f'constraint: "{type1_max}"', text)
+
+            self.assertIn(f"{env_a}:", text)
+            self.assertIn(f"{env_b}:", text)
+            self.assertIn(f"parent: {env_a}", text)
+
+            self.assertIn(f"{proj1}:", text)
+            self.assertIn(f"{proj2}:", text)
+
+        # cleanup
+        self.delete_project(cmd_env, proj2)
+        self.delete_project(cmd_env, proj1)
+        self.delete_environment(cmd_env, env_b)
+        self.delete_environment(cmd_env, env_a)
+        self.delete_type(cmd_env, type2)
+        self.delete_type(cmd_env, type1)

--- a/tests/pytest/test_integrations.py
+++ b/tests/pytest/test_integrations.py
@@ -1,0 +1,490 @@
+import os
+import unittest
+
+from testcase import TestCase
+from testcase import PROP_NAME
+from testcase import PROP_TYPE
+from testcase import PROP_VALUE
+from testcase import find_by_prop
+from testcase import missing_any
+from urllib.parse import urlparse
+
+CT_BROKEN_PROJ = "CLOUDTRUTH_TEST_BROKEN_PROJECT"
+CT_BROKEN_TEMP = "CLOUDTRUTH_TEST_BROKEN_TEMPLATE"
+CT_BROKEN_PARAM1 = "CLOUDTRUTH_TEST_BROKEN_PARAM1"
+CT_BROKEN_PARAM2 = "CLOUDTRUTH_TEST_BROKEN_PARAM2"
+CT_BROKEN_PARAM3 = "CLOUDTRUTH_TEST_BROKEN_PARAM3"
+CT_BROKEN_PARAM4 = "CLOUDTRUTH_TEST_BROKEN_PARAM4"
+CT_BROKEN_VALUE1 = "CLOUDTRUTH_TEST_BROKEN_VALUE1"
+CT_BROKEN_VALUE2 = "CLOUDTRUTH_TEST_BROKEN_VALUE2"
+CT_BROKEN_VALUE3 = "CLOUDTRUTH_TEST_BROKEN_VALUE3"
+CT_BROKEN_FQN2 = "CLOUDTRUTH_TEST_BROKEN_FQN2"
+CT_BROKEN_FQN3 = "CLOUDTRUTH_TEST_BROKEN_FQN3"
+CT_BROKEN_JMES2 = "CLOUDTRUTH_TEST_BROKEN_JMES2"
+CT_BROKEN_JMES3 = "CLOUDTRUTH_TEST_BROKEN_JMES3"
+CT_BROKEN_RUN = [
+    CT_BROKEN_PROJ,
+    CT_BROKEN_TEMP,
+    CT_BROKEN_PARAM1,
+    CT_BROKEN_PARAM2,
+    CT_BROKEN_PARAM3,
+    CT_BROKEN_PARAM4,
+    CT_BROKEN_VALUE1,
+    CT_BROKEN_VALUE2,
+    CT_BROKEN_VALUE3,
+    CT_BROKEN_FQN2,
+    CT_BROKEN_FQN3,
+    CT_BROKEN_JMES2,
+    CT_BROKEN_JMES3,
+]
+
+CT_EXP_FQN = "CLOUDTRUTH_TEST_EXPLORE_FQN"
+CT_EXP_JMES = "CLOUDTRUTH_TEST_EXPLORE_JMES"
+CT_EXP_VALUE = "CLOUDTRUTH_TEST_EXPLORE_VALUE"
+CT_EXPLORE_RUN = [
+    CT_EXP_FQN,
+    CT_EXP_JMES,
+    CT_EXP_VALUE,
+]
+
+CT_PARAM_FQN = "CLOUDTRUTH_TEST_PARAMETERS_FQN"
+CT_PARAM_JMES = "CLOUDTRUTH_TEST_PARAMETERS_JMES"
+CT_PARAM_RUN = [
+    CT_PARAM_FQN,
+    CT_PARAM_JMES,
+]
+
+CT_TEMP_FQN = "CLOUDTRUTH_TEST_TEMPLATE_FQN"
+CT_TEMP_PARAM1 = "CLOUDTRUTH_TEST_TEMPLATE_PARAM1"
+CT_TEMP_RUN = [
+    CT_TEMP_FQN,
+    CT_TEMP_PARAM1,
+]
+
+CT_BASIC_INTEG_NAME = "CLOUDTRUTH_TEST_BASIC_INTEGRATION_NAME"
+CT_BASIC_BAD_INT_NAME = "CLOUDTRUTH_TEST_BASIC_BAD_INTEGRATION_NAME"
+CT_BASIC_RUN = [
+    CT_BASIC_INTEG_NAME,
+    CT_BASIC_BAD_INT_NAME,
+]
+
+
+class TestIntegrations(TestCase):
+    def test_integration_explore_errors(self):
+        base_cmd = self.get_cli_base_cmd()
+        exp_cmd = base_cmd + "integrations explore "
+        cmd_env = self.get_cmd_env()
+
+        # add a new project
+        proj_name = self.make_name("int-explore-errors")
+        self.create_project(cmd_env, proj_name)
+
+        # check that we get notification about no provider
+        fqn = "test://missing.provider/should-gets-warning"
+        result = self.run_cli(cmd_env, exp_cmd + f"-v '{fqn}'")
+        self.assertResultError(result, f"No integration provider available for `{fqn}`")
+
+        # check that we get notification about no provider
+        fqn = "github://missing.provider/should-gets-warning"
+        result = self.run_cli(cmd_env, exp_cmd + f"-v '{fqn}'")
+        self.assertResultError(result, f"No integration available for `{fqn}`")
+
+        # cleanup
+        self.delete_project(cmd_env, proj_name)
+
+    @unittest.skipIf(missing_any(CT_EXPLORE_RUN), "Need all CT_EXPLORE_RUN parameters")
+    def test_integration_explore_success(self):
+        base_cmd = self.get_cli_base_cmd()
+        cmd_env = self.get_cmd_env()
+
+        fqn = os.environ.get(CT_EXP_FQN)
+        jmes = os.environ.get(CT_EXP_JMES)
+        value = os.environ.get(CT_EXP_VALUE)
+        url = urlparse(fqn)
+        base_fqn = f"{url.scheme}://{url.netloc}"
+
+        # make sure we see the integration in the list
+        result = self.run_cli(cmd_env, base_cmd + "int ls")
+        self.assertResultSuccess(result)
+        self.assertIn(f"{url.hostname}", result.out())
+
+        # do it again with the CSV to see name and a baseline fqn
+        result = self.run_cli(cmd_env, base_cmd + "integ ls -v --format csv")
+        self.assertResultSuccess(result)
+        self.assertIn(f"{url.hostname},{base_fqn}/,", result.out())
+
+        # check that times are added
+        result = self.run_cli(cmd_env, base_cmd + "integ ls -v --format csv --show-times")
+        self.assertResultSuccess(result)
+        self.assertIn("Created At,Modified At", result.out())
+        self.assertIn(f"{url.hostname},{base_fqn}/,", result.out())
+
+        # now, walk the path
+        explore_cmd = base_cmd + "int ex -v -f csv "
+        path_parts = [_ for _ in url.path.replace("/", "", 1).split("/") if _]
+        explore_path = base_fqn
+        for name in path_parts:
+            expected = f"{name},{explore_path}/{name}"
+            result = self.run_cli(cmd_env, explore_cmd + f"'{explore_path}'")
+            self.assertResultSuccess(result)
+            self.assertIn(expected, result.out())
+
+            # update for next iteration
+            explore_path += "/" + name
+
+        # in the "final" pass, it should contain the JMES path
+        expected = f"  {{{{ {jmes} }}}},{fqn}"
+        result = self.run_cli(cmd_env, explore_cmd + f"'{explore_path}'")
+        self.assertResultSuccess(result)
+        self.assertIn(expected, result.out())
+
+        # verify that we get a warning when trying to display --raw for a file
+        result = self.run_cli(cmd_env, explore_cmd + f"'{base_fqn}' -r")
+        self.assertResultWarning(result, "Raw content only works for a single file")
+
+        # cannot verify output, but the --raw option should be successful (and nothing in stderr)
+        result = self.run_cli(cmd_env, explore_cmd + f"'{explore_path}' --raw")
+        self.assertResultSuccess(result)
+
+        # one more time with JMES path, showing the value
+        result = self.run_cli(cmd_env, explore_cmd + f"'{fqn}' -j '{jmes}' --raw")
+        self.assertResultSuccess(result)
+        self.assertIn(value, result.out())
+
+    @unittest.skipIf(missing_any(CT_PARAM_RUN), "Need all CT_PARAM_RUN parameters")
+    def test_integration_parameters(self):
+        base_cmd = self.get_cli_base_cmd()
+        cmd_env = self.get_cmd_env()
+        proj_name = self.make_name("int-params")
+        empty_msg = f"No parameters found in project {proj_name}"
+        param_cmd = base_cmd + f"--project '{proj_name}' param "
+        show_cmd = param_cmd + "list -vsf csv"
+        show_ext = show_cmd + " --external"
+
+        fqn = os.environ.get(CT_PARAM_FQN)
+        jmes = os.environ.get(CT_PARAM_JMES)
+
+        # add a new project
+        self.create_project(cmd_env, proj_name)
+
+        # check that there are no parameters
+        result = self.run_cli(cmd_env, show_cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(empty_msg, result.out())
+
+        ######################
+        # start with a boring internal value
+        param1 = "pi"
+        value1 = "3.14159"
+        result = self.run_cli(cmd_env, param_cmd + f"set {param1} -v {value1}")
+        self.assertResultSuccess(result)
+
+        result = self.run_cli(cmd_env, show_cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(f"{param1},{value1}", result.out())
+
+        # see there are not external parameters
+        result = self.run_cli(cmd_env, show_ext)
+        self.assertResultSuccess(result)
+        self.assertIn("No external parameters found in project", result.out())
+
+        ######################
+        # flip it to an external value
+        result = self.run_cli(cmd_env, param_cmd + f"set {param1} -f {fqn} -j {jmes}")
+        self.assertResultSuccess(result)
+        self.assertIn("Updated parameter", result.out())
+
+        result = self.run_cli(cmd_env, show_cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(f"{param1},", result.out())
+        self.assertNotIn(value1, result.out())
+
+        # see the external parameter
+        result = self.run_cli(cmd_env, show_ext)
+        self.assertResultSuccess(result)
+        expected = f"{param1},{fqn},{jmes}"
+        self.assertIn(expected, result.out())
+
+        ######################
+        # flip back to internal
+        value2 = "are_round"
+        result = self.run_cli(cmd_env, param_cmd + f"set {param1} -v {value2}")
+        self.assertResultSuccess(result)
+
+        result = self.run_cli(cmd_env, show_cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(f"{param1},{value2}", result.out())
+
+        # see there are not external parameters
+        result = self.run_cli(cmd_env, show_ext)
+        self.assertResultSuccess(result)
+        self.assertIn("No external parameters found in project", result.out())
+
+        ######################
+        # create a external value
+        param2 = "eulers"
+        result = self.run_cli(cmd_env, param_cmd + f"set {param2} -f {fqn} -j {jmes}")
+        self.assertResultSuccess(result)
+        self.assertIn("Set parameter", result.out())
+
+        result = self.run_cli(cmd_env, show_cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(f"{param1},{value2}", result.out())
+        self.assertIn(f"{param2},", result.out())
+        self.assertNotIn(value1, result.out())
+
+        # see the external parameter
+        result = self.run_cli(cmd_env, show_ext)
+        self.assertResultSuccess(result)
+        expected = f"{param2},{fqn},{jmes}"
+        self.assertIn(expected, result.out())
+
+        # param get shows the external parameter properties
+        result = self.run_cli(cmd_env, param_cmd + f"get '{param2}' --details")
+        self.assertResultSuccess(result)
+        self.assertIn(f"FQN: {fqn}", result.out())
+        self.assertIn(f"JMES-path: {jmes}", result.out())
+
+        ######################
+        # templates with external parameters
+        temp_cmd = base_cmd + f"--project '{proj_name}' template "
+        temp_name = "my-int-temp"
+        filename = "template.txt"
+        body = """\
+# this is a comment that references an external parameter
+PARAMETER_2 = PARAM2
+"""
+        self.write_file(filename, body.replace("PARAM2", f"{{{{{param2}}}}}"))
+        result = self.run_cli(cmd_env, temp_cmd + f"preview '{filename}'")
+        self.assertResultSuccess(result)
+        self.assertIn(body.replace("PARAM2\n", ""), result.out())  # evaluated to an unknown value
+
+        # create the template
+        result = self.run_cli(cmd_env, temp_cmd + f"set '{temp_name}' --body '{filename}'")
+        self.assertResultSuccess(result)
+
+        # get the evaluated template
+        result = self.run_cli(cmd_env, temp_cmd + f"get '{temp_name}'")
+        self.assertResultSuccess(result)
+        self.assertIn(body.replace("PARAM2\n", ""), result.out())  # evaluated to an unknown value
+
+        # cleanup
+        self.delete_file(filename)
+        self.delete_project(cmd_env, proj_name)
+
+    @unittest.skipIf(missing_any(CT_BROKEN_RUN), "Need all CT_BROKEN_RUN parameters")
+    def test_integration_broken(self):
+        # NOTE: this test is a bit different than the others because everything needs to exist
+        base_cmd = self.get_cli_base_cmd()
+        cmd_env = self.get_cmd_env()
+
+        proj_name = os.environ.get(CT_BROKEN_PROJ)
+        temp_name = os.environ.get(CT_BROKEN_TEMP)
+        param1 = os.environ.get(CT_BROKEN_PARAM1)
+        value1 = os.environ.get(CT_BROKEN_VALUE1)
+        param2 = os.environ.get(CT_BROKEN_PARAM2)
+        fqn2 = os.environ.get(CT_BROKEN_FQN2)
+        jmes2 = os.environ.get(CT_BROKEN_JMES2)
+        value2 = os.environ.get(CT_BROKEN_VALUE2)
+        param3 = os.environ.get(CT_BROKEN_PARAM3)
+        fqn3 = os.environ.get(CT_BROKEN_FQN3)
+        jmes3 = os.environ.get(CT_BROKEN_JMES3)
+        value3 = os.environ.get(CT_BROKEN_VALUE3)
+        param4 = self.make_name(os.environ.get(CT_BROKEN_PARAM4))
+
+        # make sure everything exists in the "correct" state
+        proj_cmd = base_cmd + f"--project {proj_name} "
+        result = self.run_cli(cmd_env, proj_cmd + "projects ls")
+        self.assertResultSuccess(result)
+        self.assertIn(proj_name, result.out())
+        result = self.run_cli(cmd_env, proj_cmd + "templates ls")
+        self.assertResultSuccess(result)
+        self.assertIn(temp_name, result.out())
+
+        ##########################
+        # verify the FQNs are not reachable
+        result = self.run_cli(cmd_env, base_cmd + f"int exp '{fqn2}' -j '{jmes2}' -r")
+        self.assertResultWarning(result, f"Nothing found for FQN '{fqn2}'")
+        result = self.run_cli(cmd_env, base_cmd + f"int exp '{fqn3}' -j '{jmes3}' -r")
+        self.assertResultWarning(result, f"Nothing found for FQN '{fqn3}'")
+
+        ##########################
+        # parameter checks
+        entries = self.get_cli_entries(cmd_env, proj_cmd + "param list -vsf json", "parameter")
+        entry = find_by_prop(entries, PROP_NAME, param1)[0]
+        self.assertEqual(entry.get(PROP_VALUE), value1)
+        entry = find_by_prop(entries, PROP_NAME, param2)[0]
+        self.assertEqual(entry.get(PROP_VALUE), value2)
+        entry = find_by_prop(entries, PROP_NAME, param3)[0]
+        self.assertEqual(entry.get(PROP_VALUE), value3)
+
+        # list external parameters with no values
+        result = self.run_cli(cmd_env, proj_cmd + "param list --external")
+        self.assertResultSuccess(result)
+        self.assertIn(param2, result.out())
+        self.assertIn(param3, result.out())
+
+        # list external parameters with FQN/JMES
+        result = self.run_cli(cmd_env, proj_cmd + "param list --external -vf csv")
+        self.assertResultSuccess(result)
+        self.assertIn(f"{param2},{fqn2},{jmes2}", result.out())
+        self.assertIn(f"{param3},{fqn3},{jmes3}", result.out())
+
+        # getting the broken parameter yields an empty value, and a warning
+        result = self.run_cli(cmd_env, proj_cmd + f"param get '{param2}'")
+        self.assertResultSuccess(result)
+        self.assertIn(value2, result.out())
+
+        result = self.run_cli(cmd_env, proj_cmd + f"param get '{param3}' -d")
+        self.assertResultSuccess(result)
+        self.assertIn(f"Value: {value3}", result.out())
+        self.assertIn(f"FQN: {fqn3}", result.out())
+        self.assertIn(f"JMES-path: {jmes3}", result.out())
+
+        # export will fail, and should provide details about what failed
+        result = self.run_cli(cmd_env, proj_cmd + "param export docker")
+        self.assertResultSuccess(result)
+        self.assertIn(f"{param1.upper()}={value1}", result.out())
+        self.assertIn(f"{param2.upper()}={value2}", result.out())
+        self.assertIn(f"{param3.upper()}={value3}", result.out())
+
+        # see that adding param4 with a reference to param2 is allowed -- does not rely on evaluation
+        value4 = f"{{{{{param2}}}}}"
+        result = self.run_cli(cmd_env, proj_cmd + f"param set '{param4}' -v '{value4}' -e true")
+        self.assertResultSuccess(result)
+
+        result = self.run_cli(cmd_env, proj_cmd + "param list -vsf csv")
+        self.assertResultSuccess(result)
+        self.assertIn(f"{param4},{value2}", result.out())
+
+        result = self.run_cli(cmd_env, proj_cmd + f"param del '{param4}' -y")
+        self.assertResultSuccess(result, "Removed")
+
+        # cannot assign with broken FQN
+        result = self.run_cli(cmd_env, proj_cmd + f"param set '{param4}' -f '{fqn2}' -j '{jmes2}'")
+        self.assertResultError(result, f"The external content of `{fqn2}` is not present")
+
+        ##########################
+        # template checks -- still works using "old" values
+
+        # make sure the template contains references (not iron-clad, but worth something)
+        result = self.run_cli(cmd_env, proj_cmd + f"template get '{temp_name}' --raw")
+        self.assertResultSuccess(result)
+        self.assertIn(param1, result.out())
+        self.assertIn(param2, result.out())
+        self.assertIn(param3, result.out())
+
+        # copy current body into a file
+        filename = "preview.txt"
+        self.write_file(filename, result.out())
+
+        result = self.run_cli(cmd_env, proj_cmd + f"template get '{temp_name}'")
+        self.assertResultSuccess(result)
+        self.assertIn(value1, result.out())
+        self.assertIn(value2, result.out())
+        self.assertIn(value3, result.out())
+
+        result = self.run_cli(cmd_env, proj_cmd + f"template validate '{temp_name}'")
+        self.assertResultSuccess(result)
+
+        result = self.run_cli(cmd_env, proj_cmd + f"template preview '{filename}'")
+        self.assertResultSuccess(result)
+        self.assertIn(value1, result.out())
+        self.assertIn(value2, result.out())
+        self.assertIn(value3, result.out())
+
+        # NOTE: do NOT delete the project!!!
+        self.delete_file(filename)
+
+    @unittest.skipIf(missing_any(CT_TEMP_RUN), "Need all CT_TEMP_RUN parameters")
+    def test_integration_external_template(self):
+        # in this test, we create a parameter (param1) that has an external reference to a template
+        # that references an internal parameter (param2)
+        base_cmd = self.get_cli_base_cmd()
+        cmd_env = self.get_cmd_env()
+
+        # add a new project
+        proj_name = self.make_name("int-ext-temp")
+        self.create_project(cmd_env, proj_name)
+        proj_cmd = base_cmd + f"--project '{proj_name}' "
+
+        temp_fqn = os.environ.get(CT_TEMP_FQN)
+        param1 = os.environ.get(CT_TEMP_PARAM1)
+        value1 = "this-is the param1 value"
+        param2 = "param-refs-ext-template"
+        self.set_param(cmd_env, proj_name, param1, value1)
+        self.set_param(cmd_env, proj_name, param2, evaluate=True, fqn=temp_fqn)
+
+        # see the evaluated template shows up
+        result = self.list_params(cmd_env, proj_name, fmt="json")
+        entries = eval(result.out()).get("parameter")
+        entry1 = [e for e in entries if e.get(PROP_NAME) == param1][0]
+        self.assertEqual(entry1.get(PROP_VALUE), value1)
+        self.assertEqual(entry1.get(PROP_TYPE), "internal")
+        entry2 = [e for e in entries if e.get(PROP_NAME) == param2][0]
+        self.assertIn(value1, entry2.get(PROP_VALUE))
+        self.assertEqual(entry2.get(PROP_TYPE), "external-evaluated")
+
+        result = self.run_cli(cmd_env, proj_cmd + f"param del -y '{param1}'")
+        self.assertResultSuccess(result)  # TODO: should be error due to being referenced??
+
+        # delete external parameter
+        result = self.run_cli(cmd_env, proj_cmd + f"param del -y '{param2}'")
+        self.assertResultSuccess(result)
+
+        result = self.run_cli(cmd_env, proj_cmd + f"param del -y '{param1}'")
+        self.assertResultSuccess(result)
+        self.assertIn("Did not find parameter", result.out())  # TODO: message goes away
+
+        # attempt adding in other order -- adding external template with broken references
+        eval_err = "Evaluation error: Template contains references that do not exist"
+        result = self.run_cli(cmd_env, proj_cmd + f"param set {param2} -f '{temp_fqn}' -e true")
+        self.assertResultError(result, eval_err)
+        self.assertIn(param1, result.err())
+
+        # cleanup
+        self.delete_project(cmd_env, proj_name)
+
+    @unittest.skipIf(missing_any(CT_BASIC_RUN), "Need all CT_BASIC_RUN parameters")
+    def test_integration_basic(self):
+        base_cmd = self.get_cli_base_cmd()
+        cmd_env = self.get_cmd_env()
+
+        integ_name = os.environ.get(CT_BASIC_INTEG_NAME)
+        bad_int_name = os.environ.get(CT_BASIC_BAD_INT_NAME)
+
+        entries = self.get_cli_entries(cmd_env, base_cmd + "integrations list -f json", "integration")
+        entry = find_by_prop(entries, PROP_NAME, integ_name)
+        self.assertIsNotNone(entry)
+
+        ##########################
+        # test integration get/refresh
+        result = self.run_cli(cmd_env, base_cmd + f"integ get '{integ_name}'")
+        self.assertResultSuccess(result)
+        last_update = result.out_contains("Updated At:")
+        last_status = result.out_contains("Value:")
+
+        result = self.run_cli(cmd_env, base_cmd + f"int refresh '{integ_name}'")
+        self.assertResultSuccess(result)
+        self.assertIn(f"Refreshed integration '{integ_name}'", result.out())
+
+        result = self.run_cli(cmd_env, base_cmd + f"integ get '{integ_name}'")
+        self.assertResultSuccess(result)
+        next_update = result.out_contains("Updated At:")
+        next_status = result.out_contains("Value:")
+
+        # race condition with other tests, but the time does NOT get updated if it is already
+        # in a "checking" state
+        if "checking" not in last_status:
+            self.assertNotEqual((last_status, last_update), (next_status, next_update))
+
+        ##########################
+        # check error cases with
+        no_integration_msg = f"Integration '{bad_int_name}' not found"
+        result = self.run_cli(cmd_env, base_cmd + f"int get '{bad_int_name}'")
+        self.assertResultError(result, no_integration_msg)
+
+        result = self.run_cli(cmd_env, base_cmd + f"int refresh '{bad_int_name}'")
+        self.assertResultError(result, no_integration_msg)
+
+        # nothing to cleanup

--- a/tests/pytest/test_timing.py
+++ b/tests/pytest/test_timing.py
@@ -1,0 +1,238 @@
+import os
+
+from collections import OrderedDict
+from datetime import timedelta
+from typing import List
+
+from testcase import TestCase
+from testcase import CT_REST_DEBUG
+
+
+# some environment variables for test control (without file modification)
+CT_PERSIST = "CLOUDTRUTH_TEST_PERSIST"
+CT_PARAM_COUNT = "CLOUDTRUTH_TEST_PARAMETER_COUNT"
+CT_TEMPLATE_COUNT = "CLOUDTRUTH_TEST_TEMPLATE_COUNT"
+
+ENV_RESOLVE = "env-resolve"
+PROJ_RESOLVE = "proj-resolve"
+DEFAULT_PARAM_COUNT = 10
+DEFAULT_TEMPLATE_COUNT = 5
+
+
+def parse_time(value: str) -> int:
+    """
+    Parses the string into a integer representing the number of milliseconds.
+    """
+    if value.endswith("ms"):
+        return int(float(value.replace("ms", "")))
+    return int(float(value.replace("s", "")) * 1000)
+
+
+def parse_timing(timing_info: List[List[int]], lines: List[str]) -> List[List[int]]:
+    url_count = 0
+    for line in lines:
+        if not line.startswith("URL"):
+            continue
+
+        elapsed = line.split("elapsed: ")[-1]
+        curr_list = timing_info[url_count]
+        curr_list.append(parse_time(elapsed))
+        timing_info[url_count] = curr_list
+        url_count += 1
+
+    return timing_info
+
+
+def print_timing_info(test_name: str, timing_info: OrderedDict) -> None:
+    print("\n" + "=" * 40 + f"  {test_name} " + "=" * 40)
+    print("Times in milliseconds")
+    for operation, times in timing_info.items():
+        pretty = ", ".join([str(x) for x in times])
+        print(f"{operation}  ==>  [{pretty}]")
+
+
+def delta_to_msecs(delta: timedelta) -> int:
+    """Converts a timedelta into an integer number of milliseconds."""
+    return int(delta.seconds * 1000 + delta.microseconds / 1000)
+
+
+class TestTiming(TestCase):
+    def setUp(self) -> None:
+        self.leave_up = CT_PERSIST in os.environ
+        self.param_count = int(os.environ.get(CT_PARAM_COUNT) or DEFAULT_PARAM_COUNT)
+        self.param_prefix = "param"
+        self.template_count = int(os.environ.get(CT_TEMPLATE_COUNT) or DEFAULT_TEMPLATE_COUNT)
+        super().setUp()
+
+    def _param_name(self, index: int) -> str:
+        return f"{self.param_prefix}{index}"
+
+    def _parameter_create_timing(self, proj_name: str, num_values: int, secret: bool) -> OrderedDict:
+        base_cmd = self.get_cli_base_cmd()
+        get_cmd = base_cmd + f"--project '{proj_name}' param get "
+        list_cmd = base_cmd + f"--project '{proj_name}' param list -s -v"
+        cmd_env = self.get_cmd_env()
+        cmd_env[CT_REST_DEBUG] = "true"
+        create_timing = [
+            [],
+            [],
+            [],
+            [],
+            [],
+        ]
+        create_total = []
+        get_timing = [
+            [],
+            [],
+            [],
+        ]
+        get_total = []
+        list_timing = [
+            [],
+            [],
+            [],
+            [],
+        ]
+        list_total = []
+
+        for index in range(num_values):
+            result = self.set_param(cmd_env, proj_name, self._param_name(index), "abc123", secret=secret)
+            self.assertResultSuccess(result)
+            create_timing = parse_timing(create_timing, result.stdout)
+            create_total.append(delta_to_msecs(result.timediff))
+
+            result = self.run_cli(cmd_env, get_cmd + f"'{self._param_name(index)}'")
+            self.assertResultSuccess(result)
+            get_timing = parse_timing(get_timing, result.stdout)
+            get_total.append(delta_to_msecs(result.timediff))
+
+            result = self.run_cli(cmd_env, list_cmd)
+            self.assertResultSuccess(result)
+            list_timing = parse_timing(list_timing, result.stdout)
+            list_total.append(delta_to_msecs(result.timediff))
+
+        rval = OrderedDict()
+        rval["create-" + ENV_RESOLVE] = create_timing[0]
+        rval["create-" + PROJ_RESOLVE] = create_timing[1]
+        rval["create-param-get"] = create_timing[2]
+        rval["create-param-set"] = create_timing[3]
+        rval["create-value-set"] = create_timing[4]
+        rval["create-total"] = create_total
+
+        rval["get-" + ENV_RESOLVE] = get_timing[0]
+        rval["get-" + PROJ_RESOLVE] = get_timing[1]
+        rval["get-param-retrieve"] = get_timing[2]
+        rval["get-total"] = get_total
+
+        rval["list-" + ENV_RESOLVE] = list_timing[0]
+        rval["list-" + PROJ_RESOLVE] = list_timing[1]
+        rval["list-param-list"] = list_timing[2]
+        rval["list-total"] = list_total
+        return rval
+
+    def test_timing_secrets(self) -> None:
+        cmd_env = self.get_cmd_env()
+        proj_name = self.make_name("timing-secrets")
+        self.create_project(cmd_env, proj_name)
+
+        timing = self._parameter_create_timing(proj_name, self.param_count, True)
+        print_timing_info("timing-secrets", timing)
+
+        # cleanup
+        if not self.leave_up:
+            self.delete_project(cmd_env, proj_name)
+
+    def test_timing_params(self) -> None:
+        cmd_env = self.get_cmd_env()
+        proj_name = self.make_name("timing-params")
+        self.create_project(cmd_env, proj_name)
+
+        timing = self._parameter_create_timing(proj_name, self.param_count, False)
+        print_timing_info("timing-parameters", timing)
+
+        # cleanup
+        if not self.leave_up:
+            self.delete_project(cmd_env, proj_name)
+
+    def test_timing_template(self) -> None:
+        cmd_env = self.get_cmd_env()
+        base_cmd = self.get_cli_base_cmd()
+        proj_name = self.make_name("timing-template")
+        self.create_project(cmd_env, proj_name)
+        env_name = self.make_name("template-timing-env")
+        self.create_environment(cmd_env, env_name)
+
+        proj_cmd = base_cmd + f"--project '{proj_name}' --env '{env_name}' "
+
+        # create a couple parameters
+        param1 = "param1"
+        value1a = "first value"
+        param2 = "param2"
+        value2a = "another first"
+        self.set_param(cmd_env, proj_name, param1, value=value1a, env=env_name)
+        self.set_param(cmd_env, proj_name, param2, value=value2a, env=env_name)
+
+        filename = "temp-timing.txt"
+        body = """\
+PARAMETER1=PARAM1
+PARAMETER2=PARAM2
+"""
+        raw_body = body.replace("PARAM1", f"{{{{{param1}}}}}").replace("PARAM2", f"{{{{{param2}}}}}")
+        self.write_file(filename, raw_body)
+        temp_name = "timing-template"
+        result = self.run_cli(cmd_env, proj_cmd + f"template set '{temp_name}' -b {filename}")
+        self.assertResultSuccess(result)
+
+        # tag the environment
+        tag_name = "my-temp-timing-tag"
+        result = self.run_cli(cmd_env, base_cmd + f"env tag set '{env_name}' '{tag_name}'")
+        self.assertResultSuccess(result)
+
+        # update the values
+        value1b = "second value"
+        value2b = "first loser"
+        self.set_param(cmd_env, proj_name, param1, value=value1b, env=env_name)
+        self.set_param(cmd_env, proj_name, param2, value=value2b, env=env_name)
+
+        eval_body_a = body.replace("PARAM1", f"{value1a}").replace("PARAM2", f"{value2a}")
+        eval_body_b = body.replace("PARAM1", f"{value1b}").replace("PARAM2", f"{value2b}")
+
+        temp_get_raw_current = []
+        temp_get_current = []
+        temp_get_tag = []
+        temp_get_raw_tag = []
+
+        temp_get = proj_cmd + f"template get '{temp_name}' "
+
+        for _ in range(self.template_count):
+            result = self.run_cli(cmd_env, temp_get + f"--as-of '{tag_name}' --raw")
+            self.assertResultSuccess(result)
+            self.assertEqual(result.out(), raw_body)
+            temp_get_raw_current.append(delta_to_msecs(result.timediff))
+
+            result = self.run_cli(cmd_env, temp_get)
+            self.assertResultSuccess(result)
+            self.assertEqual(result.out(), eval_body_b)
+            temp_get_current.append(delta_to_msecs(result.timediff))
+
+            result = self.run_cli(cmd_env, temp_get + f"--as-of '{tag_name}'")
+            self.assertResultSuccess(result)
+            self.assertEqual(result.out(), eval_body_a)
+            temp_get_tag.append(delta_to_msecs(result.timediff))
+
+            result = self.run_cli(cmd_env, temp_get + f"--as-of '{tag_name}' --raw")
+            self.assertResultSuccess(result)
+            self.assertEqual(result.out(), raw_body)
+            temp_get_raw_tag.append(delta_to_msecs(result.timediff))
+
+        timing_info = OrderedDict()
+        timing_info["template-get-raw"] = temp_get_raw_current
+        timing_info["template-get-raw-tag"] = temp_get_raw_tag
+        timing_info["template-get-current"] = temp_get_current
+        timing_info["template-get-tag"] = temp_get_tag
+        print_timing_info("test_timing_template", timing_info)
+
+        # cleanup
+        self.delete_file(filename)
+        self.delete_environment(cmd_env, env_name)
+        self.delete_project(cmd_env, proj_name)

--- a/tests/pytest/testcase.py
+++ b/tests/pytest/testcase.py
@@ -1,0 +1,723 @@
+import dataclasses
+import os
+import shlex
+import subprocess
+import unittest
+import re
+from copy import deepcopy
+from datetime import datetime
+from datetime import timedelta
+from pathlib import Path
+from typing import Dict
+from typing import List
+from typing import Optional
+
+
+# These are environment variable names used by the application
+CT_API_KEY = "CLOUDTRUTH_API_KEY"
+CT_ENV = "CLOUDTRUTH_ENVIRONMENT"
+CT_PROFILE = "CLOUDTRUTH_PROFILE"
+CT_PROJ = "CLOUDTRUTH_PROJECT"
+CT_URL = "CLOUDTRUTH_SERVER_URL"
+CT_TIMEOUT = "CLOUDTRUTH_REQUEST_TIMEOUT"
+CT_REST_DEBUG = "CLOUDTRUTH_REST_DEBUG"
+CT_REST_SUCCESS = "CLOUDTRUTH_REST_SUCCESS"
+CT_REST_PAGE_SIZE = "CLOUDTRUTH_REST_PAGE_SIZE"
+
+DEFAULT_SERVER_URL = "https://api.cloudtruth.io"
+DEFAULT_ENV_NAME = "default"
+DEFAULT_PROFILE_NAME = "default"
+
+AUTO_DESCRIPTION = "Automated testing via live_test"
+TEST_PAGE_SIZE = 5
+
+CT_TEST_LOG_COMMANDS = "CT_LIVE_TEST_LOG_COMMANDS"
+CT_TEST_LOG_OUTPUT = "CT_LIVE_TEST_LOG_OUTPUT"
+CT_TEST_LOG_COMMANDS_ON_FAILURE = "CT_LIVE_TEST_LOG_COMMANDS_ON_FAILURE"
+CT_TEST_LOG_OUTPUT_ON_FAILURE = "CT_LIVE_TEST_LOG_OUTPUT_ON_FAILURE"
+CT_TEST_JOB_ID = "CT_LIVE_TEST_JOB_ID"
+CT_TEST_KNOWN_ISSUES = "CT_LIVE_TEST_KNOWN_ISSUES"
+
+SRC_ENV = "shell"
+SRC_ARG = "argument"
+SRC_PROFILE = "profile"
+SRC_DEFAULT = "default"
+
+REDACTED = "*****"
+DEFAULT_PARAM_VALUE = "-"
+
+# properties
+PROP_CREATED = "Created At"
+PROP_DESC = "Description"
+PROP_MODIFIED = "Modified At"
+PROP_NAME = "Name"
+PROP_RAW = "Raw"
+PROP_TYPE = "Type"
+PROP_VALUE = "Value"
+
+REGEX_REST_DEBUG = re.compile("^URL \\w+ .+? elapsed: [\\d\\.]+\\w+$")
+
+
+def get_cli_base_cmd() -> str:
+    """
+    This is a separate function that does not reference the `self._base_cmd' so it can be called
+    during __init__(). It returns the path to the executable (presumably) with the trailing
+    space to allow for easier consumption.
+    """
+    # walk back up looking for top of projects, and goto `target/debug/cloudtruth`
+    curr = Path(__file__).absolute()
+    exec_name = "cloudtruth.exe" if os.name == "nt" else "cloudtruth"
+    exec_path_release = Path("target") / "release" / exec_name
+    exec_path_debug = Path("target") / "debug" / exec_name
+
+    # leverage current structure... walk back up a maximum of 2 levels
+    for _ in range(3):
+        possible_debug = curr.parent / exec_path_debug
+        possible_release = curr.parent / exec_path_release
+        # print(possible_debug, possible_release, sep="\n")
+        # prefer latest build if both exist
+        if possible_debug.exists() and possible_release.exists():
+            if os.path.getmtime(possible_debug) > os.path.getmtime(possible_release):
+                return str(possible_debug) + " "
+            else:
+                return str(possible_release) + " "
+        if possible_debug.exists():
+            return str(possible_debug) + " "
+        if possible_release.exists():
+            return str(possible_release) + " "
+        curr = curr.parent
+
+    # we failed to find this, so just use the "default".
+    return exec_name + " "
+
+
+def find_by_prop(entries: List[Dict], prop_name: str, prop_value: str) -> List[Dict]:
+    return [e for e in entries if e.get(prop_name, None) == prop_value]
+
+
+def missing_any(env_var_names: List[str]) -> bool:
+    return not all([os.environ.get(x) for x in env_var_names])
+
+
+# decorator to mark a test as a known issue
+def skip_known_issue(msg: str):
+    return unittest.skipUnless(os.environ.get(CT_TEST_KNOWN_ISSUES), f"Known issue: {msg}")
+
+
+@dataclasses.dataclass
+class Result:
+    return_value: int = 0
+    stdout: List = dataclasses.field(default_factory=list)
+    stderr: List = dataclasses.field(default_factory=list)
+    timediff: timedelta = timedelta(0)
+    command: Optional[str] = None
+
+    def out(self) -> str:
+        return "\n".join(self.stdout)
+
+    def err(self) -> str:
+        return "\n".join(self.stderr)
+
+    def out_contains(self, needle: str) -> Optional[str]:
+        for line in self.stdout:
+            if needle in line:
+                return line
+        return None
+
+    def all(self) -> str:
+        return self.out() + "\n" + self.err()
+
+
+class TestCase(unittest.TestCase):
+    """
+    This extends the unittest.TestCase to add some basic functions
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._base_cmd = get_cli_base_cmd()
+        self.log_commands = int(os.environ.get(CT_TEST_LOG_COMMANDS, "0"))
+        self.log_output = int(os.environ.get(CT_TEST_LOG_OUTPUT, "0"))
+        self.log_commands_on_failure = int(os.environ.get(CT_TEST_LOG_COMMANDS_ON_FAILURE, "0"))
+        self.log_output_on_failure = int(os.environ.get(CT_TEST_LOG_OUTPUT_ON_FAILURE, "0"))
+        self.job_id = os.environ.get(CT_TEST_JOB_ID)
+        self.rest_debug = os.environ.get(CT_REST_DEBUG, "False").lower() in ("true", "1", "y", "yes")
+        self._failure_logs = None
+        self._projects = None
+        self._environments = None
+        self._users = None
+        self._invites = None
+        self._types = None
+        self._filenames = None
+        self._groups = None
+        super().__init__(*args, **kwargs)
+        self.maxDiff = None
+
+    def setUp(self) -> None:
+        # collects logs to display when/if the test case fails
+        self._failure_logs = list()
+        # start each test with empty sets for projects and environments
+        self._projects = list()
+        self._environments = list()
+        self._users = list()
+        self._invites = list()
+        self._types = list()
+        self._filenames = set()
+        self._groups = list()
+        super().setUp()
+
+    def tearDown(self) -> None:
+        # Report test failures
+        if not self.log_commands and self.log_commands_on_failure or not self.log_output and self.log_output_on_failure:
+            # Python 3.4 - 3.10
+            if hasattr(self._outcome, "errors"):
+                result = self.defaultTestResult()
+                self._feedErrorsToResult(result, self._outcome.errors)
+            # Python 3.11+
+            else:
+                result = self._outcome.result
+            success = all(test != self for test, _ in result.errors + result.failures)
+            if not success:
+                print()  # gives better reading output
+                print("\n".join(self._failure_logs))
+
+        # tear down any possibly lingering projects -- they should have been deleted in reverse
+        # order in case there are any children.
+        for proj in reversed(self._projects):
+            cmd = self._base_cmd + f'proj del "{proj}" --confirm'
+            subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        # tear down any possibly lingering environments -- they should have been deleted in reverse
+        # order in case there are any children.
+        for env in reversed(self._environments):
+            cmd = self._base_cmd + f'env del "{env}" --confirm'
+            subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        # delete any possibly lingering users
+        for usr in self._users:
+            cmd = self._base_cmd + f'user del --confirm "{usr}"'
+            subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        # delete any possibly lingering invitations
+        for email in self._invites:
+            cmd = self._base_cmd + f'user invitations del --confirm "{email}"'
+            subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        # tear down any possibly lingering types -- they should have been deleted in reverse
+        # order in case there are any children.
+        for typename in reversed(self._types):
+            cmd = self._base_cmd + f'type del "{typename}" --confirm'
+            subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        # remove any added files
+        for fname in self._filenames:
+            os.remove(fname)
+
+        # remove any added groups
+        for groupname in self._groups:
+            cmd = self._base_cmd + f'group del "{groupname}" --confirm'
+            subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+        super().tearDown()
+
+    def write_file(self, filename: str, content: str) -> None:
+        """
+        Utility to open set the filename content, and save the name in the list
+        for deletion.
+        """
+        self._filenames.add(filename)
+        file = open(filename, "w")
+        file.write(content)
+        file.close()
+
+    def delete_file(self, filename):
+        self._filenames.remove(filename)
+        os.remove(filename)
+
+    def make_name(self, name: str) -> str:
+        """
+        Adds the JOB_ID to the name if present, so multiple tests can run simultaneously.
+        """
+        if not self.job_id:
+            return name
+        return name + "-" + self.job_id
+
+    def get_cli_base_cmd(self) -> str:
+        """
+        Finds where to get the executable image from.
+        The result includes an extra space, and whatever other args may be necessary (e.g. api_key)
+        """
+        if not self._base_cmd:
+            self._base_cmd = get_cli_base_cmd()
+        return self._base_cmd
+
+    def get_cmd_env(self):
+        env_copy = deepcopy(os.environ)
+        ## temporarily unset the CLOUDTRUTH_REST_DEBUG environment variable if defined, so that
+        ## in run_cli_cmd() we can detect if a test explicitly set it. this allows us to determine if
+        ## we should keep the debug logs in stdout for tests that explicitly assert on them (ex: test_timing.py),
+        ## or if we should strip debug logs from stdout to prevent assertion failures in tests that are not
+        ## expecting debug logs.
+        if env_copy.get(CT_REST_DEBUG, "false").lower() in ("true", "1", "y", "yes"):
+            del env_copy[CT_REST_DEBUG]
+        return env_copy
+
+    def get_display_env_command(self) -> str:
+        if os.name == "nt":
+            return "SET"
+        return "printenv"
+
+    def assertResultSuccess(self, result: Result, success_msg: Optional[str] = None):
+        """
+        This is a convenience method to check the return code, and error output.
+        """
+        # check the error message is empty first, since it gives the most info about a failure
+        self.assertEqual(result.err(), "")
+        self.assertEqual(result.return_value, 0)
+        if success_msg:
+            self.assertIn(success_msg, result.out())
+
+    def assertResultWarning(self, result: Result, warn_msg: str):
+        """
+        This is a convenience method to check for successful CLI commands that emit a (partial) warning message
+        """
+        # check the message first, since it is more telling when the command fails
+        self.assertIn(warn_msg, result.err())
+        self.assertEqual(result.return_value, 0)
+
+    def assertResultError(self, result: Result, err_msg: str):
+        """
+        This is a convenience method to check for failed CLI commands with a specific (partial) error message
+        """
+        self.assertIn(err_msg, result.err())
+        self.assertNotEqual(result.return_value, 0)
+
+    def assertResultIn(self, result: Result, needle: str):
+        """
+        This is a convenience method to check for the needle in either stdout or stderr
+        """
+        self.assertIn(needle, result.all())
+
+    def assertPaginated(self, cmd_env, command: str, in_req: str, page_size: int = TEST_PAGE_SIZE):
+        """
+        Sets an artificially low CLOUDTRUTH_REST_PAGE_SIZE so we get paginated results for the
+        provided command, and checks the output includes the URLs that specify additional pages.
+        """
+        local_env = deepcopy(cmd_env)
+        local_env[CT_REST_DEBUG] = "true"
+        local_env[CT_REST_PAGE_SIZE] = str(page_size)
+        result = self.run_cli(local_env, command)
+        self.assertResultSuccess(result)
+        gets = [_ for _ in result.stdout if "URL GET" in _ and in_req in _]
+        size_search = f"page_size={page_size}"
+        size_spec = [_ for _ in gets if size_search in _]
+        self.assertGreaterEqual(len(size_spec), 2)  # should have at least 2 paginated requests
+        self.assertGreaterEqual(len([_ for _ in gets if "page=1" in _]), 1)
+        self.assertGreaterEqual(len([_ for _ in gets if "page=2" in _]), 1)
+
+    def run_cli(self, env: Dict[str, str], cmd: str) -> Result:  # noqa: C901
+        # WARNING: DOS prompt does not like the single quotes, so use double
+        cmd = cmd.replace("'", '"')
+
+        if self.log_commands:
+            print(cmd)
+        elif self.log_commands_on_failure:
+            self._failure_logs.append(cmd)
+
+        def _next_part(arg_list: List, key: str) -> str:
+            """Simple function to walk the 'arg_list' and find the item after the 'key'"""
+            for index, value in enumerate(arg_list):
+                if value == key:
+                    return arg_list[index + 1]
+            return None
+
+        # split the command args into something we can work with
+        args = shlex.split(cmd)
+        if "set" in args:
+            # if we're using any of our 'environments' aliases
+            if set(args) & set(["environments", "environment", "envs", "env", "e"]):
+                env_name = _next_part(args, "set")
+                if env_name and env_name not in self._environments:
+                    self._environments.append(env_name)
+                env_name = _next_part(args, "--rename") or _next_part(args, "-r")
+                if env_name and env_name not in self._environments:
+                    self._environments.append(env_name)
+            # if we're using any of our 'projects' aliases
+            elif set(args) & set(["projects", "project", "proj"]):
+                proj_name = _next_part(args, "set")
+                if proj_name and proj_name not in self._projects:
+                    self._projects.append(proj_name)
+                proj_name = _next_part(args, "--rename") or _next_part(args, "-r")
+                if proj_name and proj_name not in self._projects:
+                    self._projects.append(proj_name)
+            elif set(args) & set(["users", "user", "us"]):
+                user_name = _next_part(args, "set")
+                if user_name and user_name not in self._users:
+                    self._users.append(user_name)
+            elif set(args) & set(["invitations", "invites", "invite", "inv", "in"]):
+                email = _next_part(args, "set")
+                if email and email not in self._invites:
+                    self._invites.append(email)
+            elif set(args) & set(["parameter-types", "param-types", "param-type", "types", "type", "ty"]):
+                typename = _next_part(args, "set")
+                if typename and typename not in self._types:
+                    self._types.append(typename)
+            elif set(args) & set(["group", "grp", "gr", "g"]):
+                groupname = _next_part(args, "set")
+                if groupname and groupname not in self._groups:
+                    self._groups.append(groupname)
+
+        ## determine if we should strip REST debug logs from the command output. note that in get_cmd_env() we remove
+        ## CLOUDTRUTH_REST_DEBUG variable from the local copy. this makes it possible to detect if a test case
+        ## explicitly set it and thus wants the debug logs in its output
+        orig_rest_debug_value = env.get(CT_REST_DEBUG)
+        strip_rest_debug = self.rest_debug and not orig_rest_debug_value
+        if strip_rest_debug:
+            env[CT_REST_DEBUG] = "true"
+
+        start = datetime.now()
+        process = subprocess.run(cmd, env=env, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        delta = datetime.now() - start
+        result = Result(
+            return_value=process.returncode,
+            stdout=process.stdout.decode("us-ascii", errors="ignore").replace("\r", "").split("\n"),
+            stderr=process.stderr.decode("us-ascii", errors="ignore").replace("\r", "").split("\n"),
+            timediff=delta,
+            command=cmd,
+        )
+
+        ## Log outputs
+        ## TODO: may want to consider using TextTestRunners buffer option for log-on-failure behavior)
+        if self.log_output:
+            if result.stdout:
+                print("\n".join(result.stdout))
+            if result.stderr:
+                print("\n".join(result.stderr))
+        elif self.log_output_on_failure:
+            if result.stdout:
+                self._failure_logs.append("\n".join(result.stdout))
+            if result.stderr:
+                self._failure_logs.append("\n".join(result.stderr))
+        elif self.rest_debug:
+            debug_out = [line for line in result.stdout if re.match(REGEX_REST_DEBUG, line)]
+            if debug_out:
+                print("\n".join(debug_out))
+
+        if strip_rest_debug:
+            ## if stripping debug output, re-enable original CLOUDTRUTH_REST_DEBUG value if previously found
+            if orig_rest_debug_value is not None:
+                env[CT_REST_DEBUG] = orig_rest_debug_value
+            else:
+                del env[CT_REST_DEBUG]
+            ## now strip logs from output before returning. do this after the logging steps above so that console has
+            ## complete logs, but test cases have stripped logs
+            result.stdout = [line for line in result.stdout if not re.match(REGEX_REST_DEBUG, line)]
+
+        return result
+
+    def add_environment_for_cleanup(self, env_name: str) -> None:
+        if env_name not in self._environments:
+            self._environments.append(env_name)
+
+    def add_project_for_cleanup(self, proj_name: str):
+        if proj_name not in self._projects:
+            self._projects.append(proj_name)
+
+    def get_cli_entries(self, env: Dict[str, str], cmd: str, label: str) -> Optional[List[Dict]]:
+        result = self.run_cli(env, cmd)
+        self.assertResultSuccess(result)
+        if result.out().startswith("No "):
+            return []
+        return eval(result.out()).get(label)
+
+    def get_profile(self, cmd_env, prof_name: str) -> Optional[Dict]:
+        result = self.run_cli(cmd_env, self._base_cmd + "config prof list --values --format csv -s")
+        self.assertResultSuccess(result)
+        needle = f"{prof_name},"
+        for line in result.stdout:
+            if line.startswith(needle):
+                values = line.split(",")
+                return {
+                    "Name": values[0],
+                    "API": values[1],
+                    "Environment": values[2],
+                    "Project": values[3],
+                    "Description": values[4],
+                }
+        return None
+
+    def get_current_config(self, cmd_env, property_name: str) -> Optional[str]:
+        result = self.run_cli(cmd_env, self._base_cmd + "config curr --format json")
+        self.assertResultSuccess(result)
+        profile_props = eval(result.out()).get("profile", [])
+        for prop in profile_props:
+            if prop.get("Parameter") == property_name:
+                return prop.get("Value", None)
+        return None
+
+    def create_project(self, cmd_env, proj_name: str, parent: Optional[str] = None) -> Result:
+        proj_cmd = self._base_cmd + f"proj set '{proj_name}' -d '{AUTO_DESCRIPTION}' "
+        if parent:
+            proj_cmd += f"--parent '{parent}'"
+        result = self.run_cli(cmd_env, proj_cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(f"Created project '{proj_name}'", result.out())
+        return result
+
+    def delete_project(self, cmd_env, proj_name: str) -> Result:
+        result = self.run_cli(cmd_env, self._base_cmd + f"proj delete '{proj_name}' --confirm")
+        self.assertResultSuccess(result)
+        return result
+
+    def create_environment(self, cmd_env, env_name: str, parent: Optional[str] = None) -> Result:
+        cmd = self._base_cmd + f"env set '{env_name}' "
+        if parent:
+            cmd += f"-p '{parent}' "
+        cmd += f"-d '{AUTO_DESCRIPTION}'"
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(f"Created environment '{env_name}'", result.out())
+        return result
+
+    def delete_environment(self, cmd_env, env_name: str) -> Result:
+        result = self.run_cli(cmd_env, self._base_cmd + f"env del '{env_name}' --confirm")
+        self.assertResultSuccess(result)
+        return result
+
+    def create_type(
+        self,
+        cmd_env,
+        type_name: str,
+        parent: Optional[str] = None,
+        extra: Optional[str] = None,
+    ) -> Result:
+        type_cmd = self._base_cmd + f"param-type set '{type_name}' -d '{AUTO_DESCRIPTION}' "
+        if parent:
+            type_cmd += f"--parent '{parent}' "
+        if extra:
+            type_cmd += extra
+        result = self.run_cli(cmd_env, type_cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(f"Created parameter type '{type_name}'", result.out())
+        return result
+
+    def delete_type(self, cmd_env, type_name: str) -> Result:
+        result = self.run_cli(cmd_env, self._base_cmd + f"param-type delete '{type_name}' --confirm")
+        self.assertResultSuccess(result)
+        return result
+
+    def create_env_tag(
+        self, cmd_env, env_name: str, tag_name: str, desc: Optional[str] = None, time: Optional[str] = None
+    ) -> None:
+        cmd = self._base_cmd + f"env tag set '{env_name}' '{tag_name}' "
+        if desc:
+            cmd += f"--desc '{desc}'"
+        if time:
+            cmd += f"--time '{time}' "
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        self.assertIn("Created", result.out())
+
+    def delete_env_tag(self, cmd_env, env_name: str, tag_name: str) -> None:
+        cmd = self._base_cmd + f"env tag del '{env_name}' '{tag_name}' -y "
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        self.assertIn("Deleted", result.out())
+
+    def set_param(
+        self,
+        cmd_env,
+        proj: str,
+        name: str,
+        value: Optional[str] = None,
+        secret: Optional[bool] = None,
+        env: Optional[str] = None,
+        desc: Optional[str] = None,
+        param_type: Optional[str] = None,
+        fqn: Optional[str] = None,
+        jmes: Optional[str] = None,
+        evaluate: Optional[bool] = None,
+        extra: Optional[str] = None,
+    ) -> Result:
+        cmd = self._base_cmd + f"--project '{proj}' "
+        if env:
+            cmd += f"--env '{env}' "
+        cmd += f"param set '{name}' "
+        if value:
+            cmd += f"--value '{value}' "
+        if secret is not None:
+            cmd += f"--secret '{str(secret).lower()}' "
+        if desc:
+            cmd += f"--desc '{desc}' "
+        if param_type:
+            cmd += f"--type '{param_type}' "
+        if fqn:
+            cmd += f"--fqn '{fqn}' "
+        if jmes:
+            cmd += f"--jmes '{jmes}' "
+        if evaluate is not None:
+            cmd += f"--evaluate '{str(evaluate).lower()}' "
+        if extra:
+            cmd += extra
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        return result
+
+    def get_param(
+        self,
+        cmd_env,
+        proj: str,
+        name: str,
+        env: Optional[str] = None,
+        secrets: Optional[bool] = None,
+        as_of: Optional[str] = None,
+    ) -> Optional[Dict]:
+        cmd = self._base_cmd + f"--project '{proj}' "
+        if env:
+            cmd += f"--env '{env}' "
+        cmd += "param list --show-times --format json "
+        if as_of:
+            cmd += f"--as-of '{as_of}' "
+        if secrets:
+            cmd += "--secrets "
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        parameters = eval(result.out())
+        for item in parameters["parameter"]:
+            if item.get("Name") == name:
+                return item
+        return None
+
+    def unset_param(
+        self,
+        cmd_env,
+        proj: str,
+        name: str,
+        env: Optional[str] = None,
+    ) -> Result:
+        cmd = self._base_cmd + f"--project '{proj}' "
+        if env:
+            cmd += f"--env '{env}' "
+        cmd += f"param unset '{name}' "
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        return result
+
+    def delete_param(self, cmd_env, proj: str, name: str, env: Optional[str] = None) -> Result:
+        cmd = self._base_cmd + f"--project '{proj}' "
+        if env:
+            cmd += f"--env '{env}' "
+        cmd += f"param delete -y '{name}'"
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        return result
+
+    def verify_param(
+        self,
+        cmd_env,
+        proj: str,
+        name: str,
+        value: str,
+        env: Optional[str] = None,
+        as_of: Optional[str] = None,
+    ):
+        cmd = self._base_cmd + f"--project '{proj}' "
+        if env:
+            cmd += f"--env '{env}' "
+        # check the output using the 'get' command
+        cmd += f"param get '{name}' "
+        if as_of:
+            cmd += f"--as-of '{as_of}' "
+
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        self.assertIn(value, result.out())
+
+    def list_params(
+        self,
+        cmd_env,
+        proj: str,
+        env: Optional[str] = None,
+        show_values: bool = True,
+        secrets: bool = False,
+        fmt: Optional[str] = None,
+        as_of: Optional[str] = None,
+        show_times: bool = False,
+        show_rules: bool = False,
+        show_external: bool = False,
+        show_evaluated: bool = False,
+        show_parents: bool = False,
+        show_children: bool = False,
+    ) -> Result:
+        cmd = self._base_cmd + f"--project '{proj}' "
+        if env:
+            cmd += f"--env '{env}' "
+        cmd += "param ls "
+        if fmt:
+            cmd += f"-f {fmt} "
+        if as_of:
+            cmd += f"--as-of '{as_of}' "
+        if secrets:
+            cmd += "-s "
+        if show_values:
+            cmd += "-v "
+        if show_times:
+            cmd += "--show-times "
+        if show_rules:
+            cmd += "--rules "
+        if show_external:
+            cmd += "--external "
+        if show_evaluated:
+            cmd += "--evaluated "
+        if show_parents:
+            cmd += "--parents "
+        if show_children:
+            cmd += "--children "
+
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+        return result
+
+    def set_template(
+        self, cmd_env, proj: str, name: str, body: Optional[str] = None, description: Optional[str] = None
+    ) -> Result:
+        cmd = self._base_cmd + f"--project '{proj}' template set '{name}' "
+        filename = None
+        if body:
+            filename = "temp-set-template-body.txt"
+            self.write_file(filename, body)
+            cmd += f"-b '{filename}' "
+        if description:
+            cmd += f"-d '{description}' "
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+
+        if filename:
+            self.delete_file(filename)
+        return result
+
+    def delete_template(self, cmd_env, proj: str, name: str):
+        cmd = self._base_cmd + f"--project '{proj}' template del -y '{name}' "
+        result = self.run_cli(cmd_env, cmd)
+        self.assertResultSuccess(result)
+
+    def current_username(self, cmd_env) -> str:
+        result = self.run_cli(cmd_env, self._base_cmd + "config current -f json")
+        self.assertResultSuccess(result)
+        properties = eval(result.out()).get("profile")
+        entry = find_by_prop(properties, "Parameter", "User")[0]
+        return entry.get("Value")
+
+    # creates a new user and returns the API key
+    def add_user(self, cmd_env, user_name: str, role: str = "contrib") -> str:
+        result = self.run_cli(cmd_env, self._base_cmd + f"user set '{user_name}' --role '{role}'")
+        self.assertResultSuccess(result)
+        self.assertIn("Created service account", result.out())
+        if len(result.stdout) > 1:
+            # the api token is the second line
+            api_token = result.stdout[1]
+            return api_token
+        return None
+
+    def delete_user(self, cmd_env, user_name):
+        result = self.run_cli(cmd_env, self._base_cmd + f"user delete '{user_name}' -y")
+        self.assertResultSuccess(result)

--- a/tests/test_integrations.rs
+++ b/tests/test_integrations.rs
@@ -1,0 +1,18 @@
+use std::process::Command;
+
+macro_rules! pytest_dir {
+    () => {
+        concat!(env!("CARGO_MANIFEST_DIR"), "/tests/pytest")
+    };
+}
+
+#[test]
+fn test_integrations_pytest() -> std::io::Result<()> {
+    let mut handle = Command::new("python3")
+        .current_dir(pytest_dir!())
+        .args(["live_test.py", "--file", "test_integrations.py"])
+        .spawn()?;
+    let status = handle.wait()?;
+    assert!(status.success());
+    Ok(())
+}


### PR DESCRIPTION
Currently these are the remaining Python integration tests:
* `test_integrations.py`
* `test_backup.py` (currently unused due to performance bugs)
* `test_timings.py` (should be rewritten as Rust benchmark in future)

test_integrations.py has been incorporated into the Rust test suite via spawning a child Python process. In the future this should be ported over or the test design for integrations should be changed, as it makes special assumptions about the CloudTruth project in order to function.